### PR TITLE
Make filter display vertically centered

### DIFF
--- a/src/components/Filters/FilterBlock.vue
+++ b/src/components/Filters/FilterBlock.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     v-if="filterType === 'searchBy'"
-    class="filter-block button tiny tag margin-horizontal-smaller"
+    class="filter-block button tiny tag"
     :aria-label="label + 'filter'"
   >
     <span>{{ $props.label }}</span>
@@ -16,7 +16,7 @@
   </button>
   <button
     v-else
-    class="filter-block button tiny tag margin-horizontal-smaller margin-bottom-smaller"
+    class="filter-block button tiny tag margin-horizontal-smaller"
     :aria-label="label + 'filter'"
   >
     <span>{{ $t($props.label) }}</span>
@@ -46,3 +46,8 @@ export default {
   },
 }
 </script>
+<style lang="scss" scoped>
+.filter-block {
+  margin-left: 0.5rem;
+}
+</style>

--- a/src/components/Filters/FilterDisplay.vue
+++ b/src/components/Filters/FilterDisplay.vue
@@ -1,72 +1,70 @@
 <template>
-  <div class="filter-display padding-normal" aria-live="polite">
+  <div class="filter-display" aria-live="polite">
     <span v-if="anyFilterApplied" class="caption has-text-weight-semibold">{{
       $t('filters.filter-by')
     }}</span>
-    <span v-for="filter in getFilters('licenses')" :key="filter.code">
-      <FilterBlock
-        :code="filter.code"
-        :label="filter.name"
-        filter-type="licenses"
-        @filterChanged="onUpdateFilter"
-      />
-    </span>
-    <span v-for="filter in getFilters('licenseTypes')" :key="filter.code">
-      <FilterBlock
-        :code="filter.code"
-        :label="filter.name"
-        filter-type="licenseTypes"
-        @filterChanged="onUpdateFilter"
-      />
-    </span>
-    <span v-for="filter in getFilters('categories')" :key="filter.code">
-      <FilterBlock
-        :code="filter.code"
-        :label="filter.name"
-        filter-type="categories"
-        @filterChanged="onUpdateFilter"
-      />
-    </span>
-    <span v-for="filter in getFilters('extensions')" :key="filter.code">
-      <FilterBlock
-        :code="filter.code"
-        :label="filter.name"
-        filter-type="extensions"
-        @filterChanged="onUpdateFilter"
-      />
-    </span>
-    <span v-for="filter in getFilters('aspectRatios')" :key="filter.code">
-      <FilterBlock
-        :code="filter.code"
-        :label="filter.name"
-        filter-type="aspectRatios"
-        @filterChanged="onUpdateFilter"
-      />
-    </span>
-    <span v-for="filter in getFilters('sizes')" :key="filter.code">
-      <FilterBlock
-        :code="filter.code"
-        :label="filter.name"
-        filter-type="sizes"
-        @filterChanged="onUpdateFilter"
-      />
-    </span>
-    <span v-for="filter in getFilters('providers')" :key="filter.code">
-      <FilterBlock
-        :code="filter.code"
-        :label="filter.name"
-        filter-type="providers"
-        @filterChanged="onUpdateFilter"
-      />
-    </span>
-    <span>
-      <FilterBlock
-        v-if="searchByCreator"
-        label="Creator"
-        filter-type="searchBy"
-        @filterChanged="onUpdateBoolFilter"
-      />
-    </span>
+    <FilterBlock
+      v-for="filter in getFilters('licenses')"
+      :key="filter.code"
+      :code="filter.code"
+      :label="filter.name"
+      filter-type="licenses"
+      @filterChanged="onUpdateFilter"
+    />
+    <FilterBlock
+      v-for="filter in getFilters('licenseTypes')"
+      :key="filter.code"
+      :code="filter.code"
+      :label="filter.name"
+      filter-type="licenseTypes"
+      @filterChanged="onUpdateFilter"
+    />
+    <FilterBlock
+      v-for="filter in getFilters('categories')"
+      :key="filter.code"
+      :code="filter.code"
+      :label="filter.name"
+      filter-type="categories"
+      @filterChanged="onUpdateFilter"
+    />
+    <FilterBlock
+      v-for="filter in getFilters('extensions')"
+      :key="filter.code"
+      :code="filter.code"
+      :label="filter.name"
+      filter-type="extensions"
+      @filterChanged="onUpdateFilter"
+    />
+    <FilterBlock
+      v-for="filter in getFilters('aspectRatios')"
+      :key="filter.code"
+      :code="filter.code"
+      :label="filter.name"
+      filter-type="aspectRatios"
+      @filterChanged="onUpdateFilter"
+    />
+    <FilterBlock
+      v-for="filter in getFilters('sizes')"
+      :key="filter.code"
+      :code="filter.code"
+      :label="filter.name"
+      filter-type="sizes"
+      @filterChanged="onUpdateFilter"
+    />
+    <FilterBlock
+      v-for="filter in getFilters('providers')"
+      :key="filter.code"
+      :code="filter.code"
+      :label="filter.name"
+      filter-type="providers"
+      @filterChanged="onUpdateFilter"
+    />
+    <FilterBlock
+      v-if="searchByCreator"
+      label="Creator"
+      filter-type="searchBy"
+      @filterChanged="onUpdateBoolFilter"
+    />
   </div>
 </template>
 <script>
@@ -125,3 +123,13 @@ export default {
   },
 }
 </script>
+<style lang="scss" scoped>
+.filter-display {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  .caption {
+    margin-right: 0.5rem;
+  }
+}
+</style>

--- a/src/styles/components/button.sass
+++ b/src/styles/components/button.sass
@@ -6,7 +6,7 @@ $button-border-width: 1px
 
 $button-focus-color: $link-focus
 $button-focus-border-color: $link-focus-border
-$button-focus-box-shadow-size: 0 0 0 0.125em
+$button-focus-box-shadow-size: 0 0 0 0.125rem
 $button-focus-box-shadow-color: toRgba($link, 0.25)
 
 $button-active-color: $link-active
@@ -44,7 +44,7 @@ $button-colors: $colors
   --button-padding-horizontal-fourth: 0.813rem
   --button-border-width: #{$button-border-width}
   --button-font-size: #{$font-size-body-bigger}
-  --button-focused-box-shadow-color: #{toRgba($color-light-gray, 0.3)}
+  --button-focused-box-shadow-color: #{toRgba($color-light-gray, 0.5)}
   font-weight: 600
   line-height: 0
   background-color: $color-white


### PR DESCRIPTION

Currently, the search filter tags are aligned to top vertically.
<img width="422" alt="Screen Shot 2021-07-13 at 12 00 48 PM" src="https://user-images.githubusercontent.com/15233243/125424376-2cb3799d-82b8-496d-a813-fc323d0c8980.png">

However, in the design mockups they are center-aligned. This PR centers the filter tags vertically, and removes unnecessary spans from around the tag buttons:

<img width="560" alt="Screen Shot 2021-07-13 at 11 56 12 AM" src="https://user-images.githubusercontent.com/15233243/125424371-d0b8add7-3183-4974-8d86-4dabf3d09345.png">