### PR TITLE
Make sure filter tags and 'Back to search results' link are shown when necessary

### DIFF
--- a/src/pages/photos/_id.vue
+++ b/src/pages/photos/_id.vue
@@ -90,7 +90,7 @@ const PhotoDetailPage = {
   },
   beforeRouteEnter(to, from, nextPage) {
     nextPage((_this) => {
-      if (from.path === '/search' || from.path === '/search/image') {
+      if (from.path === '/search/' || from.path === '/search/image') {
         _this.shouldShowBreadcrumb = true
         _this.breadCrumbURL = from.fullPath
       }

--- a/src/pages/search.vue
+++ b/src/pages/search.vue
@@ -16,7 +16,7 @@
         <SearchGridForm @onSearchFormSubmit="onSearchFormSubmit" />
         <SearchTypeTabs />
         <FilterDisplay
-          v-if="$route.path === '/search' || $route.path === '/search/image'"
+          v-if="$route.path === '/search/' || $route.path === '/search/image'"
           :query="query"
         />
         <NuxtChild


### PR DESCRIPTION
Fixes #29 

The 'filter tags' are shown only when the user is on the Image tab of the Search page:
<img width="634" alt="Screen Shot 2021-04-28 at 10 07 54 AM" src="https://user-images.githubusercontent.com/15233243/116361832-162b2e00-a80a-11eb-86a5-e9e6b64568c6.png">
The breadcrumb saying 'Back to search results' is only shown on the PhotoDetail page if the user came there from the Image Search page:
<img width="562" alt="Screen Shot 2021-04-28 at 10 09 23 AM" src="https://user-images.githubusercontent.com/15233243/116361918-2fcc7580-a80a-11eb-83f0-0a57caaee582.png">

Update to `nuxt-i18n` has changed the URLs that were checked for this functionality from `/search` to `/search/`, with trailing slash. Because of this, the tags and breadcrumbs were never shown.

This PR changes the check for image search URL from `/search` to `/search/`.