### PR TITLE
Filter refactor

### DIFF
--- a/src/components/Filters/FilterChecklist.vue
+++ b/src/components/Filters/FilterChecklist.vue
@@ -4,44 +4,70 @@
     @click="hideLicenseExplanationVisibility()"
     @keyup.enter="hideLicenseExplanationVisibility()"
   >
-    <h4 v-if="title">{{ title }}</h4>
-
     <div
-      v-for="(item, index) in options"
-      :key="index"
-      class="margin-top-small filter-checkbox-wrapper"
+      v-if="title"
+      class="filters-title"
+      @click.prevent="toggleFilterVisibility"
+      @keyup.enter="toggleFilterVisibility"
     >
-      <label class="checkbox" :for="item.code" :disabled="isDisabled(item)">
-        <input
-          :key="index"
-          :name="item.code"
-          type="checkbox"
-          class="filter-checkbox margin-right-small"
-          :checked="item.checked"
-          :disabled="isDisabled(item)"
-          @change="onValueChange"
+      <h4>{{ title }}</h4>
+      <button
+        v-if="!filtersExpandedByDefault"
+        :aria-label="'filters list for' + title + 'category'"
+        class="filter-visibility-toggle is-white padding-vertical-small"
+      >
+        <i
+          v-if="areFiltersExpanded"
+          class="icon angle-up rotImg is-size-5 has-text-grey-light"
+          title="toggle filters visibility"
         />
-        <LicenseIcons v-if="filterType == 'licenses'" :license="item.code" />
-        {{ itemLabel(item) }}
-      </label>
-      <img
-        v-if="filterType == 'licenses'"
-        :aria-label="$t('browse-page.aria.license-explanation')"
-        tabindex="0"
-        src="@/assets/help_icon.svg"
-        alt="help"
-        class="license-help padding-top-smallest padding-right-smaller"
-        @click.stop="toggleLicenseExplanationVisibility(item.code)"
-        @keyup.enter="toggleLicenseExplanationVisibility(item.code)"
-      />
-
-      <LicenseExplanationTooltip
-        v-if="
-          shouldRenderLicenseExplanationTooltip(item.code) && !isDisabled(item)
-        "
-        :license="licenseExplanationCode"
-      />
+        <i
+          v-else
+          class="icon angle-down is-size-5 has-text-grey-light"
+          title="toggle filters visibility"
+        />
+      </button>
     </div>
+    <template v-if="areFiltersExpanded">
+      <div
+        v-for="(item, index) in options"
+        :key="index"
+        class="filter-checkbox-wrapper"
+      >
+        <!--eslint-disable vuejs-accessibility/label-has-for -->
+        <label class="checkbox" :disabled="isDisabled(item)">
+          <input
+            :key="index"
+            :name="item.code"
+            type="checkbox"
+            class="filter-checkbox margin-right-small"
+            :checked="item.checked"
+            :disabled="isDisabled(item)"
+            @change="onValueChange"
+          />
+          <LicenseIcons v-if="filterType == 'licenses'" :license="item.code" />
+          {{ itemLabel(item) }}
+        </label>
+        <img
+          v-if="filterType == 'licenses'"
+          :aria-label="$t('browse-page.aria.license-explanation')"
+          tabindex="0"
+          src="@/assets/help_icon.svg"
+          alt="help"
+          class="license-help padding-top-smallest padding-right-smaller"
+          @click.stop="toggleLicenseExplanationVisibility(item.code)"
+          @keyup.enter="toggleLicenseExplanationVisibility(item.code)"
+        />
+
+        <LicenseExplanationTooltip
+          v-if="
+            shouldRenderLicenseExplanationTooltip(item.code) &&
+            !isDisabled(item)
+          "
+          :license="licenseExplanationCode"
+        />
+      </div>
+    </template>
   </div>
 </template>
 
