### PR TITLE
Fix navbar keyboard accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "generate": "nuxt generate",
     "start": "nuxt start",
     "test": "jest",
+    "test:watch": "jest --watch",
     "test:unit": "jest",
     "test:e2e": "cypress open",
     "test:e2e:ci": "cypress run",

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -2,18 +2,21 @@
   <!-- Copied and modified from Vuetensils to match the existing bulma implementation -->
   <!-- https://github.com/AustinGil/vuetensils/blob/production/src/components/VDropdown/VDropdown.vue -->
   <div
-    :class="['navbar-item has-dropdown is-hoverable', classes.root]"
+    class="navbar-item has-dropdown is-hoverable"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
     @focus="isFocused = true"
     @blur="isFocused = false"
     @focusout="onFocusout"
   >
-    <a
+    <div
       :aria-expanded="!!isHovered || !!isFocused"
       aria-haspopup="true"
-      :class="['navbar-link is-arrowless', classes.trigger]"
-      href="#"
+      class="navbar-link is-arrowless"
+      role="button"
+      tabindex="0"
+      @keydown.enter="isFocused = !isFocused"
+      @keydown.space.prevent="isFocused = !isFocused"
       @click="isFocused = !isFocused"
       @focus="isFocused = true"
     >
@@ -21,7 +24,7 @@
         {{ text }}
         <i class="icon caret-down" />
       </slot>
-    </a>
+    </div>
 
     <div
       class="navbar-dropdown"
