### PR TITLE
All tab

### DIFF
--- a/src/components/SearchTypeTabs.vue
+++ b/src/components/SearchTypeTabs.vue
@@ -12,7 +12,7 @@
         role="tab"
         :class="tabClass(type, 'tab')"
       >
-        {{ capitalize(type) }}
+        {{ tabTitle(type) }}
       </NuxtLink>
     </div>
   </section>
@@ -48,6 +48,9 @@ export default {
         path: `/search/${pathType}`,
         query: this.$route.query,
       })
+    },
+    tabTitle(type) {
+      return this.capitalize(this.$t(`search-tab.${type}`))
     },
   },
 }

--- a/src/components/SearchTypeTabs.vue
+++ b/src/components/SearchTypeTabs.vue
@@ -6,7 +6,7 @@
         :id="type"
         :key="type"
         aria-live="polite"
-        :to="localePath({ path: `/search/${type}`, query: $route.query })"
+        :to="tabPath(type)"
         :aria-selected="activeTab == type"
         :aria-controls="'tab-' + type"
         role="tab"
@@ -25,12 +25,12 @@ export default {
   name: 'SearchTypeTabs',
   data() {
     return {
-      contentTypes: ['image', 'audio', 'video'],
+      contentTypes: ['all', 'image', 'audio', 'video'],
     }
   },
   computed: {
     activeTab() {
-      return this.$route.path.split('search/')[1] || 'image'
+      return this.$route.path.split('search/')[1] || 'all'
     },
   },
   methods: {
@@ -41,6 +41,13 @@ export default {
         'is-size-5': true,
         'is-active': tabSlug === this.activeTab,
       }
+    },
+    tabPath(type) {
+      const pathType = type === 'all' ? '' : type
+      return this.localePath({
+        path: `/search/${pathType}`,
+        query: this.$route.query,
+      })
     },
   },
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -301,6 +301,7 @@
     "image-not-found": "Couldn't find image with id {id}"
   },
   "search-tab": {
+    "all": "All",
     "image": "Image",
     "audio": "Audio",
     "video": "Video"

--- a/src/pages/search.vue
+++ b/src/pages/search.vue
@@ -15,14 +15,8 @@
       <div class="column search-grid-ctr">
         <SearchGridForm @onSearchFormSubmit="onSearchFormSubmit" />
         <SearchTypeTabs />
-        <FilterDisplay
-          v-if="$route.path === '/search/' || $route.path === '/search/image'"
-        />
-        <NuxtChild
-          :key="$route.path"
-          :query="query"
-          @onLoadMoreImages="onLoadMoreImages"
-        />
+        <FilterDisplay v-if="shouldShowFilterTags" />
+        <NuxtChild :key="$route.path" @onLoadMoreImages="onLoadMoreImages" />
       </div>
     </div>
   </div>
@@ -92,6 +86,11 @@ const BrowsePage = {
       this.$store.commit(SET_FILTER_IS_VISIBLE, {
         isFilterVisible: !this.isFilterVisible,
       })
+    },
+    shouldShowFilterTags() {
+      return (
+        this.$route.path === '/search/' || this.$route.path === '/search/image'
+      )
     },
   },
   watch: {

--- a/src/pages/search/image.vue
+++ b/src/pages/search/image.vue
@@ -9,6 +9,7 @@
 
 <script>
 export default {
+  name: 'ImageSearch',
   methods: {
     onLoadMoreImages(searchParams) {
       this.$emit('onLoadMoreImages', searchParams)

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -1,14 +1,15 @@
 <template>
   <SearchGrid
-    id="tab-image"
+    id="tab-all"
     role="tabpanel"
-    aria-labelledby="image"
+    aria-labelledby="all"
     @onLoadMoreImages="onLoadMoreImages"
   />
 </template>
 
 <script>
 export default {
+  name: 'SearchIndex',
   methods: {
     onLoadMoreImages(searchParams) {
       this.$emit('onLoadMoreImages', searchParams)


### PR DESCRIPTION
Fixes #102 

To prepare for Audio addition, this PR adds the default search tab 'All' to the current 'Image', 'Audio' and 'Video'.  Currently, the content of the 'All' tab is the same as the content of 'Image' tab:

<img width="841" alt="Screen Shot 2021-08-02 at 3 04 41 PM" src="https://user-images.githubusercontent.com/15233243/127859147-52080130-b40b-4a6d-b2c9-4a7ba817de81.png">
