### PR TITLE
Audio track + waveform A11y

### DIFF
--- a/src/components/AudioTrack/AudioTrack.vue
+++ b/src/components/AudioTrack/AudioTrack.vue
@@ -17,7 +17,7 @@
       {{ audio.category }}
     </div>
 
-    <div class="flex flex-row gap-2">
+    <div class="interactive-section flex flex-row gap-2">
       <PlayPause
         v-if="isCompact"
         class="flex-shrink-0"
@@ -26,7 +26,6 @@
         @toggle="setPlayerState"
       />
       <div
-        class="waveform-section"
         @keypress.enter="setPlayerState(!isPlaying)"
         @keypress.space="setPlayerState(!isPlaying)"
       >

--- a/src/components/AudioTrack/AudioTrack.vue
+++ b/src/components/AudioTrack/AudioTrack.vue
@@ -4,7 +4,11 @@
     aria-label="$t('audio-track.aria-label')"
     role="region"
   >
-    <div class="waveform-section">
+    <div
+      class="waveform-section"
+      @keypress.enter="setPlayerState(!isPlaying)"
+      @keypress.space="setPlayerState(!isPlaying)"
+    >
       <Waveform
         class="h-30 w-full"
         :is-ready="isReady"

--- a/src/components/AudioTrack/AudioTrack.vue
+++ b/src/components/AudioTrack/AudioTrack.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="audio-track">
-    <div class="waveform-section">
+  <div class="audio-track" aria-label="Audio Player" role="region">
+    <div class="waveform-section bg-dark-charcoal-04">
       <Waveform
         class="h-30 w-full"
         :is-ready="isReady"
@@ -8,10 +8,13 @@
         :duration="duration"
         :peaks="audio.peaks"
         @seeked="setPosition"
+        @jumpSeekedForward="jumpPositionForward"
+        @jumpSeekedBackward="jumpPositionBackward"
       />
     </div>
     <div class="info-section flex flex-row gap-6">
       <PlayPause
+        :aria-controls="ariaIdentifier"
         class="self-start flex-shrink-0"
         :is-playing="isPlaying"
         :disabled="!isReady"
@@ -39,6 +42,7 @@
     <!-- eslint-disable vuejs-accessibility/media-has-caption -->
     <audio
       v-show="false"
+      :id="ariaIdentifier"
       ref="audio"
       controls
       :src="audio.url"
