### PR TITLE
Convert ### placeholders to {}

### DIFF
--- a/get-translations.js
+++ b/get-translations.js
@@ -35,16 +35,30 @@ const makeTranslationUrl = (format = 'po') => (localeCode = 'en-gb') =>
 const fetchNgxTranslation = (locale) =>
   fetch(makeTranslationUrl('ngx')(locale)).then((res) => res.json())
 
+const replacePlaceholders = (json) => {
+  if (typeof json === 'string') {
+    return json.replace(/###([a-zA-Z-]*)###/, '{$1}')
+  }
+  let currentJson = { ...json }
+
+  for (const row of Object.entries(currentJson)) {
+    let [key, value] = row
+    currentJson[key] = replacePlaceholders(value)
+  }
+  return currentJson
+}
 /**
  * Write translation strings to a file in the locale directory
  * @param {string} locale
- * @param {any} translations
+ * @param {any} rawTranslations
  */
-const writeLocaleFile = (locale, translations) =>
-  writeFile(
+const writeLocaleFile = (locale, rawTranslations) => {
+  const translations = replacePlaceholders(rawTranslations)
+  return writeFile(
     process.cwd() + `/src/locales/${locale}.json`,
     JSON.stringify(translations, null, 2) + os.EOL
   )
+}
 
 /**
  * Write a file for each translation object


### PR DESCRIPTION
Related to #164 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
This PR adds a conversion step to #164 so that the GlotPress `###var###` placeholders are replaced with the placeholders we use in Vue-i18n, `{var}`. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
