### PR TITLE
Replace {} placeholders with ### and escape quotes in strings in POT file

### DIFF
--- a/json-to-pot.js
+++ b/json-to-pot.js
@@ -42,7 +42,7 @@ const replaceVarsPlaceholders = (string) => {
  * @return {string}
  */
 const processValue = (string) => {
-  return replaceVarsPlaceholders(string)
+  return escapeQuotes(replaceVarsPlaceholders(string))
 }
 
 const findPath = (ob, key) => {
@@ -80,6 +80,8 @@ const findPath = (ob, key) => {
 
   return path.join('.')
 }
+
+const escapeQuotes = (str) => str.replace(/"/g, '\\"')
 
 // POT Syntax
 

--- a/json-to-pot.js
+++ b/json-to-pot.js
@@ -1,9 +1,49 @@
+// More about the structure of .po files:
+// https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files
+
+/*
+ * white-space
+ #  translator-comments
+ #. extracted-comments
+ #: reference…
+ #, flag…
+ #| msgid previous-untranslated-string
+ msgid untranslated-string
+ msgstr translated-string
+ */
+
 const json = require('./src/locales/en.json')
+const fs = require('fs')
 
 const curlyRegex = new RegExp('{[a-z]*}')
 const containsCurlyWord = (string) => curlyRegex.test(string)
 const checkStringForVars = (string) =>
-  containsCurlyWord(string) ? '(Do not translate words in curly braces)' : ''
+  containsCurlyWord(string) ? '(Do not translate words between ###)' : ''
+
+/**
+ * For GlotPress to display warning when the translators try to
+ * replace placeholders with something else, we need to wrap the
+ * placeholders with `###word###`
+ * @param string
+ * @return {string}
+ */
+const replaceVarsPlaceholders = (string) => {
+  if (!containsCurlyWord(string)) {
+    return string
+  }
+  const variable = /{(?<variable>[a-z]*)}/g
+  return string.replace(variable, `###$<variable>###`)
+}
+
+/**
+ * Replace placeholder format for variables,
+ * escape quotes (in a different PR)
+ * @param string
+ * @return {string}
+ */
+const processValue = (string) => {
+  return replaceVarsPlaceholders(string)
+}
 
 const findPath = (ob, key) => {
   const path = []
@@ -56,7 +96,7 @@ function potTime(json, parent = json) {
 
 # ${findPath(parent, key)}.${key} ${checkStringForVars(value)}
 msgctxt "${findPath(parent, key)}.${key}"
-msgid "${value}"
+msgid "${processValue(value)}"
 msgstr ""`
     }
     if (typeof value === 'object') {
@@ -67,4 +107,10 @@ msgstr ""`
 }
 
 const potFile = potTime(json)
-
+try {
+  const fileName = 'test.pot'
+  fs.writeFileSync(fileName, potFile)
+  console.log(`Successfully wrote pot file to ${fileName}`)
+} catch (err) {
+  console.error(err)
+}


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Some strings in the translation file have double quotes in them. These are illegal in PO files without escaping. This PR escapes the double quotes in the 'pot' conversion script.