@@ -78,6 +82,8 @@ export default {
     player: null, // HTMLAudioElement
     currentTime: 0,
     duration: 0,
+    /** Amount in seconds to jump seek **/
+    seekJumpDuration: 15,
 
     isReady: false,
     isPlaying: false,
@@ -93,6 +99,13 @@ export default {
       const date = new Date(0)
       date.setSeconds(seconds)
       return date.toISOString().substr(11, 8).replace(/^00:/, '')
+    },
+    /**
+     * A unique string to represent the audio player in aria properties
+     * @returns {string} the id of the audio file prefixed with 'audio-'
+     */
+    ariaIdentifier() {
+      return `audio-${this.audio.id}`
     },
   },
   mounted() {
@@ -119,6 +132,14 @@ export default {
         this.player.currentTime = this.player.duration * percentage
         this.updateTime()
       }
+    },
+    jumpPositionForward() {
+      this.player.currentTime = this.player.currentTime + this.seekJumpDuration
+      this.updateTime()
+    },
+    jumpPositionBackward() {
+      this.player.currentTime = this.player.currentTime - this.seekJumpDuration
+      this.updateTime()
     },
     async setPlayerState(isPlaying) {
       if (isPlaying) {

--- a/src/components/AudioTrack/AudioTrack.vue
+++ b/src/components/AudioTrack/AudioTrack.vue
@@ -1,6 +1,10 @@
 <template>
-  <div class="audio-track" aria-label="Audio Player" role="region">
-    <div class="waveform-section bg-dark-charcoal-04">
+  <div
+    class="audio-track"
+    aria-label="$t('audio-track.aria-label')"
+    role="region"
+  >
+    <div class="waveform-section">
       <Waveform
         class="h-30 w-full"
         :is-ready="isReady"
@@ -8,13 +12,11 @@
         :duration="duration"
         :peaks="audio.peaks"
         @seeked="setPosition"
-        @jumpSeekedForward="jumpPositionForward"
-        @jumpSeekedBackward="jumpPositionBackward"
       />
     </div>
     <div class="info-section flex flex-row gap-6">
       <PlayPause
-        :aria-controls="ariaIdentifier"
+        :aria-controls="audio.id"
         class="self-start flex-shrink-0"
         :is-playing="isPlaying"
         :disabled="!isReady"
@@ -42,7 +44,7 @@
     <!-- eslint-disable vuejs-accessibility/media-has-caption -->
     <audio
       v-show="false"
-      :id="ariaIdentifier"
+      :id="audio.id"
       ref="audio"
       controls
       :src="audio.url"
@@ -82,9 +84,6 @@ export default {
     player: null, // HTMLAudioElement
     currentTime: 0,
     duration: 0,
-    /** Amount in seconds to jump seek **/
-    seekJumpDuration: 15,
-
     isReady: false,
     isPlaying: false,
   }),
@@ -99,13 +98,6 @@ export default {
       const date = new Date(0)
       date.setSeconds(seconds)
       return date.toISOString().substr(11, 8).replace(/^00:/, '')
-    },
-    /**
-     * A unique string to represent the audio player in aria properties
-     * @returns {string} the id of the audio file prefixed with 'audio-'
-     */
-    ariaIdentifier() {
-      return `audio-${this.audio.id}`
     },
   },
   mounted() {
@@ -132,14 +124,6 @@ export default {
         this.player.currentTime = this.player.duration * percentage
         this.updateTime()
       }
-    },
-    jumpPositionForward() {
-      this.player.currentTime = this.player.currentTime + this.seekJumpDuration
-      this.updateTime()
-    },
-    jumpPositionBackward() {
-      this.player.currentTime = this.player.currentTime - this.seekJumpDuration
-      this.updateTime()
     },
     async setPlayerState(isPlaying) {
       if (isPlaying) {

--- a/src/components/AudioTrack/PlayPause.vue
+++ b/src/components/AudioTrack/PlayPause.vue
@@ -1,12 +1,16 @@
 <template>
   <button
+    type="button"
     class="bg-dark-charcoal h-20 w-20 flex items-center justify-center disabled:opacity-70"
     @click="toggle"
   >
+    <span class="sr-only">{{ label }}</span>
     <svg
       class="text-white h-8 w-8"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
     >
       <use v-if="isPlaying" :href="`${icons.pause}#icon`" />
       <use v-else :href="`${icons.play}#icon`" />
@@ -38,6 +42,11 @@ export default {
       pause: pauseIcon,
     },
   }),
+  computed: {
+    label() {
+      return this.$t(this.isPlaying ? 'play-pause.pause' : 'play-pause.play')
+    },
+  },
   methods: {
     toggle() {
       this.$emit('toggle', !this.isPlaying)

--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -2,15 +2,25 @@
   <div
     ref="waveform"
     class="waveform relative bg-dark-charcoal-04 overflow-x-hidden"
+    tabIndex="0"
+    role="slider"
+    aria-label="audio seek bar"
+    aria-orientation="horizontal"
+    aria-valuemin="0"
+    :aria-valuemax="duration"
+    :aria-valuenow="currentTime"
+    :aria-valuetext="`${currentTime / 60} seconds`"
+    @keydown.arrow-left="seekJumpBackward"
+    @keydown.arrow-right="seekJumpForward"
+    @mousemove="setSeekProgress"
+    @mouseleave="clearSeekProgress"
+    @click="seek"
   >
     <svg
       class="w-full h-full"
       xmlns="http://www.w3.org/2000/svg"
       :viewBox="viewBox"
       preserveAspectRatio="none"
-      @mousemove="setSeekProgress"
-      @mouseleave="clearSeekProgress"
-      @click="seek"
     >
       <rect
         class="fill-yellow"
@@ -202,6 +212,12 @@ export default {
     },
     seek(event) {
       this.$emit('seeked', this.getPositionPercentage(event))
+    },
+    seekJumpBackward() {
+      this.$emit('jumpSeekedBackward')
+    },
+    seekJumpForward() {
+      this.$emit('jumpSeekedForward')
     },
   },
 }

