### PR TITLE
Show 404 page when requested image id doesn't exist

### DIFF
--- a/src/layouts/error.vue
+++ b/src/layouts/error.vue
@@ -2,9 +2,10 @@
   <div class="grid-container full">
     <main class="not-found">
       <h1 v-if="error.statusCode === 404">
-        {{ $t('not-found') }}
+        {{ $t('error.not-found') }}
       </h1>
-      <h1 v-else>{{ $t('error-occurred') }}</h1>
+      <h1 v-else>{{ $t('error.occurred') }}</h1>
+      <p>{{ error.message }}</p>
     </main>
   </div>
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -264,8 +264,11 @@
     "other": "Other Collections",
     "collection-size": "Collection size: {count} images"
   },
-  "not-found": "Page Not Found",
-  "error-occurred": "An error occurred",
+  "error": {
+    "not-found": "Page Not Found",
+    "occurred": "An error occurred",
+    "image-not-found": "Couldn't find image with id {id}"
+  },
   "search-tab": {
     "image": "Image",
     "audio": "Audio",

--- a/src/pages/photos/_id.vue
+++ b/src/pages/photos/_id.vue
@@ -76,23 +76,29 @@ const PhotoDetailPage = {
   async asyncData({ env, route }) {
     return { thumbnailURL: `${env.apiUrl}thumbs/${route.params.id}` }
   },
-  async fetch() {
+  async fetch({ store, route, error, app }) {
     // Clear related images if present
-    if (this.relatedImages && this.relatedImages.length > 0) {
-      this.SET_RELATED_IMAGES({ relatedImages: [], relatedImageCount: 0 })
+    if (store.state.relatedImages && store.state.relatedImages.length > 0) {
+      await store.dispatch(SET_RELATED_IMAGES, {
+        relatedImages: [],
+        relatedImageCount: 0,
+      })
     }
-
-    // Load the image + related images in parallel
-    await Promise.all([
-      this.loadImage(this.$route.params.id),
-      this[FETCH_RELATED_IMAGES]({ id: this.$route.params.id }),
-    ])
+    try {
+      // Load the image + related images in parallel
+      await Promise.all([
+        store.dispatch(FETCH_IMAGE, { id: route.params.id }),
+        store.dispatch(FETCH_RELATED_IMAGES, { id: route.params.id }),
+      ])
+    } catch (err) {
+      error({
+        statusCode: 404,
+        message: app.i18n.t('error.image-not-found', { id: route.params.id }),
+      })
+    }
   },
   beforeRouteEnter(to, from, nextPage) {
     nextPage((_this) => {
-      if (_this.$store.state.isImageNotFound) {
-        nextPage('/error')
-      }
       if (from.path === '/search/' || from.path === '/search/image') {
         _this.shouldShowBreadcrumb = true
         _this.breadCrumbURL = from.fullPath
@@ -114,9 +120,6 @@ const PhotoDetailPage = {
       if (this.image && this.image.id) {
         this[FETCH_RELATED_IMAGES]({ id: this.image.id })
       }
-    },
-    loadImage(id) {
-      return this[FETCH_IMAGE]({ id })
     },
   },
 }

--- a/src/store-modules/search-store.js
+++ b/src/store-modules/search-store.js
@@ -182,7 +182,6 @@ const state = {
   images: [],
   isFetchingImages: false,
   isFetchingImagesError: true,
-  isImageNotFound: false,
   query: {},
 }
 
@@ -202,7 +201,6 @@ const mutations = {
   },
   [SET_IMAGE](_state, params) {
     _state.image = decodeImageData(params.image)
-    _state.isImageNotFound = false
   },
   [SET_IMAGE_PAGE](_state, params) {
     _state.imagePage = params.imagePage
@@ -222,8 +220,8 @@ const mutations = {
   [SET_QUERY](_state, params) {
     setQuery(_state, params)
   },
-  [IMAGE_NOT_FOUND](_state) {
-    _state.isImageNotFound = true
+  [IMAGE_NOT_FOUND]() {
+    throw new Error('Image not found')
   },
 }
 


### PR DESCRIPTION
Fixes #46 

The fetch method in `photos/_id.vue` dispatches two actions concurrently: to fetch the current image, and the related images. If the image fetch action in the store throws an error, it is re-thrown and handled within the fetch method. The fetch method was rewritten to use the nuxt context variables instead of `this` so that we could use the standard `error` method: 
````
catch (err) {
      error({
        statusCode: 404,
        message: app.i18n.t('error.image-not-found', { id: route.params.id }),
      })
    }
```
