### PR TITLE
Fix link to an old issue

### DIFF
--- a/src/utils/getLegacySourceUrl.js
+++ b/src/utils/getLegacySourceUrl.js
@@ -2,7 +2,7 @@ import buildUrl from 'build-url'
 
 /**
  * A mapping of each legacy source with its url builder functions for each content type.
- * Urls were based off of data found here: https://github.com/wordpress/openverse-frontend/issues/315
+ * Urls were based off of data found here: https://github.com/creativecommons/cccatalog-frontend/issues/315
  */
 export const legacySourceMap = {
   ccMixter: {


### PR DESCRIPTION
Tiny change: an issue in the `creativecommons/cccatalog-frontend` was mistakenly changed to a non-existent issue in the `WordPress/openverse-frontend` repository. Changing it back. I scanned the repository, and it doesn't seem to have any other changes like this.