### PR TITLE
Add `urlChange` message and unify message format

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -130,6 +130,7 @@ export default {
   plugins: [
     { src: '~/plugins/ab-test-init.js', mode: 'client' },
     { src: '~/plugins/ga.js', mode: 'client' },
+    { src: '~/plugins/message.js' },
   ],
   css: [
     '~/assets/fonts.css',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -139,6 +139,7 @@ export default {
   ],
   head,
   env,
+  dev: process.env.NODE_ENV !== 'production',
   buildModules: [
     '@nuxtjs/style-resources',
     '@nuxtjs/svg',

--- a/src/middleware/embed.js
+++ b/src/middleware/embed.js
@@ -1,5 +1,6 @@
 import { SET_EMBEDDED } from '~/store-modules/mutation-types'
 import { sendWindowMessage } from '~/utils/sendMessage'
+import config from '../../nuxt.config.js'
 
 /**
  * In embedded mode, the app sends its size and url
@@ -22,6 +23,7 @@ export default function ({ store, query, route }) {
   }
   if (process.client) {
     sendWindowMessage({
+      debug: config.dev,
       type: 'urlChange',
       value: { path: route.fullPath, title: document.title },
     })

--- a/src/middleware/embed.js
+++ b/src/middleware/embed.js
@@ -1,4 +1,5 @@
 import { SET_EMBEDDED } from '~/store-modules/mutation-types'
+import { sendWindowMessage } from '~/utils/sendMessage'
 
 /**
  * In embedded mode, the app sends its size and url
@@ -19,13 +20,10 @@ export default function ({ store, query, route }) {
     const isEmbedded = query.embedded === 'true'
     store.commit(SET_EMBEDDED, { isEmbedded })
   }
-  if (typeof window !== 'undefined') {
-    window.parent.postMessage(
-      {
-        type: 'urlChange',
-        value: route.path,
-      },
-      '*'
-    )
+  if (process.client) {
+    sendWindowMessage({
+      type: 'urlChange',
+      value: { path: route.fullPath, title: document.title },
+    })
   }
 }

--- a/src/middleware/embed.js
+++ b/src/middleware/embed.js
@@ -1,8 +1,31 @@
 import { SET_EMBEDDED } from '~/store-modules/mutation-types'
 
-export default function ({ store, query }) {
+/**
+ * In embedded mode, the app sends its size and url
+ * to the outer window to improve the user experience.
+ *
+ * The app is in embedded mode by default. To set it to
+ * standalone mode with larger header and a footer,
+ * add `?embedded=false` to the end of the URL.
+ *
+ * Messages sent to the outer window have the following format:
+ * {type: <event type>, value: <event value>}.
+ * Currently, two event types are used:
+ * - `resize` sends the height of the window (see `src/mixins/iframeHeight.js`)
+ * - `urlChange` sends the relative path of the URL on every URL change.
+ */
+export default function ({ store, query, route }) {
   if ('embedded' in query) {
     const isEmbedded = query.embedded === 'true'
     store.commit(SET_EMBEDDED, { isEmbedded })
+  }
+  if (typeof window !== 'undefined') {
+    window.parent.postMessage(
+      {
+        type: 'urlChange',
+        value: route.path,
+      },
+      '*'
+    )
   }
 }

--- a/src/mixins/iframeHeight.js
+++ b/src/mixins/iframeHeight.js
@@ -1,5 +1,6 @@
 import debounce from 'lodash.debounce'
 import { sendWindowMessage } from '~/utils/sendMessage'
+import config from '../../nuxt.config.js'
 
 /**
  * When the app is in embedded mode, it passes the full height
@@ -42,6 +43,7 @@ export default {
     },
     notifyOuterWindow(height) {
       sendWindowMessage({
+        debug: config.dev,
         type: 'resize',
         value: { height },
       })

--- a/src/mixins/iframeHeight.js
+++ b/src/mixins/iframeHeight.js
@@ -41,7 +41,13 @@ export default {
     },
     notifyOuterWindow(height) {
       // TODO: set correct targetOrigin of the parent window
-      window.parent.postMessage({ height }, '*')
+      window.parent.postMessage(
+        {
+          type: 'resize',
+          value: height,
+        },
+        '*'
+      )
     },
   },
   watch: {

--- a/src/mixins/iframeHeight.js
+++ b/src/mixins/iframeHeight.js
@@ -1,4 +1,5 @@
 import debounce from 'lodash.debounce'
+import { sendWindowMessage } from '~/utils/sendMessage'
 
 /**
  * When the app is in embedded mode, it passes the full height
@@ -40,14 +41,10 @@ export default {
       )
     },
     notifyOuterWindow(height) {
-      // TODO: set correct targetOrigin of the parent window
-      window.parent.postMessage(
-        {
-          type: 'resize',
-          value: height,
-        },
-        '*'
-      )
+      sendWindowMessage({
+        type: 'resize',
+        value: { height },
+      })
     },
   },
   watch: {

--- a/src/plugins/message.js
+++ b/src/plugins/message.js
@@ -1,0 +1,21 @@
+import { sendWindowMessage } from '~/utils/sendMessage'
+
+/**
+ * In embedded mode, we need to notify the outer window of the current URL.
+ * Normally, the `src/middleware/embed.js` middleware does this on every
+ * route change. However, it does not run on the initial render.
+ * So, for the initial render this plugin runs when router is ready.
+ */
+export default function ({ app, store }) {
+  app.router.onReady(() => {
+    if (process.client && store.state.isEmbedded) {
+      sendWindowMessage({
+        type: 'urlChange',
+        value: {
+          path: app.router.currentRoute.fullPath,
+          title: document.title,
+        },
+      })
+    }
+  })
+}

--- a/src/plugins/message.js
+++ b/src/plugins/message.js
@@ -1,5 +1,5 @@
 import { sendWindowMessage } from '~/utils/sendMessage'
-
+import config from '../../nuxt.config.js'
 /**
  * In embedded mode, we need to notify the outer window of the current URL.
  * Normally, the `src/middleware/embed.js` middleware does this on every
@@ -10,6 +10,7 @@ export default function ({ app, store }) {
   app.router.onReady(() => {
     if (process.client && store.state.isEmbedded) {
       sendWindowMessage({
+        debug: config.dev,
         type: 'urlChange',
         value: {
           path: app.router.currentRoute.fullPath,

--- a/src/utils/sendMessage.js
+++ b/src/utils/sendMessage.js
@@ -11,6 +11,7 @@ const TARGET_ORIGIN = '*'
 export const sendWindowMessage = (message) => {
   window.parent.postMessage(
     {
+      debug: config.dev,
       type: message.type,
       value: message.value,
     },

--- a/src/utils/sendMessage.js
+++ b/src/utils/sendMessage.js
@@ -1,24 +1,16 @@
 // TODO: set correct targetOrigin of the parent window
 const TARGET_ORIGIN = '*'
-const config = {
-  dev: false,
-}
+
 /**
  * Send message to the outer window. Can only be called on client-side
  * because it uses `window` object.
  * @typedef {Object} message
+ * @property {boolean} debug - whether more verbose debug output should be used
  * @property {'resize'|'changeUrl'} type - event that triggers the message
  * @property {Object} value - the value of event
  */
 export const sendWindowMessage = (message) => {
   if (window.parent !== window) {
-    window.parent.postMessage(
-      {
-        debug: config.dev,
-        type: message.type,
-        value: message.value,
-      },
-      TARGET_ORIGIN
-    )
+    window.parent.postMessage(message, TARGET_ORIGIN)
   }
 }

--- a/src/utils/sendMessage.js
+++ b/src/utils/sendMessage.js
@@ -1,6 +1,8 @@
 // TODO: set correct targetOrigin of the parent window
 const TARGET_ORIGIN = '*'
-
+const config = {
+  dev: false,
+}
 /**
  * Send message to the outer window. Can only be called on client-side
  * because it uses `window` object.
@@ -9,12 +11,14 @@ const TARGET_ORIGIN = '*'
  * @property {Object} value - the value of event
  */
 export const sendWindowMessage = (message) => {
-  window.parent.postMessage(
-    {
-      debug: config.dev,
-      type: message.type,
-      value: message.value,
-    },
-    TARGET_ORIGIN
-  )
+  if (window.parent !== window) {
+    window.parent.postMessage(
+      {
+        debug: config.dev,
+        type: message.type,
+        value: message.value,
+      },
+      TARGET_ORIGIN
+    )
+  }
 }

--- a/src/utils/sendMessage.js
+++ b/src/utils/sendMessage.js
@@ -1,0 +1,19 @@
+// TODO: set correct targetOrigin of the parent window
+const TARGET_ORIGIN = '*'
+
+/**
+ * Send message to the outer window. Can only be called on client-side
+ * because it uses `window` object.
+ * @typedef {Object} message
+ * @property {'resize'|'changeUrl'} type - event that triggers the message
+ * @property {Object} value - the value of event
+ */
+export const sendWindowMessage = (message) => {
+  window.parent.postMessage(
+    {
+      type: message.type,
+      value: message.value,
+    },
+    TARGET_ORIGIN
+  )
+}


### PR DESCRIPTION
This PR improves the communication of the app with outer window in embedded mode.

When used in embedded mode inside an iframe, the app needs to set correct iframe height and display the correct URL in the address bar. This is achieved using messages sent from the app to the outer window. This PR specifically adds the message on every URL change.

Currently, there are two kinds of messages, which have unified format:
1. URL change, which sends the relative URL eg. `{type: 'urlChange', value: '/about' `}
2. Resize, which sends the height that iframe requires, in px, eg. `{type: 'resize', value: 1000 }`
