### PR TITLE
Fix warnings when running unit tests

### DIFF
--- a/test/unit/specs/components/filter-display.spec.js
+++ b/test/unit/specs/components/filter-display.spec.js
@@ -1,5 +1,6 @@
 import FilterDisplay from '~/components/Filters/FilterDisplay'
 import render from '../../test-utils/render'
+import FilterBlock from '~/components/Filters/FilterBlock'
 
 describe('FilterDisplay', () => {
   let options = null
@@ -7,24 +8,24 @@ describe('FilterDisplay', () => {
 
   beforeEach(() => {
     filters = {
-      licenses: [{ code: 'foo', name: 'bar', checked: false }],
-      licenseTypes: [{ code: 'foo', name: 'bar', checked: false }],
-      categories: [{ code: 'foo', name: 'bar', checked: false }],
-      extensions: [{ code: 'foo', name: 'bar', checked: false }],
-      aspectRatios: [{ code: 'foo', name: 'bar', checked: false }],
-      sizes: [{ code: 'foo', name: 'bar', checked: false }],
-      providers: [{ code: 'foo', name: 'bar', checked: false }],
+      licenses: [{ code: 'fooLicense', name: 'bar', checked: false }],
+      licenseTypes: [{ code: 'fooType', name: 'bar', checked: false }],
+      categories: [{ code: 'fooCategory', name: 'bar', checked: false }],
+      extensions: [{ code: 'fooExtension', name: 'bar', checked: false }],
+      aspectRatios: [{ code: 'fooRatio', name: 'bar', checked: false }],
+      sizes: [{ code: 'fooSize', name: 'bar', checked: false }],
+      providers: [{ code: 'fooProvider', name: 'bar', checked: false }],
       searchBy: { creator: false },
     }
     options = {
       propsData: {
         query: {
           license: 'cc0',
-          license_type: 'foo',
-          categories: 'foo',
-          extension: 'foo',
-          aspect_ratio: 'foo',
-          size: 'foo',
+          license_type: 'fooType',
+          categories: 'fooCategory',
+          extension: 'fooExtension',
+          aspect_ratio: 'fooRatio',
+          size: 'fooSize',
           source: 'foo',
         },
       },
@@ -51,7 +52,7 @@ describe('FilterDisplay', () => {
   it('should render filter if checked', () => {
     filters.licenses[0].checked = true
     const wrapper = render(FilterDisplay, options)
-    expect(wrapper.find({ name: 'FilterBlock' }).vm).toBeDefined()
+    expect(wrapper.findComponent(FilterBlock).vm).toBeDefined()
   })
 
   it('should render filter by caption label', () => {

--- a/test/unit/specs/components/hero-section.spec.js
+++ b/test/unit/specs/components/hero-section.spec.js
@@ -9,6 +9,7 @@ describe('HeroSection', () => {
   beforeEach(() => {
     commitMock = jest.fn()
     options = {
+      stubs: { HomeLicenseFilter: true },
       mocks: {
         $router: {
           push: () => {},
@@ -21,7 +22,7 @@ describe('HeroSection', () => {
     }
   })
   it('should render correct contents', () => {
-    const wrapper = render(HeroSection)
+    const wrapper = render(HeroSection, options)
     expect(wrapper.find('.hero').element).toBeDefined()
     expect(wrapper.find('.hero-search__form').element).toBeDefined()
   })

--- a/test/unit/specs/components/nav-section.spec.js
+++ b/test/unit/specs/components/nav-section.spec.js
@@ -4,7 +4,7 @@ import render from '../../test-utils/render'
 
 describe('NavSection', () => {
   it('should render correct contents', () => {
-    const wrapper = render(NavSection)
+    const wrapper = render(NavSection, { stubs: { NuxtLink: true } })
     expect(wrapper.find('nav').vm).toBeDefined()
   })
 
@@ -18,15 +18,16 @@ describe('NavSection', () => {
         },
       },
     }
-    const opts = {
+    const options = {
       propsData: {
         fixedNav: null,
         showNavSearch: 'true',
       },
-      mocks: { $store: storeMock },
+      mocks: { $store: storeMock, $router: { push: jest.fn() } },
+      stubs: { NuxtLink: true },
     }
 
-    const wrapper = render(NavSection, opts)
+    const wrapper = render(NavSection, options)
     await wrapper.setData({ form: { searchTerm: 'foo' } })
     wrapper.find('.hero_search-form').trigger('submit')
 

--- a/test/unit/specs/components/search-grid-cell.spec.js
+++ b/test/unit/specs/components/search-grid-cell.spec.js
@@ -12,35 +12,39 @@ describe('SearchGridCell', () => {
       foreign_landing_url: 'foreign_foo.bar',
     },
   }
+  const options = {
+    propsData: props,
+    stubs: { RouterLink: true },
+  }
 
   it('should render correct contents', () => {
-    const wrapper = render(SearchGridCell, { propsData: props })
+    const wrapper = render(SearchGridCell, options)
     expect(wrapper.find('div').find('figure').element).toBeDefined()
   })
 
   xit('getProviderLogo should return existing logo', () => {
-    const wrapper = render(SearchGridCell, { propsData: props })
+    const wrapper = render(SearchGridCell, options)
     expect(wrapper.vm.getProviderLogo('flickr')).not.toBe('')
   })
 
   xit('getProviderLogo should not return non existing logo', () => {
-    const wrapper = render(SearchGridCell, { propsData: props })
+    const wrapper = render(SearchGridCell, options)
     expect(wrapper.vm.getProviderLogo('does not exist')).toBe('')
   })
 
   it('getImageUrl returns image url with https://', () => {
-    const wrapper = render(SearchGridCell, { propsData: props })
+    const wrapper = render(SearchGridCell, options)
     expect(wrapper.vm.getImageUrl(props.image)).toBe('https://foo.bar')
   })
 
   it('getImageForeignUrl returns foreign image url with https://', () => {
-    const wrapper = render(SearchGridCell, { propsData: props })
+    const wrapper = render(SearchGridCell, options)
     expect(wrapper.vm.getImageForeignUrl(props.image)).toBe(
       'https://foreign_foo.bar'
     )
   })
 
-  it('links to the details page', () => {
+  it('links to the details page', async () => {
     const routerMock = {
       push: jest.fn(),
       params: {
@@ -52,7 +56,7 @@ describe('SearchGridCell', () => {
       mocks: { $router: routerMock },
     })
     const link = wrapper.find('.search-grid_image-ctr')
-    link.trigger('click')
+    await link.trigger('click')
     expect(routerMock.push).toHaveBeenCalledWith({
       name: 'photo-detail-page',
       params: { id: 0, location: routerMock.params.location },

--- a/test/unit/specs/components/search-grid-filter.spec.js
+++ b/test/unit/specs/components/search-grid-filter.spec.js
@@ -45,7 +45,9 @@ describe('SearchGridFilter', () => {
 
   it('should render correct contents', () => {
     const wrapper = render(SearchGridFilter, options)
-    expect(wrapper.find({ name: 'SearchGridFilter' }).element).toBeDefined()
+    expect(
+      wrapper.findComponent({ name: 'SearchGridFilter' }).element
+    ).toBeDefined()
   })
 
   it('should show search filters when isFilterVisible is true', () => {

--- a/test/unit/specs/components/search-grid-wrapper.spec.js
+++ b/test/unit/specs/components/search-grid-wrapper.spec.js
@@ -1,15 +1,23 @@
 import SearchGrid from '~/components/SearchGrid'
 import render from '../../test-utils/render'
 
+const options = {
+  stubs: {
+    ScrollButton: true,
+    SearchGridManualLoad: true,
+  },
+  mocks: { $store: { state: { query: { q: 'foo' } } } },
+}
+
 describe('Search Grid Wrapper', () => {
   it('renders correct content', () => {
-    const wrapper = render(SearchGrid)
+    const wrapper = render(SearchGrid, options)
     expect(wrapper.find('[data-testid="search-grid"]').element).toBeDefined()
     expect(wrapper.find('[data-testid="scroll-button"]').element).toBeDefined()
   })
 
   it('renders the scroll button when the page scrolls down', () => {
-    const wrapper = render(SearchGrid)
+    const wrapper = render(SearchGrid, options)
     window.scrollY = 80
     wrapper.vm.checkScrollLength()
     expect(wrapper.vm.showScrollButton).toBe(true)

--- a/test/unit/specs/components/search-grid.spec.js
+++ b/test/unit/specs/components/search-grid.spec.js
@@ -7,6 +7,11 @@ describe('SearchGrid', () => {
   beforeEach(() => {
     commitMock = jest.fn()
     options = {
+      stubs: {
+        SearchRating: true,
+        SaferBrowsing: true,
+        LoadingIcon: true,
+      },
       propsData: {
         query: { q: 'foo' },
         includeAnalytics: true,


### PR DESCRIPTION
Running unit tests at the moment shows many warnings. Most are due to Custom Components not being found. This PR fixes all but one of them by stubbing out the components.