### PR TITLE
Implement alternative approach to accessibility in `AudioTrack`

### DIFF
--- a/src/components/AudioTrack/AudioTrack.vue
+++ b/src/components/AudioTrack/AudioTrack.vue
@@ -1,7 +1,8 @@
 <template>
-  <div class="audio-track">
+  <div class="audio-track relative">
     <div class="waveform-section bg-dark-charcoal-04">
       <Waveform
+        aria-hidden="true"
         class="h-30 w-full"
         :is-ready="isReady"
         :current-time="currentTime"
@@ -12,6 +13,7 @@
     </div>
     <div class="info-section flex flex-row">
       <PlayPause
+        aria-hidden="true"
         class="self-start flex-shrink-0"
         :is-playing="isPlaying"
         :disabled="!isReady"
@@ -38,8 +40,8 @@
 
     <!-- eslint-disable vuejs-accessibility/media-has-caption -->
     <audio
-      v-show="false"
       ref="audio"
+      class="absolute top-0 left-0 opacity-0 pointer-events-none"
       controls
       :src="audio.url"
       crossorigin="anonymous"
@@ -49,6 +51,7 @@
       "
       @play="setIsPlaying(true)"
       @pause="setIsPlaying(false)"
+      @timeupdate="syncTime()"
     />
     <!-- eslint-enable vuejs-accessibility/media-has-caption -->
   </div>


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
This PR takes an alternative approach to #133 for achieving accessibility in the track component. 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
The idea of this PR is to make the entire audio track component a purely-visual wrapper over the native `<audio>` element, thereby inheriting all accessibility features baked into it.

This is experimental but if successful, could prove to be less dev-intensive with the added benefit of familiarity for users accustomed to the native player.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
