### PR TITLE
Fix Sketchfab viewer sizing

### DIFF
--- a/src/components/SketchFabViewer.vue
+++ b/src/components/SketchFabViewer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sketchfab-viewer image is-16by9">
+  <div class="sketchfab-viewer image is-sketchfab-viewer">
     <!-- <div v-if="loading">Loading...</div> -->
     <iframe
       id="sketchfab-iframe"
@@ -68,3 +68,20 @@ export default {
   },
 }
 </script>
+<style lang="scss" scoped>
+.image {
+  display: block;
+}
+.is-sketchfab-viewer {
+  padding-top: 56.25%;
+}
+.has-ratio {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  height: 100%;
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
## Fixes

Fixes #237 by @zackkrida

## Description

This PR fixes Sketchfab viewer size, it applies same CSS rules from previous website: http://search.creativecommons.org/photos/6b57230c-6601-476e-a04c-1456d02c9b14

## Screenshots

![fix_sketchfab_viewer_sizing](https://user-images.githubusercontent.com/29523399/134036902-53f4ccc2-3b17-4b25-bf3d-925bdda76da1.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