@@ -46,34 +49,11 @@ const Dropdown = {
   name: 'Dropdown',
   props: {
     /**
-     * The toggle button text.
+     * The trigger element text.
      */
     text: {
       type: String,
       default: '',
-    },
-    /**
-     * Where the content should be placed in relation to the button.
-     *
-     * Options: 'bottom', 'top'
-     */
-    position: {
-      type: String,
-      default: 'bottom',
-      validator(value) {
-        return ['top', 'bottom'].includes(value)
-      },
-    },
-    /**
-     * The transition name.
-     */
-    transition: {
-      type: String,
-      default: '',
-    },
-    classes: {
-      type: Object,
-      default: () => ({}),
     },
   },
   data: () => ({

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -90,11 +90,6 @@ export default Dropdown
 </script>
 
 <style lang="scss">
-.navbar-dropdown {
-  /* Override Bulma's hiding of the dropdown so that it is still focusable */
-  display: block;
-}
-
 .navbar-dropdown:not(.visible) {
   /* Accessible VisuallyHidden styles taken from @wordpress/components. Allows these components to be accessibly hidden from sight while still being focusable */
   clip: rect(1px, 1px, 1px, 1px);

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -1,0 +1,130 @@
+<template>
+  <!-- Copied and modified from Vuetensils to match the existing bulma implementation -->
+  <!-- https://github.com/AustinGil/vuetensils/blob/production/src/components/VDropdown/VDropdown.vue -->
+  <div
+    :class="['navbar-item has-dropdown is-hoverable', classes.root]"
+    @mouseenter="isHovered = true"
+    @mouseleave="isHovered = false"
+    @focus="isFocused = true"
+    @blur="isFocused = false"
+    @focusout="onFocusout"
+  >
+    <a
+      :aria-expanded="!!isHovered || !!isFocused"
+      aria-haspopup="true"
+      :class="['navbar-link is-arrowless', classes.trigger]"
+      href="#"
+      @click="isFocused = !isFocused"
+      @focus="isFocused = true"
+    >
+      <slot name="trigger">
+        {{ text }}
+        <i class="icon caret-down" />
+      </slot>
+    </a>
+
+    <div
+      class="navbar-dropdown"
+      :class="{ visible: !!isHovered || !!isFocused }"
+      role="menu"
+    >
+      <slot :onFocus="onFocus" />
+    </div>
+  </div>
+</template>
+
+<script>
+/**
+ * Mimics the behavior of the WordPress.org menubar. Creates an accessible focusable trigger element that
+ * when focused, opens an accessible dropdown menu.
+ *
+ * This does not fully follow the ARIA specification/recommendation for accessible dropdown in order to stay
+ * consistent with the WordPress.org menubar. For example, it does not implement arrow key navigation,
+ * instead just allowing for tab navigation through each item.
+ */
+const Dropdown = {
+  name: 'Dropdown',
+  props: {
+    /**
+     * The toggle button text.
+     */
+    text: {
+      type: String,
+      default: '',
+    },
+    /**
+     * Where the content should be placed in relation to the button.
+     *
+     * Options: 'bottom', 'top'
+     */
+    position: {
+      type: String,
+      default: 'bottom',
+      validator(value) {
+        return ['top', 'bottom'].includes(value)
+      },
+    },
+    /**
+     * The transition name.
+     */
+    transition: {
+      type: String,
+      default: '',
+    },
+    classes: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data: () => ({
+    isHovered: false,
+    isFocused: false,
+  }),
+  mounted() {
+    document.addEventListener('click', this.onClickout)
+  },
+  beforeDestroy() {
+    document.removeEventListener('click', this.onClickout)
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.onClickout)
+  },
+  methods: {
+    onClickout(e) {
+      if (!this.$el.contains(e.target)) {
+        this.isFocused = false
+      }
+    },
+    onFocusout(event) {
+      if (!this.$el.contains(event.relatedTarget)) {
+        this.isFocused = false
+      }
+    },
+    onFocus() {
+      this.isFocused = true
+    },
+  },
+}
+
+export default Dropdown
+</script>
+
+<style lang="scss">
+.navbar-dropdown {
+  /* Override Bulma's hiding of the dropdown so that it is still focusable */
+  display: block;
+}
+
+.navbar-dropdown:not(.visible) {
+  /* Accessible VisuallyHidden styles taken from @wordpress/components. Allows these components to be accessibly hidden from sight while still being focusable */
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  left: -2px;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  z-index: 99999;
+}
+</style>

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -10,7 +10,7 @@
     @focusout="onFocusout"
   >
     <div
-      :aria-expanded="!!isHovered || !!isFocused"
+      :aria-expanded="isHovered || isFocused"
       aria-haspopup="true"
       class="navbar-link is-arrowless"
       role="button"
@@ -20,15 +20,13 @@
       @click="isFocused = !isFocused"
       @focus="isFocused = true"
     >
-      <slot name="trigger">
-        {{ text }}
-        <i class="icon caret-down" />
-      </slot>
+      {{ text }}
+      <i class="icon caret-down" />
     </div>
 
     <div
       class="navbar-dropdown"
-      :class="{ visible: !!isHovered || !!isFocused }"
+      :class="{ visible: isHovered || isFocused }"
       role="menu"
     >
       <slot :onFocus="onFocus" />
@@ -53,7 +51,7 @@ const Dropdown = {
      */
     text: {
       type: String,
-      default: '',
+      required: true,
     },
   },
   data: () => ({

--- a/src/components/EmbeddedNavSection.vue
+++ b/src/components/EmbeddedNavSection.vue
@@ -49,54 +49,71 @@
         </div>
       </form>
       <div class="navbar-end">
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link is-arrowless">
-            {{ $t('header.about-tab') }}
-            <i class="icon caret-down" />
+        <Dropdown v-slot="{ onFocus }" :text="$t('header.about-tab')">
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/about')"
+            role="menuitem"
+            @focus="onFocus()"
+          >
+            {{ $t('header.about') }}
+          </NuxtLink>
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/sources')"
+            role="menuitem"
+            @focus="onFocus()"
+          >
+            {{ $t('header.source') }}
+          </NuxtLink>
+          <a
+            href="https://creativecommons.org/about/cclicenses/"
+            target="_blank"
+            rel="noopener"
+            class="navbar-item"
+            role="menuitem"
+            @focus="onFocus()"
+            >{{ $t('header.licenses') }}
+            <i class="icon external-link" />
           </a>
-          <div class="navbar-dropdown">
-            <NuxtLink class="navbar-item" :to="localePath('/about')">
-              {{ $t('header.about') }}
-            </NuxtLink>
-            <NuxtLink class="navbar-item" :to="localePath('/sources')">
-              {{ $t('header.source') }}
-            </NuxtLink>
-            <a
-              href="https://creativecommons.org/about/cclicenses/"
-              target="_blank"
-              rel="noopener"
-              class="navbar-item"
-              >{{ $t('header.licenses') }}
-              <i class="icon external-link" />
-            </a>
-          </div>
-        </div>
+        </Dropdown>
 
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link is-arrowless">
-            {{ $t('header.resources-tab') }}
-            <i class="icon caret-down" />
+        <Dropdown v-slot="{ onFocus }" :text="$t('header.resources-tab')">
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/search-help')"
+            role="menuitem"
+            @focus="onFocus()"
+          >
+            {{ $t('header.search-guide') }}
+          </NuxtLink>
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/meta-search')"
+            role="menuitem"
+            @focus="onFocus()"
+          >
+            {{ $t('header.meta-search') }}
+          </NuxtLink>
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/feedback')"
+            role="menuitem"
+            @focus="onFocus()"
+          >
+            {{ $t('header.feedback') }}
+          </NuxtLink>
+          <a
+            href="https://api.creativecommons.engineering/"
+            target="_blank"
+            rel="noopener"
+            role="menuitem"
+            class="navbar-item"
+            @focus="onFocus()"
+            >{{ $t('header.api') }}
+            <i class="icon external-link" />
           </a>
-          <div class="navbar-dropdown">
-            <NuxtLink class="navbar-item" :to="localePath('/search-help')">
-              {{ $t('header.search-guide') }}
-            </NuxtLink>
-            <NuxtLink class="navbar-item" :to="localePath('/meta-search')">
-              {{ $t('header.meta-search') }}
-            </NuxtLink>
-            <NuxtLink class="navbar-item" :to="localePath('/feedback')">
-              {{ $t('header.feedback') }}
-            </NuxtLink>
-            <a
-              href="https://api.creativecommons.engineering/"
-              target="_blank"
-              rel="noopener"
-              class="navbar-item"
-              >{{ $t('header.api') }}
-              <i class="icon external-link" />
-            </a>
-          </div>
-        </div>
+        </Dropdown>
 
         <NuxtLink class="navbar-item" :to="localePath('/extension')">
           {{ $t('header.extension') }}
@@ -108,9 +125,11 @@
 
 <script>
 import { SET_QUERY } from '~/store-modules/mutation-types'
+import Dropdown from '~/components/Dropdown'
 
 export default {
   name: 'EmbeddedNavSection',
+  components: { Dropdown },
   props: {
     showNavSearch: {
       default: false,

--- a/src/components/NavSection.vue
+++ b/src/components/NavSection.vue
@@ -52,54 +52,64 @@
         </form>
       </div>
       <div class="navbar-end">
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link is-arrowless">
-            {{ $t('header.about-tab') }}
-            <i class="icon caret-down" />
+        <Dropdown v-slot="{ onFocus }" :text="$t('header.about-tab')">
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/about')"
+            @focus="onFocus()"
+          >
+            {{ $t('header.about') }}
+          </NuxtLink>
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/sources')"
+            @focus="onFocus()"
+          >
+            {{ $t('header.source') }}
+          </NuxtLink>
+          <a
+            href="https://creativecommons.org/about/cclicenses/"
+            target="_blank"
+            rel="noopener"
+            class="navbar-item"
+            @focus="onFocus()"
+            >{{ $t('header.licenses') }}
+            <i class="icon external-link" />
           </a>
-          <div class="navbar-dropdown">
-            <NuxtLink class="navbar-item" :to="localePath('/about')">
-              {{ $t('header.about') }}
-            </NuxtLink>
-            <NuxtLink class="navbar-item" :to="localePath('/sources')">
-              {{ $t('header.source') }}
-            </NuxtLink>
-            <a
-              href="https://creativecommons.org/about/cclicenses/"
-              target="_blank"
-              rel="noopener"
-              class="navbar-item"
-              >{{ $t('header.licenses') }}
-              <i class="icon external-link" />
-            </a>
-          </div>
-        </div>
+        </Dropdown>
 
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link is-arrowless">
-            {{ $t('header.resources-tab') }}
-            <i class="icon caret-down" />
+        <Dropdown v-slot="{ onFocus }" :text="$t('header.resources-tab')">
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/search-help')"
+            @focus="onFocus()"
+          >
+            {{ $t('header.search-guide') }}
+          </NuxtLink>
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/meta-search')"
+            @focus="onFocus()"
+          >
+            {{ $t('header.meta-search') }}
+          </NuxtLink>
+          <NuxtLink
+            class="navbar-item"
+            :to="localePath('/feedback')"
+            @focus="onFocus()"
+          >
+            {{ $t('header.feedback') }}
+          </NuxtLink>
+          <a
+            href="https://api.creativecommons.engineering/"
+            target="_blank"
+            rel="noopener"
+            class="navbar-item"
+            @focus="onFocus()"
+            >{{ $t('header.api') }}
+            <i class="icon external-link" />
           </a>
-          <div class="navbar-dropdown">
-            <NuxtLink class="navbar-item" :to="localePath('/search-help')">
-              {{ $t('header.search-guide') }}
-            </NuxtLink>
-            <NuxtLink class="navbar-item" :to="localePath('/meta-search')">
-              {{ $t('header.meta-search') }}
-            </NuxtLink>
-            <NuxtLink class="navbar-item" :to="localePath('/feedback')">
-              {{ $t('header.feedback') }}
-            </NuxtLink>
-            <a
-              href="https://api.creativecommons.engineering/"
-              target="_blank"
-              rel="noopener"
-              class="navbar-item"
-              >{{ $t('header.api') }}
-              <i class="icon external-link" />
-            </a>
-          </div>
-        </div>
+        </Dropdown>
 
         <a
           :aria-label="$t('header.aria.extension')"
@@ -117,9 +127,11 @@
 
 <script>
 import { SET_QUERY } from '~/store-modules/mutation-types'
+import Dropdown from '~/components/Dropdown'
 
 export default {
   name: 'NavSection',
+  components: { Dropdown },
   props: {
     showNavSearch: {
       default: false,

--- a/src/styles/components/navbar.sass
+++ b/src/styles/components/navbar.sass
@@ -141,6 +141,7 @@ a.navbar-item,
     +ltr-position(1.125em)
 
 .navbar-dropdown
+  display: block
   padding-bottom: 0.5rem
   padding-top: 0.5rem
   .navbar-item

--- a/test/unit/specs/components/dropdown.spec.js
+++ b/test/unit/specs/components/dropdown.spec.js
@@ -1,0 +1,40 @@
+import Dropdown from '~/components/Dropdown'
+import render from '../../test-utils/render'
+
+describe('Dropdown', () => {
+  let options = {}
+  let props = null
+  beforeEach(() => {
+    props = {
+      filter: [{ text: 'Code is Poetry' }],
+      filterType: 'bar',
+    }
+    options = {
+      propsData: props,
+      scopedSlots: {
+        default: `<a id="dropdown-item" @focus="props.onFocus()">WordPress.org</a>`,
+      },
+    }
+  })
+
+  it('should visually hide the dropdown when not focused', () => {
+    const wrapper = render(Dropdown, options)
+    const dropdownWrapper = wrapper.get('[role="menu"]')
+    expect(dropdownWrapper.classes()).not.toContain('visible')
+  })
+
+  it('should be visible when the container is focused', async () => {
+    const wrapper = render(Dropdown, options)
+    await wrapper.trigger('focus')
+    const dropdownWrapper = wrapper.get('[role="menu"]')
+    expect(dropdownWrapper.classes()).toContain('visible')
+  })
+
+  it('should be visible when the dropdown items are focused', async () => {
+    const wrapper = render(Dropdown, options)
+    const dropdownItem = wrapper.get('#dropdown-item')
+    await dropdownItem.trigger('focus')
+    const dropdownWrapper = wrapper.get('[role="menu"]')
+    expect(dropdownWrapper.classes()).toContain('visible')
+  })
+})


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #116  by @sarayourfriend 

## Description
Adds a Dropdown component based on [Vuetensils' Dropdown](https://raw.githubusercontent.com/AustinGil/Vuetensils/production/src/components/VDropdown/VDropdown.vue) to make the navbar keyboard accessible.

## Technical details
Heavily modifies the Vuetensils' Dropdown to accomodate a couple of things:

0. Make the keyboard navigation behave the same as WordPress.org's navbar (i.e., no arrow key navigation, just tabbing through each item in order)
1. Adds focus management to each child by making an `onFocus` prop available through the default slot. This `onFocus` prop should be used in the `@focus` for each dropdown item. This makes it possible to tab "backwards" from a subsequent navbar item. For example, in the real example of the Openverse dropdown if you <kbd>Shift + Tab</kbd> from the Web Extension navbar item, you should focus into the last item of the Resources dropdown, not the Resources dropdown itself.
2. Makes the dropdown container always rendered into the DOM by using the visually hidden styles, lifted from `@wordpress/components`. This makes the dropdown items always appear in the DOM, making them keyboard focusable while hiding them from sighted users.
3. Use Bulma classes to fit the existing implementation. This is a drop-in replacement for the existing implementation, style wise, but adds keyboard accessibility (there should be no visual differences between this and the existing implementation).

## Tests
If you're on macOS, ensure that you've enabled keyboard navigation in the accessibility options following the instructions here: https://www.a11yproject.com/posts/2017-12-29-macos-browser-keyboard-navigation/

After restarting your browser, you should be able to tab through the navbar items including the dropdown items. Compare this to the live site and you'll see that it was not previously possible.

There are also unit tests to ensure that the focus management works (by teseting the presence of the `visible` class on the dropdown wrapper).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
