### PR TITLE
Unify filter category names for different media types

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -349,7 +349,7 @@
       "ogg": "OGGs",
       "flac": "FLACs"
     },
-    "extensions": {
+    "image-extensions": {
       "title": "File Type",
       "jpg": "JPEGs",
       "png": "PNGs",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -337,7 +337,7 @@
       "sound-effects": "Sound Effects",
       "podcast": "Podcast"
     },
-    "categories": {
+    "image-categories": {
       "title": "Image Type",
       "photograph": "Photographs",
       "illustration": "Illustrations",

--- a/src/store-modules/filter-store.js
+++ b/src/store-modules/filter-store.js
@@ -28,7 +28,7 @@ export const mediaFilterKeys = {
   image: [
     'licenses',
     'licenseTypes',
-    'categories',
+    'imageCategories',
     'imageExtensions',
     'aspectRatios',
     'sizes',
@@ -52,7 +52,7 @@ export const mediaFilterKeys = {
 export const mediaSpecificFilters = {
   all: ['licenses', 'licenseTypes', 'searchBy', 'mature'],
   image: [
-    'categories',
+    'imageCategories',
     'imageExtensions',
     'aspectRatios',
     'sizes',
@@ -102,20 +102,20 @@ export const filterData = {
       checked: false,
     },
   ],
-  categories: [
+  imageCategories: [
     {
       code: 'photograph',
-      name: 'filters.categories.photograph',
+      name: 'filters.image-categories.photograph',
       checked: false,
     },
     {
       code: 'illustration',
-      name: 'filters.categories.illustration',
+      name: 'filters.image-categories.illustration',
       checked: false,
     },
     {
       code: 'digitized_artwork',
-      name: 'filters.categories.digitized-artwork',
+      name: 'filters.image-categories.digitized-artwork',
       checked: false,
     },
   ],

--- a/src/store-modules/filter-store.js
+++ b/src/store-modules/filter-store.js
@@ -29,7 +29,7 @@ export const mediaFilterKeys = {
     'licenses',
     'licenseTypes',
     'categories',
-    'extensions',
+    'imageExtensions',
     'aspectRatios',
     'sizes',
     'imageProviders',
@@ -53,7 +53,7 @@ export const mediaSpecificFilters = {
   all: ['licenses', 'licenseTypes', 'searchBy', 'mature'],
   image: [
     'categories',
-    'extensions',
+    'imageExtensions',
     'aspectRatios',
     'sizes',
     'imageProviders',
@@ -124,11 +124,11 @@ export const filterData = {
     { code: 'ogg', name: 'filters.audio-extensions.ogg', checked: false },
     { code: 'flac', name: 'filters.audio-extensions.flac', checked: false },
   ],
-  extensions: [
-    { code: 'jpg', name: 'filters.extensions.jpg', checked: false },
-    { code: 'png', name: 'filters.extensions.png', checked: false },
-    { code: 'gif', name: 'filters.extensions.gif', checked: false },
-    { code: 'svg', name: 'filters.extensions.svg', checked: false },
+  imageExtensions: [
+    { code: 'jpg', name: 'filters.image-extensions.jpg', checked: false },
+    { code: 'png', name: 'filters.image-extensions.png', checked: false },
+    { code: 'gif', name: 'filters.image-extensions.gif', checked: false },
+    { code: 'svg', name: 'filters.image-extensions.svg', checked: false },
   ],
   aspectRatios: [
     { code: 'tall', name: 'filters.aspect-ratios.tall', checked: false },
@@ -271,7 +271,9 @@ function replaceFilters(state, filterData) {
         const idx = state.filters[filterType].findIndex(
           (p) => p.code === provider.code
         )
-        state.filters[filterType][idx].checked = provider.checked
+        if (idx > -1) {
+          state.filters[filterType][idx].checked = provider.checked
+        }
       })
     } else {
       state.filters[filterType] = filterData[filterType]

--- a/src/utils/searchQueryTransform.js
+++ b/src/utils/searchQueryTransform.js
@@ -10,13 +10,14 @@ const filterPropertyMappings = {
   audioCategories: 'categories',
   categories: 'categories',
   audioExtensions: 'extension',
-  extensions: 'extension',
+  imageExtensions: 'extension',
   durations: 'duration',
   aspectRatios: 'aspect_ratio',
   sizes: 'size',
   audioProviders: 'source',
   imageProviders: 'source',
   searchBy: 'searchBy',
+  mature: 'mature',
 }
 
 const getMediaFilterTypes = (searchType) => {
@@ -135,7 +136,7 @@ export const queryToFilterData = (queryString) => {
               code: provider,
               checked: true,
             }))
-    } else {
+    } else if (filterDataKey !== 'mature') {
       const queryDataKey = filterPropertyMappings[filterDataKey]
       parseQueryString(queryString, queryDataKey, filterDataKey, filters)
     }

--- a/src/utils/searchQueryTransform.js
+++ b/src/utils/searchQueryTransform.js
@@ -8,7 +8,7 @@ const filterPropertyMappings = {
   licenses: 'license',
   licenseTypes: 'license_type',
   audioCategories: 'categories',
-  categories: 'categories',
+  imageCategories: 'categories',
   audioExtensions: 'extension',
   imageExtensions: 'extension',
   durations: 'duration',
@@ -28,8 +28,8 @@ const getMediaFilterTypes = (searchType) => {
 
 // {
 //   license: 'cc0,pdm,by,by-sa,by-nc,by-nd,by-nc-sa,by-nc-nd',
-//   categories: 'photograph,illustration,digitized_artwork',
-//   extension: 'jpg,png',
+//   imageCategories: 'photograph,illustration,digitized_artwork',
+//   imageExtension: 'jpg,png',
 //   aspect_ratio: 'square',
 //   size: 'small',
 //   source: 'animaldiversity,bio_diversity,brooklynmuseum,CAPL,clevelandmuseum,deviantart'

--- a/src/utils/searchQueryTransform.js
+++ b/src/utils/searchQueryTransform.js
@@ -118,24 +118,67 @@ export const queryStringToSearchType = (queryString) => {
 }
 
 /**
+ * `source`, `extensions` and `categories` API parameters correspond
+ * to different filters in different media types:
+ * `source` - audioProviders/imageProviders
+ * `extensions` - audioExtensions/imageExtensions
+ * `categories` - audioCategories/imageCategories
+ * This function sets only filters that are possible for current
+ * media type. Eg., for queryString `search/audio?extensions=ogg`
+ * the `audioExtensions.ogg.checked` is set to true,
+ * but for `search/images?extensions=ogg`, the extensions query parameter
+ * is discarded, because `ogg` is not a valid extension for images.
+ * @param filterParameter
+ * @param parameterFilters
+ * @return {*}
+ */
+const getMediaTypeApiFilters = (filterParameter, parameterFilters) => {
+  if (filterParameter !== '') {
+    const parameterValues = filterParameter.split(',')
+    parameterValues.forEach((parameter) => {
+      let existingParameterIdx = parameterFilters.findIndex(
+        (p) => p.code === parameter
+      )
+      if (existingParameterIdx > -1) {
+        parameterFilters[existingParameterIdx] = {
+          ...parameterFilters[existingParameterIdx],
+          checked: true,
+        }
+      }
+    })
+  }
+  return parameterFilters
+}
+
+/**
  * converts the browser filter query string into the internal filter store data format
  * @param {string} queryString browser filter query string
+ * @param {Object} defaultFilters default filters for testing purposes
  */
-export const queryToFilterData = (queryString) => {
-  const filters = clonedeep(filterData)
-  Object.keys(filterPropertyMappings).forEach((filterDataKey) => {
-    if (['audioProviders', 'imageProviders'].includes(filterDataKey)) {
-      const providerParameter = getParameterByName(
+export const queryToFilterData = (queryString, defaultFilters = null) => {
+  const filters = defaultFilters
+    ? clonedeep(defaultFilters)
+    : clonedeep(filterData)
+  const searchType = queryStringToSearchType(queryString)
+  const filterTypes = getMediaFilterTypes(searchType)
+  const differentFiltersWithSameApiParams = [
+    'audioProviders',
+    'imageProviders',
+    'audioExtensions',
+    'imageExtensions',
+    'audioCategories',
+    'imageCategories',
+  ]
+  filterTypes.forEach((filterDataKey) => {
+    if (differentFiltersWithSameApiParams.includes(filterDataKey)) {
+      const parameter = getParameterByName(
         filterPropertyMappings[filterDataKey],
         queryString
       )
-      filters[filterDataKey] =
-        providerParameter === ''
-          ? []
-          : providerParameter.split(',').map((provider) => ({
-              code: provider,
-              checked: true,
-            }))
+      filters[filterDataKey] = getMediaTypeApiFilters(
+        parameter,
+        filters[filterDataKey]
+      )
     } else if (filterDataKey !== 'mature') {
       const queryDataKey = filterPropertyMappings[filterDataKey]
       parseQueryString(queryString, queryDataKey, filterDataKey, filters)

--- a/test/unit/specs/store/filter-store.spec.js
+++ b/test/unit/specs/store/filter-store.spec.js
@@ -27,10 +27,12 @@ describe('Filter Store', () => {
       expect(defaultState.filters.categories).toEqual(filterData.categories)
     })
 
-    it('state contains extensions', () => {
+    it('state contains imageExtensions', () => {
       const defaultState = store.state
 
-      expect(defaultState.filters.extensions).toEqual(filterData.extensions)
+      expect(defaultState.filters.imageExtensions).toEqual(
+        filterData.imageExtensions
+      )
     })
 
     it('state contains empty providers list', () => {
@@ -106,12 +108,17 @@ describe('Filter Store', () => {
       )
     })
 
-    it('SET_FILTER updates extensions state', () => {
-      mutations[SET_FILTER](state, { filterType: 'extensions', codeIdx: 0 })
+    it('SET_FILTER updates imageExtensions state', () => {
+      mutations[SET_FILTER](state, {
+        filterType: 'imageExtensions',
+        codeIdx: 0,
+      })
 
-      expect(state.filters.extensions[0].checked).toBeTruthy()
+      expect(state.filters.imageExtensions[0].checked).toBeTruthy()
       expect(state.query).toEqual(
-        expect.objectContaining({ extension: state.filters.extensions[0].code })
+        expect.objectContaining({
+          extension: state.filters.imageExtensions[0].code,
+        })
       )
     })
 

--- a/test/unit/specs/store/filter-store.spec.js
+++ b/test/unit/specs/store/filter-store.spec.js
@@ -24,7 +24,9 @@ describe('Filter Store', () => {
     it('state contains image types', () => {
       const defaultState = store.state
 
-      expect(defaultState.filters.categories).toEqual(filterData.categories)
+      expect(defaultState.filters.imageCategories).toEqual(
+        filterData.imageCategories
+      )
     })
 
     it('state contains imageExtensions', () => {
@@ -123,12 +125,15 @@ describe('Filter Store', () => {
     })
 
     it('SET_FILTER updates image types state', () => {
-      mutations[SET_FILTER](state, { filterType: 'categories', codeIdx: 0 })
+      mutations[SET_FILTER](state, {
+        filterType: 'imageCategories',
+        codeIdx: 0,
+      })
 
-      expect(state.filters.categories[0].checked).toBeTruthy()
+      expect(state.filters.imageCategories[0].checked).toBeTruthy()
       expect(state.query).toEqual(
         expect.objectContaining({
-          categories: state.filters.categories[0].code,
+          categories: state.filters.imageCategories[0].code,
         })
       )
     })

--- a/test/unit/specs/utils/searchQueryTransform.spec.js
+++ b/test/unit/specs/utils/searchQueryTransform.spec.js
@@ -47,20 +47,20 @@ describe('searchQueryTransform', () => {
           checked: false,
         },
       ],
-      categories: [
+      imageCategories: [
         {
           code: 'photograph',
-          name: 'filters.categories.photograph',
+          name: 'filters.image-categories.photograph',
           checked: true,
         },
         {
           code: 'illustration',
-          name: 'filters.categories.illustration',
+          name: 'filters.image-categories.illustration',
           checked: false,
         },
         {
           code: 'digitized_artwork',
-          name: 'filters.categories.digitized-artwork',
+          name: 'filters.image-categories.digitized-artwork',
           checked: false,
         },
       ],
@@ -138,20 +138,20 @@ describe('searchQueryTransform', () => {
           checked: false,
         },
       ],
-      categories: [
+      imageCategories: [
         {
           code: 'photograph',
-          name: 'filters.categories.photograph',
+          name: 'filters.image-categories.photograph',
           checked: true,
         },
         {
           code: 'illustration',
-          name: 'filters.categories.illustration',
+          name: 'filters.image-categories.illustration',
           checked: false,
         },
         {
           code: 'digitized_artwork',
-          name: 'filters.categories.digitized-artwork',
+          name: 'filters.image-categories.digitized-artwork',
           checked: false,
         },
       ],
@@ -252,7 +252,7 @@ describe('searchQueryTransform', () => {
     expect(result).toEqual(filters) // toEqual checks for value equality
   })
   it('queryStringToQueryData', () => {
-    const filters = {
+    const expectedQueryData = {
       license: 'cc0',
       license_type: 'commercial',
       categories: 'photograph',
@@ -267,6 +267,6 @@ describe('searchQueryTransform', () => {
     const queryString =
       'http://localhost:8443/search/image?q=cat&license=cc0&license_type=commercial&categories=photograph&extension=jpg&aspect_ratio=tall&size=medium&source=animaldiversity,brooklynmuseum&searchBy=creator&mature=true'
     const result = queryStringToQueryData(queryString)
-    expect(result).toEqual(filters)
+    expect(result).toEqual(expectedQueryData)
   })
 })

--- a/test/unit/specs/utils/searchQueryTransform.spec.js
+++ b/test/unit/specs/utils/searchQueryTransform.spec.js
@@ -64,11 +64,11 @@ describe('searchQueryTransform', () => {
           checked: false,
         },
       ],
-      extensions: [
-        { code: 'jpg', name: 'filters.extensions.jpg', checked: true },
-        { code: 'png', name: 'filters.extensions.png', checked: false },
-        { code: 'gif', name: 'filters.extensions.gif', checked: false },
-        { code: 'svg', name: 'filters.extensions.svg', checked: false },
+      imageExtensions: [
+        { code: 'jpg', name: 'filters.image-extensions.jpg', checked: true },
+        { code: 'png', name: 'filters.image-extensions.png', checked: false },
+        { code: 'gif', name: 'filters.image-extensions.gif', checked: false },
+        { code: 'svg', name: 'filters.image-extensions.svg', checked: false },
       ],
       aspectRatios: [
         { code: 'tall', name: 'filters.aspect-ratios.tall', checked: true },
@@ -172,11 +172,11 @@ describe('searchQueryTransform', () => {
           name: 'filters.durations.long',
         },
       ],
-      extensions: [
-        { code: 'jpg', name: 'filters.extensions.jpg', checked: true },
-        { code: 'png', name: 'filters.extensions.png', checked: false },
-        { code: 'gif', name: 'filters.extensions.gif', checked: false },
-        { code: 'svg', name: 'filters.extensions.svg', checked: false },
+      imageExtensions: [
+        { code: 'jpg', name: 'filters.image-extensions.jpg', checked: true },
+        { code: 'png', name: 'filters.image-extensions.png', checked: false },
+        { code: 'gif', name: 'filters.image-extensions.gif', checked: false },
+        { code: 'svg', name: 'filters.image-extensions.svg', checked: false },
       ],
       aspectRatios: [
         { code: 'tall', name: 'filters.aspect-ratios.tall', checked: true },

--- a/test/unit/specs/utils/searchQueryTransform.spec.js
+++ b/test/unit/specs/utils/searchQueryTransform.spec.js
@@ -1,3 +1,4 @@
+import clonedeep from 'lodash.clonedeep'
 import {
   filtersToQueryData,
   queryToFilterData,
@@ -114,7 +115,7 @@ describe('searchQueryTransform', () => {
     const result = queryToFilterData(query)
     expect(result).toEqual(filters) // toEqual checks for value equality
   })
-  it('queryToFilterData all filters', () => {
+  it('queryToFilterData all image filters', () => {
     const filters = {
       licenses: [
         { code: 'cc0', name: 'filters.licenses.cc0', checked: true },
@@ -162,7 +163,7 @@ describe('searchQueryTransform', () => {
           name: 'filters.durations.short',
         },
         {
-          checked: false,
+          checked: true,
           code: 'medium',
           name: 'filters.durations.medium',
         },
@@ -198,7 +199,7 @@ describe('searchQueryTransform', () => {
       ],
       audioCategories: [
         {
-          checked: false,
+          checked: true,
           code: 'music',
           name: 'filters.audio-categories.music',
         },
@@ -215,7 +216,7 @@ describe('searchQueryTransform', () => {
       ],
       audioExtensions: [
         {
-          checked: false,
+          checked: true,
           code: 'mp3',
           name: 'filters.audio-extensions.mp3',
         },
@@ -233,11 +234,11 @@ describe('searchQueryTransform', () => {
       audioProviders: [
         {
           checked: true,
-          code: 'animaldiversity',
+          code: 'jamendo',
         },
         {
           checked: true,
-          code: 'brooklynmuseum',
+          code: 'wikimedia',
         },
       ],
       searchBy: [
@@ -246,9 +247,13 @@ describe('searchQueryTransform', () => {
       mature: true,
     }
     const queryString =
-      'http://localhost:8443/search/image?q=cat&license=cc0&license_type=commercial&categories=photograph&extension=jpg&aspect_ratio=tall&size=medium&source=animaldiversity,brooklynmuseum&searchBy=creator&mature=true'
-
-    const result = queryToFilterData(queryString)
+      'http://localhost:8443/search/audio?q=cat&license=cc0&license_type=commercial&categories=music&extension=mp3&duration=medium&source=jamendo,wikimedia&searchBy=creator&mature=true'
+    const testFilters = clonedeep(filters)
+    testFilters.audioProviders = [
+      { code: 'jamendo', checked: true },
+      { code: 'wikimedia', checked: true },
+    ]
+    const result = queryToFilterData(queryString, testFilters)
     expect(result).toEqual(filters) // toEqual checks for value equality
   })
   it('queryStringToQueryData', () => {


### PR DESCRIPTION
Continues work on #117

## Description
<!-- Concisely describe what the pull request does. -->
Some API parameters like 'categories', 'extensions' and 'source' have the same names for different media types. This PR renames local image parameters to match the audio filter names (i.e. `categories` becomes `imageCategories`, similar to `audioCategories`). 
Also, before sending a query to the API, this PR filters values for the mentioned parameters to make sure they are applicable for the media type. For example, if we search for images, we should only use `jpeg`, not `mp3`, value `extensions` parameter from the `search/images/categories=jpeg,mp3` queryString.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
