### PR TITLE
Change AudioTrack component according to filters sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ yarn-error.log*
 /test/selenium-webdriver/geckodriver.log
 /test/selenium-webdriver/screenshots/*
 selenium-debug.log
+.env
 .idea
 .vscode
 *.suo

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "storybook": "nuxt storybook",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:unit": "jest",
+    "test:unit": "jest --collectCoverage=false",
     "test:e2e": "cypress open",
     "test:e2e:ci": "cypress run",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",

--- a/src/components/AudioResultsList.vue
+++ b/src/components/AudioResultsList.vue
@@ -10,7 +10,8 @@
         v-for="audio in audios"
         :key="audio.id"
         :audio="audio"
-        :is-compact="true"
+        :size="audioTrackSize"
+        layout="row"
       />
     </div>
     <div v-if="!isFetchingAudiosError" class="load-more">
@@ -65,18 +66,16 @@ export default {
     }
   },
   computed: {
-    ...mapState([
-      'audios',
-      'isFetching.audios',
-      'isFetchingError.audios',
-      'errorMessage',
-    ]),
+    ...mapState(['audios', 'errorMessage', 'isFilterVisible']),
     ...mapState({
-      resultsCount: 'count',
+      isFetchingAudios: 'isFetching.audios',
+      isFetchingAudiosError: 'isFetchingError.audios',
+      resultsCount: 'audiosCount',
       currentPage: 'audioPage',
+      audioPageCount: 'pageCount.audios',
     }),
     audiosCount() {
-      const count = this.resultsCount.audios
+      const count = this.resultsCount
       if (count === 0) {
         return this.$t('browse-page.audio-no-results')
       }
@@ -89,7 +88,10 @@ export default {
           })
     },
     isFinished() {
-      return this.currentPage >= this.$store.state.pageCount.audios
+      return this.currentPage >= this.audioPageCount
+    },
+    audioTrackSize() {
+      return this.isFilterVisible ? 'm' : 's'
     },
   },
   methods: {

--- a/src/components/AudioResultsList.vue
+++ b/src/components/AudioResultsList.vue
@@ -5,7 +5,7 @@
         {{ audiosCount }}
       </span>
     </div>
-    <div class="px-6">
+    <div class="px-6 pt-6">
       <AudioTrack
         v-for="audio in audios"
         :key="audio.id"

--- a/src/components/AudioTrack/layouts/Full.vue
+++ b/src/components/AudioTrack/layouts/Full.vue
@@ -50,6 +50,7 @@ export default {
         date.setSeconds(ms / 1e3)
         return date.toISOString().substr(11, 8).replace(/^00:/, '')
       }
+      return '--:--'
     }
 
     return {

--- a/src/components/AudioTrack/layouts/Full.vue
+++ b/src/components/AudioTrack/layouts/Full.vue
@@ -45,9 +45,11 @@ export default {
      * @returns {string} the duration in a human-friendly format
      */
     const timeFmt = (ms) => {
-      const date = new Date(0)
-      date.setSeconds(ms / 1e3)
-      return date.toISOString().substr(11, 8).replace(/^00:/, '')
+      if (ms) {
+        const date = new Date(0)
+        date.setSeconds(ms / 1e3)
+        return date.toISOString().substr(11, 8).replace(/^00:/, '')
+      }
     }
 
     return {

--- a/src/components/AudioTrack/layouts/Row.vue
+++ b/src/components/AudioTrack/layouts/Row.vue
@@ -7,7 +7,7 @@
       class="flex"
       :class="isSmall ? 'flex-row gap-8' : 'flex-col justify-between'"
     >
-      <div class="flex-shrink-0">
+      <div class="flex-shrink-0" :class="isSmall ? 'w-96' : ''">
         <NuxtLink
           :to="localePath(`/audio/${audio.id}`)"
           class="font-heading font-semibold text-2xl"
@@ -35,12 +35,12 @@
             </span>
           </div>
 
-          <div class="part-b">
-            <template v-if="isSmall">
+          <div class="part-b inline-flex space-x-1">
+            <div v-if="isSmall">
               {{ timeFmt(audio.duration) }} {{ $t('interpunct') }}
               {{ $t(`audio-categories.${audio.category}`) }}
               {{ $t('interpunct') }}
-            </template>
+            </div>
             <License class="inline" :license="audio.license" />
           </div>
         </div>

--- a/src/components/AudioTrack/layouts/Row.vue
+++ b/src/components/AudioTrack/layouts/Row.vue
@@ -7,7 +7,7 @@
       class="flex"
       :class="isSmall ? 'flex-row gap-8' : 'flex-col justify-between'"
     >
-      <div class="flex-shrink-0" :class="isSmall ? 'w-96' : ''">
+      <div class="flex-shrink-0" :class="isSmall ? 'w-70' : ''">
         <NuxtLink
           :to="localePath(`/audio/${audio.id}`)"
           class="font-heading font-semibold text-2xl"

--- a/src/components/AudioTrack/layouts/Row.vue
+++ b/src/components/AudioTrack/layouts/Row.vue
@@ -30,16 +30,20 @@
             </i18n>
             <span v-if="!isSmall">
               {{ $t('interpunct') }} {{ timeFmt(audio.duration) }}
-              {{ $t('interpunct') }}
-              {{ $t(`audio-categories.${audio.category}`) }}
+              <template v-if="audio.category">
+                {{ $t('interpunct') }}
+                {{ $t(`audio-categories.${audio.category}`) }}
+              </template>
             </span>
           </div>
 
           <div class="part-b inline-flex space-x-1">
             <div v-if="isSmall">
               {{ timeFmt(audio.duration) }} {{ $t('interpunct') }}
-              {{ $t(`audio-categories.${audio.category}`) }}
-              {{ $t('interpunct') }}
+              <template v-if="audio.category">
+                {{ $t(`audio-categories.${audio.category}`) }}
+                {{ $t('interpunct') }}
+              </template>
             </div>
             <License class="inline" :license="audio.license" />
           </div>

--- a/src/components/AudioTrack/layouts/Row.vue
+++ b/src/components/AudioTrack/layouts/Row.vue
@@ -71,9 +71,12 @@ export default {
      * @returns {string} the duration in a human-friendly format
      */
     const timeFmt = (ms) => {
-      const date = new Date(0)
-      date.setSeconds(ms / 1e3)
-      return date.toISOString().substr(11, 8).replace(/^00:/, '')
+      if (ms) {
+        const date = new Date(0)
+        date.setSeconds(ms / 1e3)
+        return date.toISOString().substr(11, 8).replace(/^00:/, '')
+      }
+      return '--:--'
     }
 
     const isSmall = computed(() => props.size === 's')

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -617,8 +617,7 @@
     "title": "Audio Category",
     "music": "Music",
     "sound-effects": "Sound Effects",
-    "podcast": "Podcast",
-    "undefined": "Undefined category"
+    "podcast": "Podcast"
   },
   "license-names": {
     "cc0": "CC0",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -617,7 +617,8 @@
     "title": "Audio Category",
     "music": "Music",
     "sound-effects": "Sound Effects",
-    "podcast": "Podcast"
+    "podcast": "Podcast",
+    "undefined": "Undefined category"
   },
   "license-names": {
     "cc0": "CC0",

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2021-09-28T13:31:53+00:00\n"
+"POT-Creation-Date: 2021-09-17T16:40:38+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1252,7 +1252,8 @@ msgctxt "browse-page.all-no-results"
 msgid "No results"
 msgstr ""
 
-#: src/components/AudioResultsList.vue:81
+# browse-page.audio-no-results
+#: src/components/AudioResultsList.vue:74
 msgctxt "browse-page.audio-no-results"
 msgid "No audio results"
 msgstr ""
@@ -1269,8 +1270,8 @@ msgid_plural "###localeCount### results"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Do not translate words between ### ###.
-#: src/components/AudioResultsList.vue:87
+# browse-page.audio-result-count (Do not translate words between ###)
+#: src/components/AudioResultsList.vue:80
 msgctxt "browse-page.audio-result-count"
 msgid "###localeCount### audio result"
 msgid_plural "###localeCount### audio results"
@@ -1292,8 +1293,8 @@ msgid_plural "Over ###localeCount### results"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Do not translate words between ### ###.
-#: src/components/AudioResultsList.vue:84
+# browse-page.audio-result-count-more (Do not translate words between ###)
+#: src/components/AudioResultsList.vue:77
 msgctxt "browse-page.audio-result-count-more"
 msgid "Over ###localeCount### audio results"
 msgid_plural "Over ###localeCount### audio results"
@@ -1308,19 +1309,20 @@ msgid_plural "Over ###localeCount### image results"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Do not translate words between ### ###.
-#: src/components/AudioResultsList.vue:25
+# browse-page.no-more (Do not translate words between ###)
+#: src/components/AudioResultsList.vue:26
 msgctxt "browse-page.no-more"
 msgid "No more ###type### :("
 msgstr ""
 
-#: src/components/AudioResultsList.vue:29
+# browse-page.load
+#: src/components/AudioResultsList.vue:30
 msgctxt "browse-page.load"
 msgid "Load more results"
 msgstr ""
 
-#. Do not translate words between ### ###.
-#: src/components/AudioResultsList.vue:36
+# browse-page.fetching-error (Do not translate words between ###)
+#: src/components/AudioResultsList.vue:37
 msgctxt "browse-page.fetching-error"
 msgid "Error fetching ###type###:"
 msgstr ""
@@ -1987,6 +1989,12 @@ msgctxt "filters.audio-categories.podcast"
 msgid "Podcast"
 msgstr ""
 
+# audio-categories.undefined
+msgctxt "audio-categories.undefined"
+msgid "Undefined category"
+msgstr ""
+
+# filters.licenses.cc0
 msgctxt "filters.licenses.cc0"
 msgid "CC0"
 msgstr ""

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2021-09-17T16:40:38+00:00\n"
+"POT-Creation-Date: 2021-09-28T13:37:17+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1252,8 +1252,7 @@ msgctxt "browse-page.all-no-results"
 msgid "No results"
 msgstr ""
 
-# browse-page.audio-no-results
-#: src/components/AudioResultsList.vue:74
+#: src/components/AudioResultsList.vue:80
 msgctxt "browse-page.audio-no-results"
 msgid "No audio results"
 msgstr ""
@@ -1270,8 +1269,8 @@ msgid_plural "###localeCount### results"
 msgstr[0] ""
 msgstr[1] ""
 
-# browse-page.audio-result-count (Do not translate words between ###)
-#: src/components/AudioResultsList.vue:80
+#. Do not translate words between ### ###.
+#: src/components/AudioResultsList.vue:86
 msgctxt "browse-page.audio-result-count"
 msgid "###localeCount### audio result"
 msgid_plural "###localeCount### audio results"
@@ -1293,8 +1292,8 @@ msgid_plural "Over ###localeCount### results"
 msgstr[0] ""
 msgstr[1] ""
 
-# browse-page.audio-result-count-more (Do not translate words between ###)
-#: src/components/AudioResultsList.vue:77
+#. Do not translate words between ### ###.
+#: src/components/AudioResultsList.vue:83
 msgctxt "browse-page.audio-result-count-more"
 msgid "Over ###localeCount### audio results"
 msgid_plural "Over ###localeCount### audio results"
@@ -1309,19 +1308,18 @@ msgid_plural "Over ###localeCount### image results"
 msgstr[0] ""
 msgstr[1] ""
 
-# browse-page.no-more (Do not translate words between ###)
+#. Do not translate words between ### ###.
 #: src/components/AudioResultsList.vue:26
 msgctxt "browse-page.no-more"
 msgid "No more ###type### :("
 msgstr ""
 
-# browse-page.load
 #: src/components/AudioResultsList.vue:30
 msgctxt "browse-page.load"
 msgid "Load more results"
 msgstr ""
 
-# browse-page.fetching-error (Do not translate words between ###)
+#. Do not translate words between ### ###.
 #: src/components/AudioResultsList.vue:37
 msgctxt "browse-page.fetching-error"
 msgid "Error fetching ###type###:"
@@ -1989,12 +1987,6 @@ msgctxt "filters.audio-categories.podcast"
 msgid "Podcast"
 msgstr ""
 
-# audio-categories.undefined
-msgctxt "audio-categories.undefined"
-msgid "Undefined category"
-msgstr ""
-
-# filters.licenses.cc0
 msgctxt "filters.licenses.cc0"
 msgid "CC0"
 msgstr ""

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -67,6 +67,7 @@ module.exports = {
       20: '5.00rem',
       24: '6.00rem',
       30: '7.50rem',
+      96: '24.00rem',
     },
     ringWidth: {
       DEFAULT: '1.5px',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -67,7 +67,7 @@ module.exports = {
       20: '5.00rem',
       24: '6.00rem',
       30: '7.50rem',
-      96: '24.00rem',
+      70: '17.50rem',
     },
     ringWidth: {
       DEFAULT: '1.5px',

--- a/test/unit/specs/components/AudioTrack/audio-track.spec.js
+++ b/test/unit/specs/components/AudioTrack/audio-track.spec.js
@@ -1,0 +1,84 @@
+import AudioTrack from '~/components/AudioTrack/AudioTrack'
+import { render } from '@testing-library/vue'
+import Vuei18n from 'vue-i18n'
+
+const enMessages = require('~/locales/en.json')
+const useVueI18n = (vue) => {
+  vue.use(Vuei18n)
+
+  const i18n = new Vuei18n({
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages: { en: enMessages },
+  })
+
+  return {
+    i18n,
+  }
+}
+
+const stubs = {
+  AudioController: true,
+  PlayPause: true,
+  Waveform: true,
+}
+
+describe('AudioTrack', () => {
+  let options = null
+  let props = null
+
+  beforeEach(() => {
+    props = {
+      audio: {
+        id: 'e19345b8-6937-49f7-a0fd-03bf057efc28',
+        title: 'La vie des bêtes',
+        foreign_landing_url: 'https://www.jamendo.com/track/11188',
+        creator: 'AS-POTIRONT!',
+        creator_url: 'https://www.jamendo.com/artist/264/as-potiront',
+        url: 'https://mp3d.jamendo.com/download/track/11188/mp32',
+        license: 'by-nc-sa',
+        license_version: '2.5',
+        license_url: 'https://creativecommons.org/licenses/by-nc-sa/2.5/',
+        provider: 'jamendo',
+        source: 'jamendo',
+        tags: [
+          {
+            name: 'vocal',
+          },
+          {
+            name: 'male',
+          },
+          {
+            name: 'speed_medium',
+          },
+          {
+            name: 'party',
+          },
+          {
+            name: 'cuivres',
+          },
+        ],
+        fields_matched: ['tags.name'],
+        thumbnail:
+          'https://localhost:8000/v1/audio/e19345b8-6937-49f7-a0fd-03bf057efc28/thumb',
+        waveform:
+          'https://localhost:8000/v1/audio/e19345b8-6937-49f7-a0fd-03bf057efc28/waveform',
+        genres: ['pop', 'rock', 'manouche'],
+        detail_url:
+          'http://localhost:8000/v1/audio/e19345b8-6937-49f7-a0fd-03bf057efc28',
+        related_url:
+          'http://localhost:8000/v1/audio/e19345b8-6937-49f7-a0fd-03bf057efc28/recommendations',
+      },
+    }
+
+    options = {
+      propsData: props,
+      stubs,
+    }
+  })
+
+  it('should render the audio track even without duration', () => {
+    const { getByText } = render(AudioTrack, options, useVueI18n)
+    getByText(props.audio.creator)
+  })
+})

--- a/test/unit/specs/components/AudioTrack/audio-track.spec.js
+++ b/test/unit/specs/components/AudioTrack/audio-track.spec.js
@@ -91,4 +91,18 @@ describe('AudioTrack', () => {
     const { getByText } = render(AudioTrack, options, useVueI18n)
     getByText('by ' + props.audio.creator)
   })
+
+  it('should show audio title as page title', () => {
+    const { getByText } = render(AudioTrack, options, useVueI18n)
+    const element = getByText(props.audio.title + ' by')
+    expect(element).toBeInstanceOf(HTMLHeadingElement)
+    expect(element.tagName).toEqual('H1')
+  })
+
+  it('should show audio creator with link', () => {
+    const { getByText } = render(AudioTrack, options, useVueI18n)
+    const element = getByText(props.audio.creator)
+    expect(element).toBeInstanceOf(HTMLAnchorElement)
+    expect(element).toHaveAttribute('href', props.audio.creator_url)
+  })
 })

--- a/test/unit/specs/components/AudioTrack/audio-track.spec.js
+++ b/test/unit/specs/components/AudioTrack/audio-track.spec.js
@@ -92,9 +92,9 @@ describe('AudioTrack', () => {
     getByText('by ' + props.audio.creator)
   })
 
-  it('should show audio title as page title', () => {
+  it('should show audio title as main page title', () => {
     const { getByText } = render(AudioTrack, options, useVueI18n)
-    const element = getByText(props.audio.title + ' by')
+    const element = getByText(props.audio.title)
     expect(element).toBeInstanceOf(HTMLHeadingElement)
     expect(element.tagName).toEqual('H1')
   })

--- a/test/unit/specs/components/AudioTrack/audio-track.spec.js
+++ b/test/unit/specs/components/AudioTrack/audio-track.spec.js
@@ -20,6 +20,7 @@ const useVueI18n = (vue) => {
 const stubs = {
   AudioController: true,
   PlayPause: true,
+  NuxtLink: true,
   Waveform: true,
 }
 
@@ -77,8 +78,17 @@ describe('AudioTrack', () => {
     }
   })
 
-  it('should render the audio track even without duration', () => {
+  it('should render the full audio track component even without duration', () => {
     const { getByText } = render(AudioTrack, options, useVueI18n)
     getByText(props.audio.creator)
+  })
+
+  it('should render the row audio track component even without duration', () => {
+    options.propsData = {
+      ...options.propsData,
+      layout: 'row',
+    }
+    const { getByText } = render(AudioTrack, options, useVueI18n)
+    getByText('by ' + props.audio.creator)
   })
 })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #238 by @krysal

## Description
<!-- Concisely describe what the pull request does. -->
This PR updates the AudioTrack component to render even if the `audio` object doens't specify `duration` or `category`. Also, changes the variant according to if the filter sidebar is visible or not, as in mockups [[ref1][mockup1], [ref2][mockup2]]

[mockup1]: https://www.figma.com/file/vEoItpMQyFZb5AZV9aoP7I/Audio-integration?node-id=1070%3A10966
[mockup2]: https://www.figma.com/file/vEoItpMQyFZb5AZV9aoP7I/Audio-integration?node-id=1147%3A12234

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
Adds an 'Undefined category' to avoid showing the locale key and shows `--:--` in case the duration of the track is unknown. These fields should always be present once we add them to the API, but I believe they are not strictly required to show the component.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
I added some minimal tests to verify the component is working, we should add more to test for accessibility aspects of the Audio player but I don't want to block this issue any longer.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

### With sidebar open
![sidebar_open](https://user-images.githubusercontent.com/9145885/134993974-4d1910f1-9fa8-4477-bba2-74fed4e572bd.png)

### With sidebar closed
![sidebar_closed](https://user-images.githubusercontent.com/9145885/134993987-64132988-400c-4093-9cad-0c91f95cb661.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
