### PR TITLE
Replace CC logo in the header with WP photos

### DIFF
--- a/src/components/NavSection.vue
+++ b/src/components/NavSection.vue
@@ -1,10 +1,7 @@
 <template>
   <nav :aria-label="$t('header.aria.primary')" class="navbar">
     <div class="navbar-brand has-color-white">
-      <NuxtLink class="logo" to="/">
-        <IconSearchLogo />
-      </NuxtLink>
-
+      <NuxtLink class="logo" to="/">WP Photos</NuxtLink>
       <a
         role="button"
         :class="{ ['navbar-burger']: true, ['is-active']: isBurgerMenuActive }"
@@ -112,12 +109,10 @@
 </template>
 
 <script>
-import IconSearchLogo from '@creativecommons/vocabulary/assets/logos/products/search.svg?inline'
 import { SET_QUERY } from '~/store-modules/mutation-types'
 
 export default {
   name: 'NavSection',
-  components: { IconSearchLogo },
   props: {
     showNavSearch: {
       default: false,
@@ -149,10 +144,13 @@ export default {
 /* header */
 .logo {
   color: black;
-
-  svg {
-    height: 100%;
-    width: auto;
+  font-size: 2rem;
+  font-weight: bold;
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
Fixes #7 

This PR replaces the logo in the header with 'WP Photos': 
<img width="763" alt="Screen Shot 2021-04-07 at 3 33 48 PM" src="https://user-images.githubusercontent.com/15233243/113867490-478a7e00-97b7-11eb-9b9a-97a7e7126770.png">
