### PR TITLE
Add EDUimages to meta search

### DIFF
--- a/src/utils/getLegacySourceUrl.js
+++ b/src/utils/getLegacySourceUrl.js
@@ -17,6 +17,16 @@ export const legacySourceMap = {
       }
     },
   },
+  'EDU images': {
+    image(search) {
+      return {
+        url: 'https://images.all4ed.org',
+        query: {
+          s: search.q,
+        },
+      }
+    },
+  },
   Europeana: {
     audio(search) {
       let query = `${search.q} AND RIGHTS:*creative*` // search cc licensed works


### PR DESCRIPTION
Fixes #67 

Adds a new source to meta search. This is a small source but contains very high-quality images for an important niche (education), so it's a nice addition to fast track.