--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -9,7 +9,7 @@
     aria-valuemin="0"
     :aria-valuemax="duration"
     :aria-valuenow="currentTime"
-    :aria-valuetext="`${currentTime / 60} seconds`"
+    :aria-valuetext="`${timeFmt(currentTime)} seconds`"
     @keydown.arrow-left="seekJumpBackward"
     @keydown.arrow-right="seekJumpForward"
     @mousemove="setSeekProgress"

--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -4,7 +4,7 @@
     class="waveform relative bg-dark-charcoal-04 overflow-x-hidden"
     tabIndex="0"
     role="slider"
-    aria-label="$t('waveform.label')"
+    :aria-label="$t('waveform.label')"
     aria-orientation="horizontal"
     aria-valuemin="0"
     :aria-valuemax="duration"

--- a/src/components/AudioTrack/Waveform.vue
+++ b/src/components/AudioTrack/Waveform.vue
@@ -214,9 +214,11 @@ export default {
       this.$emit('seeked', this.getPositionPercentage(event))
     },
     seekJumpBackward() {
+      this.clearSeekProgress()
       this.$emit('jumpSeekedBackward')
     },
     seekJumpForward() {
+      this.clearSeekProgress()
       this.$emit('jumpSeekedForward')
     },
   },

--- a/src/components/AudioTrack/meta/AudioTrack.stories.mdx
+++ b/src/components/AudioTrack/meta/AudioTrack.stories.mdx
@@ -28,6 +28,7 @@ export const Template = (args, { argTypes }) => ({
     name="Default"
     args={{
       audio: {
+        id: 12345432,
         title: 'Eine kleine Nachtmusik',
         url:
           'https://upload.wikimedia.org/wikipedia/commons/2/24/Mozart_-_Eine_kleine_Nachtmusik_-_1._Allegro.ogg',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -570,10 +570,13 @@
     "edge": "Edge"
   },
   "waveform": {
-    "loading": "Loading..."
+    "label": "Audio seek bar",
+    "loading": "Loading...",
+    "current-time": "{time} seconds"
   },
   "audio-track": {
-    "title": "{title} by {creator}"
+    "title": "{title} by {creator}",
+    "aria-label": "Audio Player"
   },
   "play-pause": {
     "play": "Play",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -574,5 +574,9 @@
   },
   "audio-track": {
     "title": "{title} by {creator}"
+  },
+  "play-pause": {
+    "play": "Play",
+    "pause": "Pause"
   }
 }

--- a/src/utils/searchQueryTransform.js
+++ b/src/utils/searchQueryTransform.js
@@ -17,7 +17,7 @@ const filterPropertyMappings = {
   audioProviders: 'source',
   imageProviders: 'source',
   searchBy: 'searchBy',
-  mature: 'mature',zz
+  mature: 'mature',
 }
 
 const getMediaFilterTypes = (searchType) => {

--- a/src/utils/searchQueryTransform.js
+++ b/src/utils/searchQueryTransform.js
@@ -17,7 +17,7 @@ const filterPropertyMappings = {
   audioProviders: 'source',
   imageProviders: 'source',
   searchBy: 'searchBy',
-  mature: 'mature',
+  mature: 'mature',zz
 }
 
 const getMediaFilterTypes = (searchType) => {


### PR DESCRIPTION
## Changes

- Adds the proper ARIA roles to the waveform to make it function as a slider
- Improves play/pause button a11y with a text label and hiding the icon from screen readers
- Adds left + right arrow key seeking + shift key modification (1s seek w/o modifier, 15s seek w/ shift)
- Adds play/pause toggling to the waveform
	- I logically wanted to apply this to the entire Audio Track, but doing so means double events on the play/pause button and makes pressing enter on the track title to navigate to the single view toggle the player state

## Demo vid

https://user-images.githubusercontent.com/6351754/130304731-40d18745-7fa9-4a42-9242-450c06346820.mp4

## Prior art

- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role
- https://deezer.io/towards-an-accessible-player-b38431bb5721
- https://blog.atrera.com/javascript/accessibility/2019/06/28/create-a-custom-audio-player-with-accessibility.html
- https://sarahmhigley.com/writing/playing-with-state/