### PR TITLE
Update about and sources pages

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -124,6 +124,7 @@
     "single-name": "Source",
     "providers": {
       "source": "Source",
+      "domain": "Domain",
       "item": "Total items"
     },
     "cc-content": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -104,12 +104,6 @@
       "content": "Please note that Openverse does not verify whether the images are properly CC licensed, or whether the attribution and other licensing information we have aggregated is accurate or complete. Please independently verify the licensing status and attribution information before reusing the content. For more details, read the {terms}.",
       "terms": "Openverse Terms of Use"
     },
-    "sources": "Sources",
-    "providers": {
-      "source": "Source",
-      "domain": "Domain",
-      "work": "# CC Licensed Works"
-    },
     "aria": {
       "common-crawl": "Common Crawl",
       "meta": "meta search",

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -48,10 +48,9 @@
               >
             </template>
             <template #community>
-              <!-- TODO: Update link to team page on Make WordPress -->
               <a
                 :aria-label="$t('about.aria.community')"
-                href="https://make.wordpress.org/"
+                href="https://make.wordpress.org/openverse/"
                 >{{ $t('about.planning.community') }}</a
               >
             </template>

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -90,39 +90,6 @@
               >
             </template>
           </i18n>
-
-          <h2 class="margin-top-large margin-bottom-normal">
-            {{ $t('about.sources') }}
-          </h2>
-          <table
-            :aria-label="$t('about.aria.sources')"
-            role="region"
-            class="table is-bordered is-striped margin-bottom-large"
-          >
-            <thead>
-              <tr>
-                <th>{{ $t('about.providers.source') }}</th>
-                <th>{{ $t('about.providers.domain') }}</th>
-                <th>{{ $t('about.providers.work') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="(imageProvider, index) in imageProviders" :key="index">
-                <td>{{ imageProvider.display_name }}</td>
-                <td>
-                  <a
-                    :aria-label="imageProvider.display_name"
-                    :href="imageProvider.source_url"
-                  >
-                    {{ imageProvider.source_url }}
-                  </a>
-                </td>
-                <td class="number-cell">
-                  {{ getProviderImageCount(imageProvider.image_count) }}
-                </td>
-              </tr>
-            </tbody>
-          </table>
         </div>
       </div>
     </div>
@@ -143,14 +110,6 @@ const AboutPage = {
   },
   computed: {
     ...mapState(['isEmbedded']),
-    imageProviders() {
-      return this.$store.state.imageProviders
-    },
-  },
-  methods: {
-    getProviderImageCount(imageCount) {
-      return imageCount.toLocaleString(this.$i18n.locale)
-    },
   },
 }
 

--- a/src/pages/feedback.vue
+++ b/src/pages/feedback.vue
@@ -2,7 +2,7 @@
   <div class="section">
     <div :class="['container', isEmbedded ? '' : 'is-fluid']">
       <div class="padding-bottom-big">
-        <h1 id="feedback" class="title is-2">
+        <h1 id="feedback" class="title is-2 margin-bottom-large">
           {{ $t('feedback.title') }}
         </h1>
         <i18n

--- a/src/pages/sources.vue
+++ b/src/pages/sources.vue
@@ -69,7 +69,7 @@
           </div>
         </div>
 
-        <h3 class="title subtitle is-4 margin-vertical-normal">
+        <h3 class="title subtitle is-3 margin-vertical-normal">
           {{ $t('sources.suggestions') }}
         </h3>
         <a
@@ -84,7 +84,6 @@
           />
         </a>
       </div>
-
       <i18n path="sources.detail" tag="p">
         <template #single-name>
           <strong>
@@ -95,7 +94,7 @@
       <table
         :aria-label="$t('about.aria.sources')"
         role="region"
-        class="table is-bordered is-striped margin-bottom-large margin-top-normal"
+        class="table is-striped margin-bottom-large margin-top-normal"
       >
         <thead>
           <tr>
@@ -124,7 +123,7 @@
         </thead>
         <tbody>
           <tr v-for="(imageProvider, index) in sortedProviders" :key="index">
-            <td>
+            <td class="bold-cell">
               <a
                 :aria-label="imageProvider.display_name"
                 :href="`/search?source=${imageProvider.source_name}`"
@@ -132,7 +131,7 @@
                 {{ imageProvider.display_name }}
               </a>
             </td>
-            <td>
+            <td class="bold-cell">
               <a
                 :aria-label="imageProvider.display_name"
                 :href="imageProvider.source_url"
@@ -200,7 +199,10 @@ export default SourcePage
 <style lang="scss" scoped>
 @import '~/styles/text-only-page.scss';
 
-.table.is-bordered {
+$table-border: 1px solid $color-light-gray;
+$table-border-radius: 4px;
+
+.table {
   th {
     cursor: pointer;
   }
@@ -219,6 +221,47 @@ export default SourcePage
   td,
   th {
     word-break: initial;
+    border-bottom: none;
+    border-top: none;
   }
+
+  /* The following are styles for rounding the table's */
+  border-collapse: separate;
+  border-radius: $table-border-radius;
+
+  th:first-child {
+    border-top-left-radius: $table-border-radius;
+  }
+  th:last-child {
+    border-top-right-radius: $table-border-radius;
+  }
+
+  tr:last-child {
+    td {
+      border-bottom: $table-border;
+    }
+    td:first-child {
+      border-bottom-left-radius: $table-border-radius;
+    }
+    td:last-child {
+      border-bottom-right-radius: $table-border-radius;
+    }
+  }
+
+  td {
+    border-left: $table-border;
+  }
+
+  tr td:last-child {
+    border-right: $table-border;
+  }
+}
+
+.bold-cell {
+  font-weight: 600;
+}
+
+.number-cell {
+  font-weight: 500;
 }
 </style>

--- a/src/pages/sources.vue
+++ b/src/pages/sources.vue
@@ -9,13 +9,13 @@
           <h3 class="title subtitle is-normal is-4">
             {{ $t('sources.cc-content.where') }}
           </h3>
-          <p class="body-big margin-vertical-normal">
+          <p class="margin-vertical-normal">
             {{ $t('sources.cc-content.content') }}
           </p>
           <i18n
             path="sources.cc-content.provider"
             tag="p"
-            class="body-big margin-vertical-normal"
+            class="margin-vertical-normal"
           >
             <template #flickr>
               <a aria-label="flickr" href="https://www.flickr.com/">{{
@@ -31,7 +31,7 @@
           <i18n
             path="sources.cc-content.europeana"
             tag="p"
-            class="body-big margin-vertical-normal"
+            class="margin-vertical-normal"
           >
             <template #link>
               <a aria-label="europeana" href="https://www.europeana.eu/en">{{
@@ -51,7 +51,7 @@
           <h3 class="title subtitle is-normal is-4">
             {{ $t('sources.new-content.next') }}
           </h3>
-          <p class="body-big margin-vertical-normal">
+          <p class="margin-vertical-normal">
             {{ $t('sources.new-content.integrate') }}
           </p>
           <div class="content">

--- a/src/pages/sources.vue
+++ b/src/pages/sources.vue
@@ -1,132 +1,74 @@
 <template>
   <div class="section">
-    <div :class="['container columns', isEmbedded ? '' : 'is-fluid']">
-      <header class="column is-full margin-bottom-small">
-        <h1 class="title is-2">
+    <div :class="['container', isEmbedded ? '' : 'is-fluid']">
+      <div class="margin-bottom-large">
+        <h1 class="title is-2 margin-bottom-large">
           {{ $t('sources.title') }}
         </h1>
-      </header>
-    </div>
-    <div
-      :class="[
-        'container columns is-variable is-4',
-        isEmbedded ? '' : 'is-fluid',
-      ]"
-    >
-      <div class="column">
-        <i18n path="sources.detail" tag="p">
-          <template #single-name>
-            <strong>
-              {{ $t('sources.single-name') }}
-            </strong>
-          </template>
-        </i18n>
-        <table
-          :aria-label="$t('about.aria.sources')"
-          role="region"
-          class="table is-bordered is-striped margin-bottom-large margin-top-normal"
-        >
-          <thead>
-            <tr>
-              <th
-                tabindex="0"
-                @click="sortTable('display_name')"
-                @keypress.enter="sortTable('display_name')"
+        <div class="margin-bottom-large">
+          <h3 class="title subtitle is-normal is-4">
+            {{ $t('sources.cc-content.where') }}
+          </h3>
+          <p class="body-big margin-vertical-normal">
+            {{ $t('sources.cc-content.content') }}
+          </p>
+          <i18n
+            path="sources.cc-content.provider"
+            tag="p"
+            class="body-big margin-vertical-normal"
+          >
+            <template #flickr>
+              <a aria-label="flickr" href="https://www.flickr.com/">{{
+                $t('sources.cc-content.flickr')
+              }}</a>
+            </template>
+            <template #smithsonian>
+              <a aria-label="smithsonian" href="https://www.si.edu/">{{
+                $t('sources.cc-content.smithsonian')
+              }}</a>
+            </template>
+          </i18n>
+          <i18n
+            path="sources.cc-content.europeana"
+            tag="p"
+            class="body-big margin-vertical-normal"
+          >
+            <template #link>
+              <a aria-label="europeana" href="https://www.europeana.eu/en">{{
+                $t('sources.cc-content.europeana-link')
+              }}</a>
+            </template>
+            <template #link-api>
+              <a
+                aria-label="europeana-api"
+                href="https://pro.europeana.eu/page/apis"
+                >{{ $t('sources.cc-content.europeana-api') }}</a
               >
-                <span class="table-header-inner">
-                  {{ $t('sources.providers.source') }}
-                  <span class="icon"><i class="icon sort" /></span>
-                </span>
-              </th>
-              <th
-                tabindex="0"
-                @click="sortTable('image_count')"
-                @keypress.enter="sortTable('image_count')"
-              >
-                <span class="table-header-inner">
-                  {{ $t('sources.providers.item') }}
-                  <span class="icon"><i class="icon sort" /></span>
-                </span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(imageProvider, index) in sortedProviders" :key="index">
-              <td>
-                <a
-                  :aria-label="imageProvider.display_name"
-                  :href="`/search?source=${imageProvider.source_name}`"
-                >
-                  {{ imageProvider.display_name }}
-                </a>
-              </td>
-              <td class="number-cell">
-                {{ getProviderImageCount(imageProvider.image_count) }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="column">
-        <h3 class="title subtitle is-normal is-4">
-          {{ $t('sources.cc-content.where') }}
-        </h3>
-        <p class="body-big margin-vertical-normal">
-          {{ $t('sources.cc-content.content') }}
-        </p>
-        <i18n
-          path="sources.cc-content.provider"
-          tag="p"
-          class="body-big margin-vertical-normal"
-        >
-          <template #flickr>
-            <a aria-label="flickr" href="https://www.flickr.com/">{{
-              $t('sources.cc-content.flickr')
-            }}</a>
-          </template>
-          <template #smithsonian>
-            <a aria-label="smithsonian" href="https://www.si.edu/">{{
-              $t('sources.cc-content.smithsonian')
-            }}</a>
-          </template>
-        </i18n>
-        <i18n
-          path="sources.cc-content.europeana"
-          tag="p"
-          class="body-big margin-vertical-normal"
-        >
-          <template #link>
-            <a aria-label="europeana" href="https://www.europeana.eu/en">{{
-              $t('sources.cc-content.europeana-link')
-            }}</a>
-          </template>
-          <template #link-api>
-            <a
-              aria-label="europeana-api"
-              href="https://pro.europeana.eu/page/apis"
-              >{{ $t('sources.cc-content.europeana-api') }}</a
-            >
-          </template>
-        </i18n>
-        <h3 class="title subtitle is-normal is-4">
-          {{ $t('sources.new-content.next') }}
-        </h3>
-        <p class="body-big margin-vertical-normal">
-          {{ $t('sources.new-content.integrate') }}
-        </p>
-        <div class="content">
-          <ul>
-            <li>
-              {{ $t('sources.new-content.impact') }}
-            </li>
-            <li>
-              {{ $t('sources.new-content.reuse') }}
-            </li>
-            <li>
-              {{ $t('sources.new-content.total-items') }}
-            </li>
-          </ul>
+            </template>
+          </i18n>
         </div>
+        <div class="margin-bottom-large">
+          <h3 class="title subtitle is-normal is-4">
+            {{ $t('sources.new-content.next') }}
+          </h3>
+          <p class="body-big margin-vertical-normal">
+            {{ $t('sources.new-content.integrate') }}
+          </p>
+          <div class="content">
+            <ul>
+              <li>
+                {{ $t('sources.new-content.impact') }}
+              </li>
+              <li>
+                {{ $t('sources.new-content.reuse') }}
+              </li>
+              <li>
+                {{ $t('sources.new-content.total-items') }}
+              </li>
+            </ul>
+          </div>
+        </div>
+
         <h5 class="title subtitle is-5 margin-vertical-normal">
           {{ $t('sources.suggestions') }}
         </h5>
@@ -140,6 +82,68 @@
           <i class="margin-left-small icon external-link" />
         </a>
       </div>
+
+      <i18n path="sources.detail" tag="p">
+        <template #single-name>
+          <strong>
+            {{ $t('sources.single-name') }}
+          </strong>
+        </template>
+      </i18n>
+      <table
+        :aria-label="$t('about.aria.sources')"
+        role="region"
+        class="table is-bordered is-striped margin-bottom-large margin-top-normal"
+      >
+        <thead>
+          <tr>
+            <th
+              tabindex="0"
+              @click="sortTable('display_name')"
+              @keypress.enter="sortTable('display_name')"
+            >
+              <span class="table-header-inner">
+                {{ $t('sources.providers.source') }}
+                <span class="icon"><i class="icon sort" /></span>
+              </span>
+            </th>
+            <th>{{ $t('sources.providers.domain') }}</th>
+            <th
+              tabindex="0"
+              @click="sortTable('image_count')"
+              @keypress.enter="sortTable('image_count')"
+            >
+              <span class="table-header-inner">
+                {{ $t('sources.providers.item') }}
+                <span class="icon"><i class="icon sort" /></span>
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(imageProvider, index) in sortedProviders" :key="index">
+            <td>
+              <a
+                :aria-label="imageProvider.display_name"
+                :href="`/search?source=${imageProvider.source_name}`"
+              >
+                {{ imageProvider.display_name }}
+              </a>
+            </td>
+            <td>
+              <a
+                :aria-label="imageProvider.display_name"
+                :href="imageProvider.source_url"
+              >
+                {{ imageProvider.source_url }}
+              </a>
+            </td>
+            <td class="number-cell">
+              {{ getProviderImageCount(imageProvider.image_count) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>

--- a/src/pages/sources.vue
+++ b/src/pages/sources.vue
@@ -6,7 +6,7 @@
           {{ $t('sources.title') }}
         </h1>
         <div class="margin-bottom-large">
-          <h3 class="title subtitle is-normal is-4">
+          <h3 class="title subtitle is-normal is-3">
             {{ $t('sources.cc-content.where') }}
           </h3>
           <p class="margin-vertical-normal">
@@ -48,7 +48,7 @@
           </i18n>
         </div>
         <div class="margin-bottom-large">
-          <h3 class="title subtitle is-normal is-4">
+          <h3 class="title subtitle is-normal is-3">
             {{ $t('sources.new-content.next') }}
           </h3>
           <p class="margin-vertical-normal">
@@ -202,7 +202,16 @@ export default SourcePage
 $table-border: 1px solid $color-light-gray;
 $table-border-radius: 4px;
 
-.table {
+.title.is-3 {
+  font-size: 1.1875rem;
+}
+
+.button.is-primary {
+  font-size: 1.1875rem;
+  font-weight: 700;
+}
+
+.table.is-striped {
   th {
     cursor: pointer;
   }
@@ -225,7 +234,7 @@ $table-border-radius: 4px;
     border-top: none;
   }
 
-  /* The following are styles for rounding the table's */
+  /* The following are styles for rounding the table's corners */
   border-collapse: separate;
   border-radius: $table-border-radius;
 

--- a/src/pages/sources.vue
+++ b/src/pages/sources.vue
@@ -73,7 +73,7 @@
           {{ $t('sources.suggestions') }}
         </h5>
         <a
-          href="https://github.com/creativecommons/cccatalog/issues/new?assignees=&labels=awaiting+triage%2C+ticket+work+required%2C+providers&template=new-source-suggestion.md&title=%5BSource+Suggestion%5D+Insert+source+name+here"
+          href="https://github.com/WordPress/openverse-catalog/issues/new?assignees=&labels=%F0%9F%9A%A6+status%3A+awaiting+triage%2C+%F0%9F%A7%B9+status%3A+ticket+work+required%2C+%E2%98%81%EF%B8%8F+provider%3A+any&template=new-source-suggestion.md&title=%5BSource+Suggestion%5D+Insert+source+name+here"
           class="button is-primary is-uppercase"
           target="_blank"
           rel="noopener noreferrer"

--- a/src/pages/sources.vue
+++ b/src/pages/sources.vue
@@ -69,17 +69,19 @@
           </div>
         </div>
 
-        <h5 class="title subtitle is-5 margin-vertical-normal">
+        <h3 class="title subtitle is-4 margin-vertical-normal">
           {{ $t('sources.suggestions') }}
-        </h5>
+        </h3>
         <a
           href="https://github.com/WordPress/openverse-catalog/issues/new?assignees=&labels=%F0%9F%9A%A6+status%3A+awaiting+triage%2C+%F0%9F%A7%B9+status%3A+ticket+work+required%2C+%E2%98%81%EF%B8%8F+provider%3A+any&template=new-source-suggestion.md&title=%5BSource+Suggestion%5D+Insert+source+name+here"
-          class="button is-primary is-uppercase"
+          class="button is-primary padding-vertical-bigger"
           target="_blank"
           rel="noopener noreferrer"
         >
           {{ $t('sources.issue-button') }}
-          <i class="margin-left-small icon external-link" />
+          <i
+            class="icon external-link margin-horizontal-small margin-top-small"
+          />
         </a>
       </div>
 

--- a/src/styles/base/generic.sass
+++ b/src/styles/base/generic.sass
@@ -11,7 +11,7 @@ $body-overflow-y: scroll
 $body-color: $color-dark-slate-gray
 $body-font-size: 1em
 $body-weight: $weight-normal
-$body-line-height: 1.5
+$body-line-height: 1.9
 
 $code-family: $family-code
 $code-padding: 0.25em 0.5em 0.25em

--- a/src/styles/base/generic.sass
+++ b/src/styles/base/generic.sass
@@ -75,6 +75,7 @@ body
   font-display: swap
   -webkit-font-smoothing: antialiased
   -moz-osx-font-smoothing: grayscale
+
 // Inline
 
 a

--- a/src/styles/utilities/derived-variables.scss
+++ b/src/styles/utilities/derived-variables.scss
@@ -72,7 +72,7 @@ $pre-background: $background;
 $link: $color-transition-blue;
 $link-visited: currentColor;
 
-$link-hover: currentColor;
+$link-hover: $color-transition-blue;
 $link-hover-border: $color-light-gray;
 
 $link-focus: currentColor;


### PR DESCRIPTION
Fixes #34.

## Description 
This PR remove the sources table in `/about` page and expand the one in the `/sources` page, as presented in @panchovm's [mockups][mockups] for transitional styles. Also updates the links to the Make WordPress team and to suggest new sources to the Catalog.

[mockups]: https://www.figma.com/file/BlUTIXRHLOq5mRITpDpi3E/Transitional-styles?node-id=0%3A1&viewport=74%2C344%2C0.09312169253826141

## Preview
https://ov-fe-preview.herokuapp.com/sources