### PR TITLE
Improve result count strings for i18n

### DIFF
--- a/src/components/SearchGridManualLoad.vue
+++ b/src/components/SearchGridManualLoad.vue
@@ -106,7 +106,7 @@ export default {
         ? this.$store.state.imagesCount
         : this.imagesCount
       return count >= 10000
-        ? this.$tc('browse-page.image-result-count', count, {
+        ? this.$tc('browse-page.image-result-count-more', count, {
             localeCount: count.toLocaleString(this.$i18n.locale),
           })
         : this.$tc('browse-page.image-result-count', count, {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -376,10 +376,12 @@
     "show": "Show results"
   },
   "browse-page": {
-    "audio-result-count": "no audios | {localeCount} audio | {localeCount} audios",
-    "image-result-count": "no images | {localeCount} image | {localeCount} images",
-    "result-count": "{count} images",
-    "result-count-more": "Over {count} images",
+    "all-result-count": "no results|{localeCount} result|{localeCount} results",
+    "audio-result-count": "no audio results|{localeCount} audio result|{localeCount} audio results",
+    "image-result-count": "no image results|{localeCount} image result|{localeCount} image results",
+    "all-result-count-more": "Over {localeCount} results",
+    "audio-result-count-more": "Over {localeCount} audio results",
+    "image-result-count-more": "Over {localeCount} image results",
     "no-more": "No more images :(",
     "load": "Load more results",
     "error": "Error fetching images:",

--- a/src/store-modules/filter-store.js
+++ b/src/store-modules/filter-store.js
@@ -165,7 +165,6 @@ const getters = {
         })
       }
     })
-    console.log('all image filters: ', allImageFilters)
     return allImageFilters
   },
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #130 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
This PR improves wording for displaying the number of results on the search page, and the handling of i18n with it.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
Previously, the result count was displayed as "1 image", "N images" or "Over N images" (for more than 10,000 results).

This PR uses the following wording, depending on the result count:

Fewer than 10,000 results: 1 result / N [ image | audio ] results 
More than 10,000 results: Over N [ image| audio] results

To ensure correct word pluralization and correct number formatting in other languages, we need to pass the count to the vue-i18n both as a Number, and a localized string representation (eg. 11,500 for English, 11 500 for Russian, and ١١٬٥٠٠ for Arabic). 
When translating, we will need to ensure that all different pluralization variants are added.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