@@ -68,13 +94,19 @@ export default {
      * Show filters expanded by default
      * @todo: The A/B test is over and we're going with the expanded view. Can remove a lot of this old test logic
      */
+    filtersExpandedByDefault() {
+      return true
+    },
+    areFiltersExpanded() {
+      return this.filtersExpandedByDefault || this.filtersVisible
+    },
     isSingleFilter() {
-      return this.filterType == 'searchBy'
+      return this.$props.filterType === 'searchBy'
     },
   },
   methods: {
     itemLabel(item) {
-      return this.filterType == 'providers' ? item.name : this.$t(item.name)
+      return this.filterType === 'providers' ? item.name : this.$t(item.name)
     },
     onValueChange(e) {
       this.$emit('filterChanged', {
@@ -82,6 +114,11 @@ export default {
         filterType: this.$props.filterType,
       })
     },
+    /**
+     * This function is used to hide sub items in filters
+     * It was decided not to use them after a/b tests
+     * TODO: either remove or use if necessary when implementing new designs
+     */
     toggleFilterVisibility() {
       this.filtersVisible = !this.filtersVisible
     },
@@ -134,9 +171,9 @@ export default {
 .filters {
   border-bottom: 2px solid rgb(245, 245, 245);
   padding: 1.5rem 1rem 1.5rem 1.5rem;
-  &.single {
-    padding-left: 1rem;
-  }
+  //&.single {
+  //  padding-left: 1rem;
+  //}
 }
 
 .filters-title {
@@ -147,6 +184,7 @@ export default {
   line-height: 1.5;
   letter-spacing: normal;
   cursor: pointer;
+  margin-bottom: 0.5rem;
 }
 
 .filter-visibility-toggle {
@@ -168,11 +206,11 @@ label {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 0.75rem;
 }
 
 .checkbox {
   display: flex;
-  margin-bottom: 0.75rem;
   align-items: center;
   font-size: 14px;
 }

--- a/src/components/Filters/FiltersList.vue
+++ b/src/components/Filters/FiltersList.vue
@@ -22,97 +22,24 @@
         </span>
       </button>
     </div>
-    <form :class="{ 'filters-form': true }" role="list">
+    <form class="filters-form" role="list">
       <FilterCheckList
+        v-for="filterType in filterTypes"
+        :key="filterType"
         role="listitem"
-        :options="filters.licenseTypes"
+        :options="filters[filterType]"
         :disabled="licenseTypesDisabled"
-        :title="$t('filters.license-types.title')"
-        filter-type="licenseTypes"
+        :title="filterTypeTitle(filterType)"
+        :filter-type="filterType"
         @filterChanged="onUpdateFilter"
       />
-      <FilterCheckList
-        v-if="activeTab == 'image'"
-        role="listitem"
-        :options="filters.licenses"
-        :disabled="licensesDisabled"
-        :title="$t('filters.licenses.title')"
-        filter-type="licenses"
-        @filterChanged="onUpdateFilter"
-      />
-      <FilterCheckList
-        v-if="activeTab == 'image'"
-        role="listitem"
-        :options="filters.providers"
-        :title="$t('filters.providers.title')"
-        filter-type="providers"
-        @filterChanged="onUpdateFilter"
-      />
-      <FilterCheckList
-        v-if="activeTab == 'image'"
-        role="listitem"
-        :options="filters.categories"
-        :title="$t('filters.categories.title')"
-        filter-type="categories"
-        @filterChanged="onUpdateFilter"
-      />
-      <FilterCheckList
-        v-if="activeTab == 'image'"
-        role="listitem"
-        :options="filters.extensions"
-        :title="$t('filters.extensions.title')"
-        filter-type="extensions"
-        @filterChanged="onUpdateFilter"
-      />
-      <FilterCheckList
-        v-if="activeTab == 'image'"
-        role="listitem"
-        :options="filters.aspectRatios"
-        :title="$t('filters.aspect-ratios.title')"
-        filter-type="aspectRatios"
-        @filterChanged="onUpdateFilter"
-      />
-      <FilterCheckList
-        v-if="activeTab == 'image'"
-        role="listitem"
-        :options="filters.sizes"
-        :title="$t('filters.sizes.title')"
-        filter-type="sizes"
-        @filterChanged="onUpdateFilter"
-      />
-      <div
-        v-if="activeTab == 'image'"
-        class="margin-normal filter-option small-filter margin-bottom-normal"
-      >
-        <label for="creator" :aria-label="$t('browse-page.aria.creator')">
-          <input
-            id="creator"
-            type="checkbox"
-            :aria-label="$t('browse-page.aria.creator')"
-            :checked="filters.searchBy.creator"
-            @change="onUpdateSearchByCreator"
-          />
-          {{ $t('filters.creator.title') }}</label
-        >
-      </div>
     </form>
-    <div
-      v-if="isFilterApplied"
-      class="margin-big padding-bottom-normal clear-filters is-hidden-touch"
-    >
+    <div v-if="isFilterApplied" class="clear-filters filter-buttons">
       <button class="button tiny" @click="onClearFilters">
         {{ $t('filter-list.clear') }}
       </button>
-    </div>
-    <div
-      v-if="isFilterApplied"
-      class="has-background-white padding-big is-hidden-desktop has-text-centered"
-    >
-      <button class="button tiny margin-right-normal" @click="onClearFilters">
-        {{ $t('filter-list.clear') }}
-      </button>
       <button
-        class="button is-primary tiny"
+        class="button is-primary tiny is-hidden-desktop"
         @click="onToggleSearchGridFilter()"
       >
         {{ $t('filter-list.show') }}
@@ -129,18 +56,35 @@ export default {
   components: {
     FilterCheckList,
   },
-  props: [
-    'filters',
-    'isFilterApplied',
-    'licenseTypesDisabled',
-    'licensesDisabled',
-  ],
+  props: ['isFilterApplied', 'licenseTypesDisabled', 'licensesDisabled'],
   computed: {
+    filters() {
+      return this.$store.getters.getAllImageFilters
+    },
+    filterTypes() {
+      return Object.keys(this.filters)
+    },
     activeTab() {
       return this.$route.path.split('search/')[1] || 'image'
     },
   },
   methods: {
+    filterTypeTitle(filterType) {
+      const kebabize = (str) => {
+        return str
+          .split('')
+          .map((letter, idx) => {
+            return letter.toUpperCase() === letter
+              ? `${idx !== 0 ? '-' : ''}${letter.toLowerCase()}`
+              : letter
+          })
+          .join('')
+      }
+      if (filterType == 'searchBy') {
+        return ''
+      }
+      return this.$t(`filters.${kebabize(filterType)}.title`)
+    },
     onUpdateFilter({ code, filterType }) {
       this.$emit('onUpdateFilter', { code, filterType })
     },
@@ -161,5 +105,17 @@ export default {
 .scroll-y {
   overflow-y: scroll;
   height: calc(100vh - 84px);
+}
+.filter-buttons {
+  padding: 1.5rem;
+  text-align: center;
+  @include desktop {
+    padding: 0;
+    padding-bottom: 1rem;
+    margin: 1.5rem;
+  }
+}
+.filter-buttons .button:first-child {
+  margin-right: 1rem;
 }
 </style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -339,6 +339,7 @@
       "title": "Search by Creator"
     },
     "searchBy": {
+      "title": "Search By",
       "creator": "Creator"
     },
     "license-explanation": {

--- a/src/store-modules/filter-store.js
+++ b/src/store-modules/filter-store.js
@@ -164,7 +164,6 @@ const getters = {
         }
       }
     })
-    console.log('getimagefilters returns ', allImageFilters)
     return allImageFilters
   },
 }

--- a/src/store-modules/filter-store.js
+++ b/src/store-modules/filter-store.js
@@ -140,30 +140,32 @@ const getters = {
   },
   getAllImageFilters: (state) => {
     let allImageFilters = {}
-    Object.keys(state.filters).forEach((filterType) => {
-      if (IMAGE_FILTERS.includes(filterType)) {
-        if (filterType === 'searchBy') {
-          allImageFilters[filterType] = [
-            {
-              code: 'creator',
-              name: 'filters.creator.title',
-              filterType: 'searchBy',
-              checked: state.filters.searchBy.creator,
-            },
-          ]
-        } else if (filterType !== 'mature') {
-          const newFilters = state.filters[filterType].map((f) => {
-            return {
-              code: f.code,
-              name: f.name,
-              filterType: filterType,
-              checked: f.checked,
-            }
-          })
-          allImageFilters[filterType] = newFilters
-        }
+    IMAGE_FILTERS.forEach((filterType) => {
+      if (filterType === 'searchBy') {
+        allImageFilters.searchBy = [
+          {
+            code: 'creator',
+            name: 'filters.creator.title',
+            filterType: 'searchBy',
+            checked: state.filters.searchBy.creator,
+          },
+        ]
+      } else if (filterType !== 'mature') {
+        // TODO: when adding other media type filters,
+        // convert media-specific filterType to generic typeName
+        // (eg. imageCategories -> categories)
+        const typeName = filterType
+        allImageFilters[typeName] = state.filters[typeName].map((f) => {
+          return {
+            code: f.code,
+            name: f.name,
+            filterType: typeName,
+            checked: f.checked,
+          }
+        })
       }
     })
+    console.log('all image filters: ', allImageFilters)
     return allImageFilters
   },
 }

--- a/src/store-modules/filter-store.js
+++ b/src/store-modules/filter-store.js
@@ -13,6 +13,17 @@ import {
   queryToFilterData,
 } from '~/utils/searchQueryTransform'
 
+const IMAGE_FILTERS = [
+  'licenses',
+  'licenseTypes',
+  'categories',
+  'extensions',
+  'aspectRatios',
+  'sizes',
+  'providers',
+  'searchBy',
+  'mature',
+]
 export const filterData = {
   licenses: [
     { code: 'cc0', name: 'filters.licenses.cc0', checked: false },
@@ -126,6 +137,35 @@ const getters = {
       }
     })
     return appliedFilters
+  },
+  getAllImageFilters: (state) => {
+    let allImageFilters = {}
+    Object.keys(state.filters).forEach((filterType) => {
+      if (IMAGE_FILTERS.includes(filterType)) {
+        if (filterType === 'searchBy') {
+          allImageFilters[filterType] = [
+            {
+              code: 'creator',
+              name: 'filters.creator.title',
+              filterType: 'searchBy',
+              checked: state.filters.searchBy.creator,
+            },
+          ]
+        } else if (filterType !== 'mature') {
+          const newFilters = state.filters[filterType].map((f) => {
+            return {
+              code: f.code,
+              name: f.name,
+              filterType: filterType,
+              checked: f.checked,
+            }
+          })
+          allImageFilters[filterType] = newFilters
+        }
+      }
+    })
+    console.log('getimagefilters returns ', allImageFilters)
+    return allImageFilters
   },
 }
 


### PR DESCRIPTION
Related to #105 

This PR refactors `FilterChecklist` to remove unnecessary repetition.
It also adds `filter-store` getters for applied filter tags so that the UI gets a list of unified objects for the filter (instead of some filter types that are arrays, some objects and some strings.

This will prepare the code base for adding the media type  specific filters.