### PR TITLE
License filter alignment and Search button height fixes

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -142,7 +142,9 @@ $hero-height: 55vh;
     padding: 0.5rem 1.2rem;
     @include desktop {
       font-size: 1.75rem;
-      padding: 2.407rem 2.5rem;
+      padding-left: var(--button-padding-horizontal);
+      padding-right: var(--button-padding-horizontal);
+      height: 5.063rem;
     }
   }
 }

--- a/src/components/HomeLicenseFilter.vue
+++ b/src/components/HomeLicenseFilter.vue
@@ -1,14 +1,10 @@
 <template>
   <fieldset class="home-license-filter margin-top-xl">
-    <legend class="is-block margin-bottom-small has-text-weight-medium">
+    <legend>
       {{ $t('hero.license-filter.label') }}
     </legend>
     <template v-for="(licenseType, index) in licenseTypes">
-      <label
-        :key="index"
-        class="checkbox margin-right-big"
-        :for="licenseType.code"
-      >
+      <label :key="index" class="checkbox" :for="licenseType.code">
         <input
           :id="licenseType.code"
           type="checkbox"
@@ -46,15 +42,17 @@ export default {
 
 <style lang="scss" scoped>
 .home-license-filter {
-  text-align: left;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  legend {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-bottom: 0.5rem;
+  }
 }
-span {
-  display: block;
-  font-size: 1.25em;
-  font-weight: 600;
-}
-.license-filters {
-  display: inline-block;
+
+.checkbox:not(:last-child) {
+  margin-right: 1.5rem;
 }
 </style>


### PR DESCRIPTION
This PR contains two tiny style fixes: 

1. The home page filter legend wasn't centered:

<img width="573" alt="Screen Shot 2021-07-08 at 6 41 15 AM" src="https://user-images.githubusercontent.com/15233243/124863372-9f57a180-dfbf-11eb-918e-2cd273d630c5.png">

2. The Search button was a tiny bit smaller than the Search input:
<img width="310" alt="Screen Shot 2021-07-08 at 7 36 31 AM" src="https://user-images.githubusercontent.com/15233243/124863361-9cf54780-dfbf-11eb-8e28-bb78d336fb69.png">
<img width="573" alt="Screen Shot 2021-07-08 at 6 41 15 AM" src="https://user-images.githubusercontent.com/15233243/124863372-9f57a180-dfbf-11eb-918e-2cd273d630c5.png">

So excited to have the new styles 🎉 