### PR TITLE
Remove link to old CC Search

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,8 +4,7 @@ import pkg from './package.json'
  * Default environment variables are set on this key. Defaults are fallbacks to existing env vars.
  */
 export const env = {
-  apiUrl:
-    process.env.API_URL || 'https://api-dev.creativecommons.engineering/v1/',
+  apiUrl: process.env.API_URL || 'https://api.creativecommons.engineering/v1/',
   socialSharing: process.env.SOCIAL_SHARING || true,
   enableGoogleAnalytics: process.env.ENABLE_GOOGLE_ANALYTICS || false,
   googleAnalyticsUA: process.env.GOOGLE_ANALYTICS_UA || 'UA-2010376-36',

--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -77,21 +77,6 @@
         </div>
         <HomeLicenseFilter />
       </form>
-      <div class="help-links is-hidden-mobile">
-        <i18n
-          path="hero.old-cc-search.label"
-          tag="span"
-          class="margin-right-bigger"
-        >
-          <template v-slot:link>
-            <a
-              href="https://oldsearch.creativecommons.org/"
-              :aria-label="$t('hero.aria.old-cc-search')"
-              >{{ $t('hero.old-cc-search.link') }}</a
-            >
-          </template>
-        </i18n>
-      </div>
     </div>
     <img
       class="logo-cloud"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,18 +13,13 @@
     "license-filter": {
       "label": "I want something I can"
     },
-    "old-cc-search": {
-      "label": "Go to the {link} portal",
-      "link": "old CC Search"
-    },
     "locale": {
       "label": "Languages available",
       "icon": "locale"
     },
     "aria": {
       "search": "search",
-      "caption": "about cc licenses",
-      "old-cc-search": "old cc search"
+      "caption": "about cc licenses"
     }
   },
   "header": {
@@ -103,7 +98,6 @@
       "content": "Please note that CC does not verify whether the images are properly CC licensed, or whether the attribution and other licensing information we have aggregated is accurate or complete. Please independently verify the licensing status and attribution information before reusing the content. For more details, read the {terms}.",
       "terms": "CC Terms of Use"
     },
-    "old-cc-search": "Looking for the old CC Search portal? Visit {link}.",
     "sources": "Sources",
     "providers": {
       "source": "Source",
@@ -117,7 +111,6 @@
       "projects": "current projects",
       "contribution": "contribution guidelines",
       "terms": "cc terms of use",
-      "old-cc-search": "old cc search",
       "sources": "sources table"
     }
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -13,18 +13,13 @@
     "license-filter": {
       "label": "Je veux quelque chose que je peux"
     },
-    "old-cc-search": {
-      "label": "Accédez au {link} portail",
-      "link": "ancienne recherche CC"
-    },
     "locale": {
       "label": "Langues disponibles",
       "icon": "lieu"
     },
     "aria": {
       "search": "chercher",
-      "caption": "à propos des licences cc",
-      "old-cc-search": "ancienne recherche cc"
+      "caption": "à propos des licences cc"
     }
   },
   "header": {
@@ -90,7 +85,6 @@
       "content": "Veuillez noter que CC ne vérifie pas si les images sont correctement sous licence CC, ou si l'attribution et les autres informations de licence que nous avons agrégées sont exactes ou complètes. Veuillez vérifier indépendamment l'état de la licence et les informations d'attribution avant de réutiliser le contenu. Pour plus de détails, lisez les {terms}.",
       "terms": "Conditions d'utilisation de CC"
     },
-    "old-cc-search": "Vous recherchez l'ancien portail de recherche CC? Visitez {link}.",
     "sources": "Sources",
     "providers": {
       "source": "La source",
@@ -104,7 +98,6 @@
       "projects": "projets actuels",
       "contribution": "directives de contribution",
       "terms": "conditions d'utilisation cc",
-      "old-cc-search": "ancienne recherche cc",
       "sources": "table des sources"
     }
   },

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -82,15 +82,6 @@
               >
             </template>
           </i18n>
-          <i18n path="about.old-cc-search" tag="p">
-            <template v-slot:link>
-              <a
-                :aria-label="$t('about.aria.old-cc-search')"
-                href="https://oldsearch.creativecommons.org"
-                >https://oldsearch.creativecommons.org</a
-              >
-            </template>
-          </i18n>
           <h2 class="margin-top-large margin-bottom-normal">
             {{ $t('about.sources') }}
           </h2>


### PR DESCRIPTION
Fixes #3

This PR removes links to the old CC Search page from the `HeroSection` and the about page.

The API URL in `nuxt.config.js` was changed to working URL to enable testing. 