### PR TITLE
Update CopyLicense, PhotoDetails and search-help for i18n

### DIFF
--- a/src/components/ImageDetails/CopyLicense.vue
+++ b/src/components/ImageDetails/CopyLicense.vue
@@ -1,7 +1,5 @@
 <template>
   <div class="copy-license margin-vertical-normal">
-    <!-- TODO: change to accommodate different sentence structures -->
-    <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
     <h5 class="b-header margin-bottom-small">
       {{ $t('photo-details.reuse.copy-license.title') }}
     </h5>
@@ -51,42 +49,61 @@
         :class="tabClass(0, 'tabs-panel')"
         tabindex="0"
       >
-        <span
+        <i18n
           id="attribution"
           ref="photoAttribution"
+          path="photo-details.reuse.credit.text"
+          tag="span"
           class="photo_usage-attribution is-block"
         >
-          <a
-            :href="image.foreign_landing_url"
-            target="_blank"
-            rel="noopener"
-            @click="onPhotoSourceLinkClicked"
-            @keyup.enter="onPhotoSourceLinkClicked"
-            >{{ imageTitle }}</a
-          >
-          <span v-if="image.creator">
-            by
+          <template #title>
             <a
-              v-if="image.creator_url"
-              :href="image.creator_url"
+              :href="image.foreign_landing_url"
               target="_blank"
               rel="noopener"
-              @click="onPhotoCreatorLinkClicked"
-              @keyup.enter="onPhotoCreatorLinkClicked"
-              >{{ image.creator }}</a
-            >
-            <span v-else>{{ image.creator }}</span>
-          </span>
-          {{ isTool ? 'is marked with' : 'is licensed under' }}
-          <a
-            class="photo_license"
-            :href="licenseURL"
-            target="_blank"
-            rel="noopener"
+              @click="onPhotoSourceLinkClicked"
+              @keyup.enter="onPhotoSourceLinkClicked"
+              >{{ imageTitle }}</a
+            ></template
           >
-            {{ fullLicenseName.toUpperCase() }}
-          </a>
-        </span>
+          <template #creator>
+            <i18n
+              v-if="image.creator"
+              path="photo-details.reuse.credit.creator-text"
+              tag="span"
+            >
+              <template #creator-name>
+                <a
+                  v-if="image.creator_url"
+                  :href="image.creator_url"
+                  target="_blank"
+                  rel="noopener"
+                  @click="onPhotoCreatorLinkClicked"
+                  @keyup.enter="onPhotoCreatorLinkClicked"
+                  >{{ image.creator }}</a
+                >
+                <span v-else>{{ image.creator }}</span>
+              </template>
+            </i18n>
+          </template>
+          <template #marked-licensed>
+            {{
+              isTool
+                ? $t('photo-details.reuse.credit.marked')
+                : $t('photo-details.reuse.credit.licensed')
+            }}
+          </template>
+          <template #license>
+            <a
+              class="photo_license"
+              :href="licenseURL"
+              target="_blank"
+              rel="noopener"
+            >
+              {{ fullLicenseName.toUpperCase() }}
+            </a>
+          </template>
+        </i18n>
 
         <CopyButton
           id="copyattr-rich"
@@ -124,21 +141,48 @@
         :class="tabClass(2, 'tabs-panel')"
         tabindex="0"
       >
-        <p
+        <i18n
           id="attribution-text"
           ref="photoAttribution"
-          class="photo_usage-attribution is-block"
+          path="photo-details.reuse.credit.text"
+          tag="p"
         >
-          {{ imageTitle }}
-          <span v-if="image.creator"> by {{ image.creator }} </span>
-          {{ isTool ? 'is marked under' : 'is licensed with' }}
-          {{ fullLicenseName.toUpperCase() }}. To
-          {{ isTool ? 'view the terms' : 'view a copy of this license' }}, visit
-          <template v-if="licenseURL">
-            {{ licenseURL.substring(0, licenseURL.indexOf('?')) }}
+          <template #title>
+            {{ imageTitle }}
           </template>
-        </p>
-
+          <template #creator>
+            <i18n
+              v-if="image.creator"
+              path="photo-details.reuse.credit.creator-text"
+            >
+              <template #creator-name>
+                {{ image.creator }}
+              </template>
+            </i18n>
+          </template>
+          <template #marked-licensed>
+            {{
+              isTool
+                ? $t('photo-details.reuse.credit.marked')
+                : $t('photo-details.reuse.credit.licensed')
+            }}
+          </template>
+          <template #license> {{ fullLicenseName.toUpperCase() }}</template>
+          <template #view-legal>
+            <i18n path="photo-details.reuse.credit.view-legal-text">
+              <template #terms-copy>
+                {{
+                  isTool
+                    ? $t('photo-details.reuse.credit.terms-text')
+                    : $t('photo-details.reuse.credit.copy-text')
+                }}
+              </template>
+              <template v-if="licenseURL" #URL>
+                {{ licenseURL.substring(0, licenseURL.indexOf('?')) }}
+              </template>
+            </i18n>
+          </template>
+        </i18n>
         <CopyButton
           id="copyattr-plain"
           el="#attribution-text"
