### PR TITLE
User settable audio track progress

### DIFF
--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="waveform"
-    class="waveform bg-dark-charcoal-04 rounded-sm"
+    class="waveform bg-dark-charcoal-04"
     @click="setProgress"
     @mousemove="setPreviewProgress"
     @mouseleave="clearPreviewProgress"

--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="waveform bg-dark-charcoal-04">
+  <div ref="waveform" class="waveform bg-dark-charcoal-04" @click="setProgress">
     <svg
       class="w-full h-full"
       xmlns="http://www.w3.org/2000/svg"
@@ -51,19 +51,16 @@ export default {
       default: () => Array.from({ length: 100 }, () => Math.random()),
       validator: (val) => val.every((item) => item >= 0 && item <= 1),
     },
-    /**
-     * the percentage of the graph that has been played; This represents the
-     * seekbar of the audio player.
-     */
-    percentage: {
-      type: Number,
-      validator: (val) => val >= 0 && val <= 100,
-      default: 0,
-    },
   },
   data: () => ({
     barWidth: 2, // px
     barGap: 2, // px
+
+    /**
+     * the percentage of the graph that has been played; This represents the
+     * seekbar of the audio player. A number from 1-100.
+     */
+    percentage: 0,
 
     waveformWidth: 100, // dummy start value
     observer: null, // ResizeObserver
@@ -110,6 +107,11 @@ export default {
     },
     updateWaveformWidth() {
       this.waveformWidth = this.$el.clientWidth
+    },
+    setProgress(event) {
+      const startPosition = this.$refs.waveform.getBoundingClientRect().left
+      const newPosition = event.clientX
+      this.percentage = (newPosition - startPosition) / this.waveformWidth
     },
   },
 }

--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -146,7 +146,6 @@ export default {
     },
     clearPreviewProgress() {
       this.previewPercentage = 0
-      console.log('mouseleave!')
     },
   },
 }

--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -1,9 +1,10 @@
 <template>
   <div
     ref="waveform"
-    class="waveform bg-dark-charcoal-04"
+    class="waveform bg-dark-charcoal-04 rounded-sm"
     @click="setProgress"
     @mousemove="setPreviewProgress"
+    @mouseleave="clearPreviewProgress"
   >
     <svg
       class="w-full h-full"
@@ -142,6 +143,10 @@ export default {
     },
     setPreviewProgress(event) {
       this.previewPercentage = this.getPosition(event)
+    },
+    clearPreviewProgress() {
+      this.previewPercentage = 0
+      console.log('mouseleave!')
     },
   },
 }

--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -1,5 +1,10 @@
 <template>
-  <div ref="waveform" class="waveform bg-dark-charcoal-04" @click="setProgress">
+  <div
+    ref="waveform"
+    class="waveform bg-dark-charcoal-04"
+    @click="setProgress"
+    @mousemove="setPreviewProgress"
+  >
     <svg
       class="w-full h-full"
       xmlns="http://www.w3.org/2000/svg"
@@ -14,11 +19,18 @@
         :height="tallestPeak"
       />
       <rect
+        fill="none"
+        x="0"
+        y="0"
+        :width="previewBarWidth"
+        :height="tallestPeak"
+      />
+      <rect
         v-for="(peak, index) in normalizedPeaks"
         :key="index"
         class="transform origin-bottom"
         :class="[
-          spaceBefore(index) < progressBarWidth
+          spaceBefore(index) < widestWidth
             ? 'fill-black'
             : 'fill-dark-charcoal-20',
         ]"
@@ -61,6 +73,10 @@ export default {
      * seekbar of the audio player. A number from 1-100.
      */
     percentage: 0,
+    /**
+     * the position of the graph that the user is hovering over.
+     */
+    previewPercentage: 0,
 
     waveformWidth: 100, // dummy start value
     observer: null, // ResizeObserver
@@ -89,6 +105,14 @@ export default {
     progressBarWidth() {
       return this.waveformWidth * this.percentage
     },
+    previewBarWidth() {
+      return this.waveformWidth * this.previewPercentage
+    },
+    widestWidth() {
+      return this.previewBarWidth > this.progressBarWidth
+        ? this.previewBarWidth
+        : this.progressBarWidth
+    },
   },
   async mounted() {
     this.updateWaveformWidth()
@@ -108,10 +132,16 @@ export default {
     updateWaveformWidth() {
       this.waveformWidth = this.$el.clientWidth
     },
-    setProgress(event) {
+    getPosition(event) {
       const startPosition = this.$refs.waveform.getBoundingClientRect().left
       const newPosition = event.clientX
-      this.percentage = (newPosition - startPosition) / this.waveformWidth
+      return (newPosition - startPosition) / this.waveformWidth
+    },
+    setProgress(event) {
+      this.percentage = this.getPosition(event)
+    },
+    setPreviewProgress(event) {
+      this.previewPercentage = this.getPosition(event)
     },
   },
 }


### PR DESCRIPTION
Related to #127 

Set the waveform progress on user click + hover of the waveform. so excited you started this work!

We probably want to lift up some of the state here and make waveform "dumb". It would accept the current progress, the 'preview' progress (the user hover %), and of course the waveform data, and emit events on user hover + click.

then the actual state would live in some sort of `AudioPlayer` parent component, I'd think.

![CleanShot 2021-08-14 at 07 20 07](https://user-images.githubusercontent.com/6351754/129444736-e950d0ee-ab61-4b45-8b29-e392eb12e44d.gif)

or we could do it this way. either has its pros/cons