### PR TITLE
Fix typo on WordPress word

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -101,7 +101,7 @@
       "common-crawl": "Common Crawl",
       "meta": "meta search",
       "projects": "Openverse projects",
-      "community": "Make Wordpress community",
+      "community": "Make WordPress community",
       "terms": "Openverse terms of use",
       "sources-table": "sources table",
       "creative-commons": "Creative Commons",

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -371,7 +371,7 @@ msgstr ""
 # about.planning.community
 #: src/pages/about.vue:54
 msgctxt "about.planning.community"
-msgid "Make Wordpress community"
+msgid "Make WordPress community"
 msgstr ""
 
 # footer.navigation.terms


### PR DESCRIPTION
## Fixes
It is really minor fix. The commit title is self-explanatory.

## Description
I found this typo when translating Openverse to Indonesian during WordPress Translation Day 2021 mini-event.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

![Screen Shot 2021-09-22 at 08 10 35](https://user-images.githubusercontent.com/1859092/134268465-60ba8fca-70e1-4aa8-afd6-69126a326412.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
