### PR TITLE
Add feature flag for non-image media types

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -12,6 +12,8 @@ export const env = {
   filterStorageKey: 'openverse-filter-visibility',
   notificationStorageKey: 'openverse-show-notification',
   enableInternalAnalytics: process.env.ENABLE_INTERNAL_ANALYTICS || false,
+  /** Feature flag to enable non-image media */
+  allMediaFeature: process.env.ALL_MEDIA_FEATURE || true,
 }
 
 /**

--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -79,7 +79,7 @@ export default {
     onSubmit() {
       this.$store.commit(SET_QUERY, { query: { q: this.form.searchTerm } })
       const newPath = this.localePath({
-        path: '/search',
+        path: process.env.allMediaFeature ? '/search' : '/search/image',
         query: {
           q: this.form.searchTerm,
           ...filtersToQueryData(this.$store.state.filters, ALL_MEDIA),

--- a/src/components/SearchTypeTabs.vue
+++ b/src/components/SearchTypeTabs.vue
@@ -26,8 +26,12 @@ import { queryStringToSearchType } from '~/utils/search-query-transform'
 export default {
   name: 'SearchTypeTabs',
   data() {
+    let contentTypes = [IMAGE, AUDIO, VIDEO]
+    if (process.env.allMediaFeature) {
+      contentTypes.unshift(ALL_MEDIA)
+    }
     return {
-      contentTypes: [ALL_MEDIA, IMAGE, AUDIO, VIDEO],
+      contentTypes,
     }
   },
   computed: {

--- a/src/pages/search/audio.vue
+++ b/src/pages/search/audio.vue
@@ -1,7 +1,11 @@
 <template>
   <div id="tab-audio" role="tabpanel" aria-labelledby="audio">
-    <AudioResultsList :query="query" @onLoadMoreAudios="onLoadMoreAudios" />
-    <MetaSearchForm type="audio" :query="query" :supported="true" />
+    <AudioResultsList
+      v-if="supported"
+      :query="query"
+      @onLoadMoreAudios="onLoadMoreAudios"
+    />
+    <MetaSearchForm type="audio" :query="query" :supported="supported" />
   </div>
 </template>
 
@@ -11,6 +15,12 @@ import { AUDIO } from '~/constants/media'
 
 export default {
   name: 'AudioSearch',
+  data() {
+    return {
+      // Only show audio results if non-image results are supported
+      supported: process.env.allMediaFeature,
+    }
+  },
   computed: {
     query() {
       return this.$store.state.query
@@ -21,6 +31,7 @@ export default {
   },
   methods: {
     onLoadMoreAudios(searchParams) {
+      if (!this.supported) return
       this.$emit('onLoadMoreItems', searchParams)
     },
   },

--- a/src/store-modules/filter-store.js
+++ b/src/store-modules/filter-store.js
@@ -36,16 +36,18 @@ export const mediaFilterKeys = {
     'searchBy',
     'mature',
   ],
-  audio: [
-    'licenses',
-    'licenseTypes',
-    'audioCategories',
-    'audioExtensions',
-    'durations',
-    'audioProviders',
-    'searchBy',
-    'mature',
-  ],
+  audio: process.env.allMediaFeature
+    ? [
+        'licenses',
+        'licenseTypes',
+        'audioCategories',
+        'audioExtensions',
+        'durations',
+        'audioProviders',
+        'searchBy',
+        'mature',
+      ]
+    : [],
   video: [],
   all: ['licenses', 'licenseTypes', 'searchBy', 'mature'],
 }
@@ -58,7 +60,9 @@ export const mediaSpecificFilters = {
     'sizes',
     'imageProviders',
   ],
-  audio: ['audioCategories', 'audioExtensions', 'durations', 'audioProviders'],
+  audio: process.env.allMediaFeature
+    ? ['audioCategories', 'audioExtensions', 'durations', 'audioProviders']
+    : [],
   video: [],
 }
 


### PR DESCRIPTION
This PR adds a `process.env.allMediaFeature` feature flag for the displaying of non-image media on Openverse. This will allow us to only enable audio and video support on wordpress.org/openverse when those sources are fully indexed, and prevents us from showing test data live. Currently the flag is used to:

- Hide the 'all' tab, and send users to the 'image' tab from the search bar
- Hide audio files on the audio tab, and mark audio meta search as _unsupported_
	- This inadvertently fixes the audio bug in #239 

This `allMediaFeature` is _enabled_ by default, so work can resume as it nothing changed.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