@@ -177,7 +221,9 @@ export default {
     },
     imageTitle() {
       const title = this.$props.image.title
-      return title !== 'Image' ? `"${title}"` : 'Image'
+      return title !== 'Image'
+        ? `"${title}"`
+        : this.$t('photo-details.reuse.image')
     },
   },
   methods: {

--- a/src/components/ImageDetails/PhotoDetails.vue
+++ b/src/components/ImageDetails/PhotoDetails.vue
@@ -57,22 +57,25 @@
         <h1 class="title is-5 b-header">
           {{ image.title }}
         </h1>
-        <span v-if="image.creator" class="caption has-text-weight-semibold">
-          <!-- TODO: need to change to accommodate sentence order in different languages -->
-          <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
-          by
-          <!-- eslint-enable -->
-          <a
-            v-if="image.creator_url"
-            :aria-label="'author' + image.creator"
-            :href="image.creator_url"
-            @click="onPhotoCreatorLinkClicked"
-            @keyup.enter="onPhotoCreatorLinkClicked"
-          >
-            {{ image.creator }}
-          </a>
-          <span v-else>{{ image.creator }}</span>
-        </span>
+        <i18n
+          v-if="image.creator"
+          class="caption has-text-weight-semibold"
+          path="photo-details.creator"
+          tag="span"
+        >
+          <template #name>
+            <a
+              v-if="image.creator_url"
+              :aria-label="'author' + image.creator"
+              :href="image.creator_url"
+              @click="onPhotoCreatorLinkClicked"
+              @keyup.enter="onPhotoCreatorLinkClicked"
+            >
+              {{ image.creator }}
+            </a>
+            <span v-else>{{ image.creator }}</span>
+          </template>
+        </i18n>
       </div>
       <section class="tabs">
         <div role="tablist" :aria-label="$t('photo-details.aria.details')">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -174,6 +174,8 @@
     "intro": "When you search, you can enter special symbols or words to your search term to make your search results more precise.",
     "exact": {
       "title": "Search for an exact match",
+      "aria-label": "quote unquote Claude Monet",
+      "claude-monet": "\"Claude Monet\"",
       "content": "Put a word or phrase inside quotes. For example, {link}."
     },
     "combine": {
@@ -184,25 +186,55 @@
       "negate": "{symbol} negates a single token",
       "prefix": "{symbol} at the end of a term signifies a prefix query",
       "precedence": "{open} and {close} signify precedence",
-      "fuzziness": "{symbol} after a word signifies edit distance (fuzziness)"
+      "fuzziness": "{symbol} after a word signifies edit distance (fuzziness)",
+      "aria-labels": {
+        "fuzziness": "tilde N",
+        "open": "open parenthesis",
+        "close": "close parenthesis",
+        "star": "star symbol",
+        "minus": "minus symbol",
+        "plus": "plus symbol",
+        "vertical-bar": "vertical bar symbol"
+      }
     },
     "example": {
-      "and": "Example: {link}{br} This will search for images related to both dog and cat.",
-      "or": "Example: {link}{br} This will search for images related to dog or cat, but not necessarily both.",
+      "and": {
+        "description": "Example: {link}{br} This will search for images related to both dog and cat.",
+        "aria-label": "dog plus cat",
+        "example": "dog+cat"
+      },
+      "or": {
+        "description": "Example: {link}{br} This will search for images related to dog or cat, but not necessarily both.",
+        "aria-label": "dog vertical bar cat",
+        "example": "dog|cat"
+      },
       "negate": {
-        "description": "You can use the {highlight} to exclude a search term from the results.",
+        "description": "You can use the {operator} to exclude a search term from the results.",
+        "operator-name": "operator (signifies NOT)",
+        "operator-aria-label": "minus operator (signifies NOT)",
+        "aria-label": "dog minus pug",
+        "example": "dog -pug",
         "content": "Example: {link}{br} This will search for images related to dog but won't include results related to 'pug'"
       },
       "prefix": {
-        "description": "You can use the {highlight} to mark a prefix term. This will match anything after the *.",
+        "description": "You can use the {operator-name} to mark a prefix term. This will match anything after the *.",
+        "operator-name": "operator (wildcard)",
+        "operator-aria-label": "star operator (wildcard)",
+        "aria-label": "net star symbol",
+        "example": "net*",
         "content": "Example: {link}{br} This will search for images matching anything with 'net'. This might include 'network', 'Netflix', 'Netherlands', etc.."
       },
       "precedence": {
         "description": "You can use parentheses {highlight} to specify precedence of terms or combine more complex queries.",
+        "aria-label": "dogs plus open parenthesis corgis vertical bar labrador close parenthesis",
+        "example": "dogs + (corgis | labrador)",
         "content": "Example: {link}{br} This will search for images that match dogs that are either corgis or labrador."
       },
       "fuzziness": {
         "description": "You can use {highlight} to specify some fuzzy logic to the term according to the {link} — the number of one character changes that need to be made to one string to make it the same as another string.",
+        "link-text": "Levenshtein Edit Distance",
+        "aria-label": "theatre tilde 1",
+        "example": "theatre~1",
         "content": "Example: {link}{br} This will search for images that match strings close to the term 'theatre' with a difference of one character. Results might include terms with different spellings like 'theater'."
       }
     }
@@ -386,13 +418,24 @@
   },
   "photo-details": {
     "back": "Back to search results",
+    "creator": "by {name}",
     "reuse": {
       "title": "Reuse",
       "license-header": "License",
       "tool-header": "Public Domain",
+      "image": "Image",
       "attribution": {
         "main": "This image was marked with a {link} license.",
         "license": "license."
+      },
+      "credit": {
+        "text": "{title}{creator}{marked-licensed}{license}{view-legal}",
+        "creator-text": " by {creator-name}",
+        "marked": "is marked with",
+        "licensed": "is licensed under",
+        "view-legal-text": ". To view {terms-copy}visit {URL}",
+        "terms-text": "the terms,",
+        "copy-text": "a copy of this license,"
       },
       "license": {
         "content": "Read more about the license {link}",

--- a/src/pages/search-help.vue
+++ b/src/pages/search-help.vue
@@ -9,50 +9,67 @@
           {{ $t('search-guide.intro') }}
         </p>
 
-        <h3 class="margin-top-large">
+        <h2 class="margin-top-large title is-3">
           {{ $t('search-guide.exact.title') }}
-        </h3>
+        </h2>
         <i18n path="search-guide.exact.content" tag="p">
           <template #link>
             <!-- eslint-disable -->
             <a
-              aria-label="quote unquote Claude Monet"
+              :aria-label="$t('search-guide.exact.aria-label')"
               href='https://search.creativecommons.org/search?q="Claude%20Monet"'
             >
-              <em>"Claude Monet"</em>
+              <em>{{ $t('search-guide.exact.claude-monet') }}</em>
             </a>
             <!-- eslint-enable -->
           </template>
         </i18n>
 
-        <h3 role="region" class="margin-vertical-normal">
+        <h3 class="margin-vertical-normal">
           {{ $t('search-guide.combine.title') }}
         </h3>
 
         <p class="margin-vertical-normal">
           {{ $t('search-guide.combine.description') }}
         </p>
-        <!-- TODO: review for i18n to accommodate language sentence structure -->
         <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
         <ul>
           <i18n path="search-guide.combine.and" tag="li" class="listitem">
             <template #symbol>
-              <code aria-label="plus" class="literal">+</code>
+              <code
+                :aria-label="$t('search-guide.combine.aria-labels.plus')"
+                class="literal"
+                >+</code
+              >
             </template>
           </i18n>
           <i18n path="search-guide.combine.or" tag="li" class="listitem">
             <template #symbol>
-              <code aria-label="vertical bar" class="literal">|</code>
+              <code
+                :aria-label="
+                  $t('search-guide.combine.aria-labels.vertical-bar')
+                "
+                class="literal"
+                >|</code
+              >
             </template>
           </i18n>
           <i18n path="search-guide.combine.negate" tag="li" class="listitem">
             <template #symbol>
-              <code aria-label="minus" class="literal">-</code>
+              <code
+                :aria-label="$t('search-guide.combine.aria-labels.minus')"
+                class="literal"
+                >-</code
+              >
             </template>
           </i18n>
           <i18n path="search-guide.combine.prefix" tag="li" class="listitem">
             <template #symbol>
-              <code aria-label="star" class="literal">*</code>
+              <code
+                :aria-label="$t('search-guide.combine.aria-labels.star')"
+                class="literal"
+                >*</code
+              >
             </template>
           </i18n>
           <i18n
@@ -61,30 +78,42 @@
             class="listitem"
           >
             <template #open>
-              <code aria-label="open paranthesis" class="literal">(</code>
+              <code
+                :aria-label="$t('search-guide.combine.aria-labels.open')"
+                class="literal"
+                >(</code
+              >
             </template>
             <template #close>
-              <code aria-label="close paranthesis" class="literal">)</code>
+              <code
+                :aria-label="$t('search-guide.combine.aria-labels.close')"
+                class="literal"
+                >)</code
+              >
             </template>
           </i18n>
           <i18n path="search-guide.combine.fuzziness" tag="li" class="listitem">
             <template #symbol>
-              <code aria-label="tilde N" class="literal">~N</code>
+              <code
+                :aria-label="$t('search-guide.combine.aria-labels.fuzziness')"
+                class="literal"
+                >~N</code
+              >
             </template>
           </i18n>
         </ul>
 
         <i18n
-          path="search-guide.example.and"
+          path="search-guide.example.and.description"
           tag="p"
           class="margin-vertical-normal"
         >
           <template #link>
             <a
-              aria-label="dog plus cat"
+              :aria-label="$t('search-guide.example.and.aria-label')"
               href="https://search.creativecommons.org/search?q=dog%2Bcat"
             >
-              <em>dog+cat</em>
+              <em>{{ $t('search-guide.example.and.example') }}</em>
             </a>
           </template>
           <template #br>
@@ -99,10 +128,10 @@
         >
           <template #link>
             <a
-              aria-label="dog vertical bar cat"
+              :aria-label="$t('search-guide.example.or.aria-label')"
               href="https://search.creativecommons.org/search?q=dog%7Ccat"
             >
-              <em>dog|cat</em>
+              <em>{{ $t('search-guide.example.or.example') }}</em>
             </a>
           </template>
           <template #br>
@@ -115,9 +144,12 @@
           tag="p"
           class="margin-top-normal"
         >
-          <template #highlight>
-            <em aria-label="minus operator (signifies NOT)"
-              >- operator (signifies NOT)</em
+          <template #operator>
+            <em
+              :aria-label="
+                $t('search-guide.example.negate.operator-aria-label')
+              "
+              >- {{ $t('search-guide.example.negate.operator-name') }}</em
             >
           </template>
         </i18n>
@@ -129,10 +161,10 @@
         >
           <template #link>
             <a
-              aria-label="dog minus pug"
+              :aria-label="$t('search-guide.example.negate.aria-label')"
               href="https://search.creativecommons.org/search?q=dog%20-pug"
             >
-              <em>dog -pug</em>
+              <em>{{ $t('search-guide.example.negate.example') }}</em>
             </a>
           </template>
           <template #br>
@@ -145,8 +177,10 @@
           tag="p"
           class="margin-top-normal"
         >
-          <template #highlight>
-            <em>* operator (wildcard)</em>
+          <template #operator>
+            <em :aria-label="$t('search-guide.example.prefix.aria-label')"
+              >* {{ $t('search-guide.example.prefix.operator-name') }}</em
+            >
           </template>
         </i18n>
 
@@ -157,10 +191,10 @@
         >
           <template #link>
             <a
-              aria-label="net star"
+              :aria-label="$t('search-guide.example.prefix.aria-label')"
               href="https://search.creativecommons.org/search?q=net%2a"
             >
-              <em>net*</em>
+              <em>{{ $t('search-guide.example.prefix.example') }}</em>
             </a>
           </template>
           <template #br>
@@ -185,10 +219,10 @@
         >
           <template #link>
             <a
-              aria-label="dogs plus open paranthesis corgis vertical bar labrador close paranthesis"
+              :aria-label="$t('search-guide.example.precedence.aria-label')"
               href="https://search.creativecommons.org/search?q=dogs%20%2B%20%28corgis%20%7C%20labrador%29"
             >
-              <em>dogs + (corgis | labrador)</em>
+              <em>{{ $t('search-guide.example.precedence.example') }}</em>
             </a>
           </template>
           <template #br>
@@ -205,9 +239,9 @@
             <em aria-label="tilde N">~N</em>
           </template>
           <template #link>
-            <a href="http://en.wikipedia.org/wiki/Levenshtein_distance"
-              >Levenshtein Edit Distance</a
-            >
+            <a href="http://en.wikipedia.org/wiki/Levenshtein_distance">
+              {{ $t('search-guide.example.fuzziness.link-text') }}
+            </a>
           </template>
         </i18n>
 
@@ -218,10 +252,10 @@
         >
           <template #link>
             <a
-              aria-label="theatre tilde 1"
+              :aria-label="$t('search-guide.example.fuzziness.aria-label')"
               href="https://search.creativecommons.org/search?q=theatre~1"
             >
-              <em>theatre~1</em>
+              <em>{{ $t('search-guide.example.fuzziness.example') }}</em>
             </a>
           </template>
           <template #br>


### PR DESCRIPTION
Fixes #21 

This PR rewrites the texts of some components and pages to make sure that they don't break when we translating the texts into languages with different sentence structures. It also extracts some strings that were left inside the code of search-help page.

One last thing that needs to be reworked is the license attribution code in HTML format. It will be done in a different PR. 