### PR TITLE
Add correct meta video filters to the new filter method

### DIFF
--- a/src/components/Filters/FiltersList.vue
+++ b/src/components/Filters/FiltersList.vue
@@ -46,7 +46,7 @@
 
 <script>
 import { kebabize } from '~/utils/formatStrings'
-import { AUDIO, IMAGE } from '~/constants/media'
+import { AUDIO, IMAGE, VIDEO } from '~/constants/media'
 import FilterChecklist from './FilterChecklist'
 
 export default {
@@ -56,11 +56,14 @@ export default {
   },
   computed: {
     filters() {
+      console.log(this.$store.state.searchType)
       switch (this.$store.state.searchType) {
         case AUDIO:
           return this.$store.getters.audioFiltersForDisplay
         case IMAGE:
           return this.$store.getters.imageFiltersForDisplay
+        case VIDEO:
+          return this.$store.getters.videoFiltersForDisplay
         default:
           return this.$store.getters.allFiltersForDisplay
       }

--- a/src/constants/media.js
+++ b/src/constants/media.js
@@ -3,6 +3,8 @@ export const IMAGE = 'image'
 export const VIDEO = 'video'
 export const ALL_MEDIA = 'all'
 
+// Media types
 export const mediaTypes = [AUDIO, IMAGE]
-export const supportedMediaTypes = [AUDIO, IMAGE]
+// Media types which support custom filters
+export const supportedMediaTypes = [VIDEO, IMAGE, VIDEO]
 export const allMediaTypes = [ALL_MEDIA, IMAGE, AUDIO, VIDEO]

--- a/src/constants/media.js
+++ b/src/constants/media.js
@@ -6,5 +6,5 @@ export const ALL_MEDIA = 'all'
 // Media types
 export const mediaTypes = [AUDIO, IMAGE]
 // Media types which support custom filters
-export const supportedMediaTypes = [VIDEO, IMAGE, VIDEO]
+export const supportedMediaTypes = [AUDIO, IMAGE, VIDEO]
 export const allMediaTypes = [ALL_MEDIA, IMAGE, AUDIO, VIDEO]

--- a/src/pages/search/audio.vue
+++ b/src/pages/search/audio.vue
@@ -6,6 +6,7 @@
     aria-labelledby="audio"
   />
 </template>
+
 <script>
 import { UPDATE_SEARCH_TYPE } from '~/store-modules/action-types'
 import { AUDIO } from '~/constants/media'

--- a/src/pages/search/video.vue
+++ b/src/pages/search/video.vue
@@ -6,3 +6,15 @@
     aria-labelledby="video"
   />
 </template>
+
+<script>
+import { UPDATE_SEARCH_TYPE } from '~/store-modules/action-types'
+import { VIDEO } from '~/constants/media'
+
+export default {
+  name: 'VideoSearch',
+  async mounted() {
+    await this.$store.dispatch(UPDATE_SEARCH_TYPE, { searchType: VIDEO })
+  },
+}
+</script>

--- a/src/store-modules/filter-store.js
+++ b/src/store-modules/filter-store.js
@@ -13,9 +13,15 @@ import {
   filtersToQueryData,
   queryToFilterData,
 } from '~/utils/searchQueryTransform'
-import { ALL_MEDIA, AUDIO, IMAGE, supportedMediaTypes } from '~/constants/media'
+import {
+  ALL_MEDIA,
+  AUDIO,
+  IMAGE,
+  VIDEO,
+  supportedMediaTypes,
+} from '~/constants/media'
 
-const mediaFilterKeys = {
+export const mediaFilterKeys = {
   image: [
     'licenses',
     'licenseTypes',
@@ -37,6 +43,7 @@ const mediaFilterKeys = {
     'searchBy',
     'mature',
   ],
+  video: ['licenseTypes'],
   all: ['licenses', 'licenseTypes', 'searchBy', 'mature'],
 }
 const mediaSpecificFilters = {
@@ -48,19 +55,9 @@ const mediaSpecificFilters = {
     'imageProviders',
   ],
   audio: ['audioCategories', 'audioExtensions', 'durations', 'audioProviders'],
+  video: [],
 }
 
-const IMAGE_FILTERS = [
-  'licenses',
-  'licenseTypes',
-  'categories',
-  'extensions',
-  'aspectRatios',
-  'sizes',
-  'providers',
-  'searchBy',
-  'mature',
-]
 export const filterData = {
   licenses: [
     { code: 'cc0', name: 'filters.licenses.cc0', checked: false },
@@ -182,7 +179,7 @@ const getters = {
    */
   appliedFilterTags: (state) => {
     let appliedFilters = []
-    const filterKeys = [...mediaFilterKeys[state.searchType]]
+    const filterKeys = mediaFilterKeys[state.searchType]
     filterKeys.forEach((filterType) => {
       if (filterType !== 'mature') {
         const newFilters = state.filters[filterType]
@@ -212,13 +209,19 @@ const getters = {
   },
   audioFiltersForDisplay: (state) => {
     return getMediaTypeFilters(state, {
-      mediaType: 'audio',
+      mediaType: AUDIO,
       includeMature: false,
     })
   },
   imageFiltersForDisplay: (state) => {
     return getMediaTypeFilters(state, {
       mediaType: IMAGE,
+      includeMature: false,
+    })
+  },
+  videoFiltersForDisplay: (state) => {
+    return getMediaTypeFilters(state, {
+      mediaType: VIDEO,
       includeMature: false,
     })
   },
@@ -244,9 +247,12 @@ function setQuery(state) {
 }
 
 function getMediaTypeFilters(state, { mediaType, includeMature = false }) {
-  let filterKeys = [...mediaFilterKeys[mediaType]]
+  // eslint-disable-next-line no-debugger
+  debugger
+
+  let filterKeys = mediaFilterKeys[mediaType]
   if (!includeMature) {
-    filterKeys.splice(filterKeys.indexOf('mature'), 1)
+    filterKeys = filterKeys.filter((filterKey) => filterKey !== 'mature')
   }
   const mediaTypeFilters = {}
   filterKeys.forEach((filterKey) => {

--- a/src/utils/getLegacySourceUrl.js
+++ b/src/utils/getLegacySourceUrl.js
@@ -175,7 +175,7 @@ export const legacySourceMap = {
 /**
  * getLegacySourceUrl
  *
- * Return a valid url of search results for the provided meta search type (currently audio or video)
+ * Return a valid url of search results for the provided meta search type
  * @param {('image'|'audio'|'video')} type The type of media our meta search is for
  *
  *  */

--- a/src/utils/searchQueryTransform.js
+++ b/src/utils/searchQueryTransform.js
@@ -18,6 +18,7 @@ const filterPropertyMappings = {
   imageProviders: 'source',
   searchBy: 'searchBy',
 }
+// @TODO Can we import this from mediaFilterKeys in `openverse-frontend/src/store-modules/filter-store.js` somehow?
 const mediaFilters = {
   all: ['licenses', 'licenseTypes', 'searchBy'],
   image: [
@@ -28,6 +29,7 @@ const mediaFilters = {
     'imageProviders',
   ],
   audio: ['audioCategories', 'audioExtensions', 'durations', 'audioProviders'],
+  video: ['licenseTypes'],
 }
 // {
 //   license: 'cc0,pdm,by,by-sa,by-nc,by-nd,by-nc-sa,by-nc-nd',


### PR DESCRIPTION
Related to #105, builds on work in #117

This PR adds the correctly-displayed filters for video, as a way of testing the new filter style PR. 
I also removed some unnecessary spreads, and fixed a bug in the approach for removing the 'mature' filter in the `getMediaTypeFilters` function, which was incorrectly removing an array item if the mature filter wasn't present.