### PR TITLE
Remove hard-coded API URL for image thumbnails

### DIFF
--- a/src/components/ImageDetails/PhotoDetails.vue
+++ b/src/components/ImageDetails/PhotoDetails.vue
@@ -15,11 +15,7 @@
       <img
         v-show="!sketchFabUid"
         :class="{ photo_image: true, loading: !isLoaded }"
-        :src="
-          isLoaded
-            ? image.url
-            : `https://api-dev.creativecommons.engineering/v1/thumbs/${$route.params.id}`
-        "
+        :src="imgUrl"
         :alt="image.title"
         @load="onImageLoad"
       />
@@ -189,6 +185,7 @@ export default {
     'imageHeight',
     'imageType',
     'socialSharingEnabled',
+    'thumbnail',
   ],
   data() {
     return {
@@ -197,8 +194,11 @@ export default {
     }
   },
   computed: {
+    imgUrl() {
+      return this.image && this.image.url ? this.image.url : this.thumbnail
+    },
     isLoaded() {
-      return this.image && this.image.url
+      return this.image && !!this.image.url
     },
     sketchFabUid() {
       if (this.image.source !== 'sketchfab' || this.sketchFabfailure) {

--- a/src/pages/photos/_id.vue
+++ b/src/pages/photos/_id.vue
@@ -2,6 +2,7 @@
   <div :aria-label="$t('photo-details.aria.main')">
     <PhotoDetails
       :image="image"
+      :thumbnail="thumbnailURL"
       :bread-crumb-u-r-l="breadCrumbURL"
       :should-show-breadcrumb="shouldShowBreadcrumb"
       :query="query"
@@ -72,13 +73,16 @@ const PhotoDetailPage = {
       this.getRelatedImages()
     },
   },
+  async asyncData({ env, route }) {
+    return { thumbnailURL: `${env.apiUrl}thumbs/${route.params.id}` }
+  },
   async fetch() {
     // Clear related images if present
     if (this.relatedImages && this.relatedImages.length > 0) {
       this.SET_RELATED_IMAGES({ relatedImages: [], relatedImageCount: 0 })
     }
 
-    // Laad the image + related images in parallel
+    // Load the image + related images in parallel
     await Promise.all([
       this.loadImage(this.$route.params.id),
       this[FETCH_RELATED_IMAGES]({ id: this.$route.params.id }),


### PR DESCRIPTION
Fixes #14

The Photo page displays a thumbnail while the original image is being loaded. This thumbnail stopped loading because its URL was hard-coded using the the now non-functioning API URL.

The base API URL is set in the `nuxt.config.js` file. It is available as `env.apiUrl` parameter inside `nuxt context`.

We can only access nuxt context inside such functions as `asyncData` or `fetch` on a page.  This is why we create a `thumbnailURL` variable using the `env.apiURL` inside the `photos` page's `asyncData` and pass it to the `PhotoDetails` component as a prop.