### PR TITLE
Add focus style for play/pause button

### DIFF
--- a/src/components/AudioTrack/PlayPause.vue
+++ b/src/components/AudioTrack/PlayPause.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     type="button"
-    class="bg-dark-charcoal h-20 w-20 flex items-center justify-center disabled:opacity-70"
+    class="flex items-center justify-center bg-dark-charcoal h-20 w-20 transition-shadow duration-100 ease-linear disabled:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-pink"
     @click="toggle"
   >
     <span class="sr-only">{{ label }}</span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -103,6 +103,9 @@ module.exports = {
   variants: {
     extend: {
       opacity: ['disabled'],
+      ringColor: ['focus-visible'],
+      ringOffsetWidth: ['focus-visible'],
+      ringWidth: ['focus-visible'],
     },
   },
   plugins: [],


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #148 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
This PR adds a ring around the play/pause toggle button when focused. The Tailwind config added in the PR would also be useful in resolving #147.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
The focus outline is only shown for the [`focus-visible` state](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible). Browser support is [good](https://caniuse.com/css-focus-visible) but Safari is the next IE.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
<img width="345" alt="Screenshot 2021-08-30 at 9 32 54 AM" src="https://user-images.githubusercontent.com/16580576/131283664-6646627b-f456-43fb-b41d-953db52b4f08.png">

The border fades in and out, similar to Gutenberg. Since the button has no rounded corners, neither does the outline.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
