### PR TITLE
Fix paths for jest coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,10 +18,5 @@ module.exports = {
   testPathIgnorePatterns: ['/e2e/'],
   collectCoverage: true,
   coverageDirectory: '<rootDir>/test/unit/coverage',
-  collectCoverageFrom: [
-    '<rootDir>/src/components/**/*.vue',
-    '<rootDir>/src/layouts/**/*.vue',
-    '<rootDir>/src/pages/**/*.vue',
-    '<rootDir>/src/**/*.js',
-  ],
+  collectCoverageFrom: ['<rootDir>/src/**/*.vue', '<rootDir>/src/**/*.js'],
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,9 @@ module.exports = {
   collectCoverage: true,
   coverageDirectory: '<rootDir>/test/unit/coverage',
   collectCoverageFrom: [
-    '<rootDir>/components/**/*.vue',
-    '<rootDir>/pages/**/*.vue',
+    '<rootDir>/src/components/**/*.vue',
+    '<rootDir>/src/layouts/**/*.vue',
+    '<rootDir>/src/pages/**/*.vue',
+    '<rootDir>/src/**/*.js',
   ],
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #250 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
This PR fixes the paths in `jest.config.js` so that running tests also displays the coverage information.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run `npm run test` and see that we need to write more tests :)

## Screenshots
```
---------------------------------|---------|----------|---------|---------|-----------------------------------------------------
File                             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                   
---------------------------------|---------|----------|---------|---------|-----------------------------------------------------
All files                        |   40.38 |    29.68 |   37.03 |   40.49 |                                                     
 ab-tests                        |     100 |      100 |     100 |     100 |                                                     
  index.js                       |     100 |      100 |     100 |     100 |                                                     
 ab-tests/experiments            |     100 |      100 |     100 |     100 |                                                     
  donation-language.js           |     100 |      100 |     100 |     100 |                                                     
 analytics                       |   16.67 |     5.26 |   21.43 |   16.67 |                                                     
  events.js                      |      50 |      100 |      50 |      50 | 12-16                                               
  google-analytics.js            |      10 |     5.26 |      10 |      10 | 3-33,37-47                                          
 components                      |   52.61 |    46.81 |   49.64 |   52.61 |                                                     
  .eslintrc.js                   |       0 |      100 |     100 |       0 | 1                                                   
  AppModal.vue                   |       0 |        0 |       0 |       0 | 27-51                                               
  AudioResultsList.vue           |       0 |        0 |       0 |       0 | 47-106                                              
  CopyButton.vue                 |   92.31 |      100 |   83.33 |   92.31 | 42                                                  
  Dropdown.vue                   |      40 |        0 |   42.86 |      40 | 65-78                                               
  DropdownButton.vue             |    87.5 |    78.95 |     100 |    87.5 | 76,81,102,110                                       
  EmbeddedNavSection.vue         |       0 |      100 |       0 |       0 | 127-154                                             
  ExtensionBrowsers.vue          |       0 |      100 |       0 |       0 | 18-26                                               
  FooterSection.vue              |       0 |      100 |       0 |       0 | 70-77                                               
  HeaderSection.vue              |     100 |      100 |     100 |     100 |                                                     
  HeroSection.vue                |      90 |       50 |     100 |      90 | 75                                                  
  HomeLicenseFilter.vue          |     100 |      100 |     100 |     100 |                                                     
  LicenseElements.vue            |       0 |      100 |       0 |       0 | 22-46                                               
  LicenseIcons.vue               |     100 |       50 |     100 |     100 | 41                                                  
  LocaleSelector.vue             |       0 |      100 |       0 |       0 | 48-59                                               
  MigrationNotice.vue            |       0 |      100 |     100 |       0 | 18                                                  
  NavSection.vue                 |    87.5 |      100 |      75 |    87.5 | 155                                                 
  NotificationBanner.vue         |       0 |      100 |       0 |       0 | 37-51                                               
  PhotoTags.vue                  |      60 |      100 |      50 |      60 | 29-34                                               
  SaferBrowsing.vue              |       0 |      100 |       0 |       0 | 43-69                                               
  ScrollButton.vue               |       0 |        0 |       0 |       0 |                                                     
  SearchGrid.vue                 |   66.67 |       50 |   66.67 |   66.67 | 29-33                                               
  SearchGridCell.vue             |   71.43 |       60 |   78.57 |   71.43 | 52,86,90,98,104,114,127-136                         
  SearchGridForm.vue             |   47.62 |        0 |   53.85 |   47.62 | 81,91,99-121                                        
  SearchGridManualLoad.vue       |   77.27 |       40 |   78.57 |   77.27 | 100-101,125,139,148                                 
  SearchRating.vue               |     100 |      100 |     100 |     100 |                                                     
  SearchTypeTabs.vue             |       0 |        0 |       0 |       0 | 22-59                                               
  SketchFabViewer.vue            |       0 |        0 |       0 |       0 | 18-66                                               
 components/AudioDetails         |       0 |      100 |       0 |       0 |                                                     
  Table.vue                      |       0 |      100 |       0 |       0 | 74-87                                               
  Tags.vue                       |       0 |      100 |       0 |       0 | 19-37                                               
 components/AudioTrack           |       0 |        0 |       0 |       0 |                                                     
  AudioController.vue            |       0 |        0 |       0 |       0 | 30-175                                              
  AudioTrack.vue                 |       0 |      100 |       0 |       0 | 34-105                                              
  PlayPause.vue                  |       0 |        0 |       0 |       0 | 22-60                                               
  Waveform.vue                   |       0 |        0 |       0 |       0 | 111-420                                             
 components/AudioTrack/layouts   |       0 |      100 |       0 |       0 |                                                     
  Full.vue                       |       0 |      100 |       0 |       0 | 44-50                                               
  Row.vue                        |       0 |      100 |       0 |       0 | 55-79                                               
 components/ContentReport        |   71.43 |      100 |      50 |   71.43 |                                                     
  ContentReportForm.vue          |   90.48 |      100 |    87.5 |   90.48 | 150-151                                             
  DmcaNotice.vue                 |       0 |      100 |       0 |       0 | 58                                                  
  OtherIssueForm.vue             |       0 |      100 |       0 |       0 | 46-60                                               
  ReportError.vue                |      50 |      100 |       0 |      50 | 26                                                  
 components/Filters              |   46.77 |       20 |   41.67 |   46.77 |                                                     
  FilterChecklist.vue            |      50 |    27.78 |   43.75 |      50 | 116-134,138-144,151-157                             
  FilterDisplay.vue              |   66.67 |      100 |      50 |   66.67 | 25,36                                               
  FilterTag.vue                  |     100 |       50 |     100 |     100 | 31                                                  
  FiltersList.vue                |   18.75 |        0 |       0 |   18.75 | 59-91                                               
  LicenseExplanationTooltip.vue  |   14.29 |        0 |       0 |   14.29 | 49-59                                               
  SearchGridFilter.vue           |    87.5 |      100 |      75 |    87.5 | 35                                                  
 components/ImageDetails         |   86.54 |    64.29 |   83.87 |   86.54 |                                                     
  ImageAttribution.vue           |     100 |      100 |     100 |     100 |                                                     
  ImageInfo.vue                  |   72.73 |       50 |      60 |   72.73 | 80,93-96                                            
  ImageSocialShare.vue           |     100 |      100 |     100 |     100 |                                                     
  PhotoDetails.vue               |   81.82 |       70 |      80 |   81.82 | 226,247,256,272                                     
  ReuseSurvey.vue                |     100 |      100 |     100 |     100 |                                                     
  SocialShareButtons.vue         |     100 |      100 |     100 |     100 |                                                     
 components/License              |       0 |      100 |       0 |       0 |                                                     
  License.vue                    |       0 |      100 |       0 |       0 | 31-69                                               
 components/MediaInfo            |   44.44 |        0 |   36.36 |   44.44 |                                                     
  CopyLicense.vue                |   57.14 |        0 |   44.44 |   57.14 | 202-206,219,232-238                                 
  MediaLicense.vue               |       0 |        0 |       0 |       0 | 65-80                                               
 components/MetaSearch           |       0 |        0 |       0 |       0 |                                                     
  MetaSearchForm.vue             |       0 |        0 |       0 |       0 | 35-60                                               
  MetaSourceList.vue             |       0 |      100 |       0 |       0 | 22-41                                               
 components/meta                 |       0 |      100 |       0 |       0 |                                                     
  DropdownButton.stories.js      |       0 |      100 |       0 |       0 | 8-44                                                
 constants                       |   63.64 |      100 |     100 |   63.64 |                                                     
  license.js                     |       0 |      100 |     100 |       0 | 1-14                                                
  media.js                       |     100 |      100 |     100 |     100 |                                                     
 data                            |   15.79 |     5.26 |     3.7 |   16.07 |                                                     
  api-service.js                 |    37.5 |    33.33 |   11.11 |    37.5 | 11-21,27-47                                         
  audio-service.js               |       0 |        0 |       0 |       0 | 6-53                                                
  bug-report-service.js          |       0 |      100 |       0 |       0 | 3-5                                                 
  existing-audio-providers.js    |     100 |      100 |     100 |     100 |                                                     
  existing-image-providers.js    |     100 |      100 |     100 |     100 |                                                     
  image-service.js               |       0 |        0 |       0 |       0 | 3-36                                                
  media-provider-service.js      |   11.11 |        0 |       0 |    12.5 | 15-122                                              
  report-service.js              |       0 |      100 |       0 |       0 | 3-5                                                 
  usage-data-service.js          |       0 |      100 |       0 |       0 | 3-35                                                
 feature-flags                   |       0 |      100 |     100 |       0 |                                                     
  index.js                       |       0 |      100 |     100 |       0 | 2                                                   
 layouts                         |       0 |      100 |       0 |       0 |                                                     
  default.vue                    |       0 |      100 |       0 |       0 | 11-15                                               
  embedded-with-nav-search.vue   |       0 |      100 |       0 |       0 | 11-20                                               
  embedded.vue                   |       0 |      100 |       0 |       0 | 11-20                                               
  error.vue                      |       0 |      100 |     100 |       0 | 14                                                  
  with-nav-search.vue            |       0 |      100 |       0 |       0 | 11-15                                               
 locales/scripts                 |       0 |        0 |       0 |       0 |                                                     
  get-translations.js            |       0 |        0 |       0 |       0 | 5-109                                               
  get-validated-locales.js       |       0 |      100 |       0 |       0 | 1-28                                                
  json-to-pot.js                 |       0 |        0 |       0 |       0 | 14-175                                              
  ngx-json-to-json.js            |       0 |        0 |       0 |       0 | 1-47                                                
  parse-vue-files.js             |       0 |        0 |       0 |       0 | 4-121                                               
  update-locale-list.js          |       0 |        0 |       0 |       0 | 5-69                                                
 middleware                      |       0 |        0 |       0 |       0 |                                                     
  middleware.js                  |       0 |        0 |       0 |       0 | 20-33                                               
 mixins                          |       0 |        0 |       0 |       0 |                                                     
  i18n-sync.js                   |       0 |        0 |       0 |       0 | 14-34                                               
  iframe-height.js               |       0 |        0 |       0 |       0 | 11-54                                               
 pages                           |       0 |        0 |       0 |       0 |                                                     
  about.vue                      |       0 |        0 |       0 |       0 | 99-104                                              
  extension.vue                  |       0 |        0 |       0 |       0 | 73-110                                              
  feedback.vue                   |       0 |        0 |       0 |       0 | 64-108                                              
  index.vue                      |       0 |        0 |       0 |       0 | 6-14                                                
  meta-search.vue                |       0 |        0 |       0 |       0 | 108-113                                             
  search-help.vue                |       0 |        0 |       0 |       0 | 258-272                                             
  search.vue                     |       0 |        0 |       0 |       0 | 25-112                                              
  sources.vue                    |       0 |        0 |       0 |       0 | 137-172                                             
 pages/audio                     |       0 |        0 |       0 |       0 |                                                     
  _id.vue                        |       0 |        0 |       0 |       0 | 27-122                                              
 pages/photos                    |       0 |        0 |       0 |       0 |                                                     
  _id.vue                        |       0 |        0 |       0 |       0 | 29-129                                              
 pages/search                    |       0 |        0 |       0 |       0 |                                                     
  audio.vue                      |       0 |        0 |       0 |       0 | 13-35                                               
  image.vue                      |       0 |      100 |       0 |       0 | 11-21                                               
  index.vue                      |       0 |      100 |       0 |       0 | 11-21                                               
  video.vue                      |       0 |      100 |       0 |       0 | 11-17                                               
 plugins                         |       0 |        0 |       0 |       0 |                                                     
  ab-test-init.js                |       0 |        0 |       0 |       0 | 8-9                                                 
  ga.js                          |       0 |        0 |       0 |       0 | 7-45                                                
  migration-notice.js            |       0 |        0 |       0 |       0 | 9-11                                                
  url-change.js                  |       0 |        0 |       0 |       0 | 10-12                                               
  vue-i18n.js                    |       0 |        0 |       0 |       0 | 2-29                                                
 store                           |       0 |      100 |       0 |       0 |                                                     
  index.js                       |       0 |      100 |       0 |       0 | 25-70                                               
 store-modules                   |   68.27 |    43.96 |   61.24 |   68.53 |                                                     
  abtest-store.js                |       0 |        0 |       0 |       0 | 5-30                                                
  action-types.js                |     100 |      100 |     100 |     100 |                                                     
  active-media-store.js          |       0 |      100 |       0 |       0 | 10-33                                               
  attribution-store.js           |     100 |      100 |     100 |     100 |                                                     
  bug-report-store.js            |     100 |      100 |     100 |     100 |                                                     
  filter-store.js                |   44.19 |    26.09 |   32.43 |   44.44 | 167-172,189-231,258-283,303-323                     
  media-provider-store.js        |   80.65 |       50 |   83.33 |      80 | 42,60-64,84,91                                      
  mutation-types.js              |     100 |      100 |     100 |     100 |                                                     
  nav-store.js                   |       0 |      100 |       0 |       0 | 3-13                                                
  notification-store.js          |       0 |      100 |       0 |       0 | 4-26                                                
  related-media-store.js         |   76.19 |       50 |   83.33 |      75 | 27,31,56-57,73                                      
  report-content-store.js        |     100 |      100 |     100 |     100 |                                                     
  search-store.js                |   69.72 |    52.38 |   69.44 |   69.16 | 166-169,183-201,242-266,286-288,301-303,308,342-345 
  social-store.js                |     100 |      100 |     100 |     100 |                                                     
  usage-data-analytics-types.js  |     100 |      100 |     100 |     100 |                                                     
  usage-data-store.js            |   73.68 |       50 |    87.5 |   92.31 | 17                                                  
  user-store.js                  |       0 |      100 |     100 |       0 | 3                                                   
 utils                           |   73.35 |     54.4 |      75 |   74.92 |                                                     
  attribution-html.js            |   84.21 |       50 |     100 |   84.21 | 3,14-15                                             
  decode-data.js                 |     100 |      100 |     100 |     100 |                                                     
  decode-media-data.js           |     100 |    42.86 |     100 |     100 | 8-13                                                
  format-strings.js              |      40 |        0 |       0 |      50 | 3-6                                                 
  get-browser-info.js            |       0 |        0 |       0 |       0 | 1-20                                                
  get-legacy-source-url.js       |   71.11 |    36.67 |     100 |   81.58 | 35-36,52-53,124-125,194                             
  get-parameter-by-name.js       |     100 |      100 |     100 |     100 |                                                     
  get-provider-logo.js           |       0 |        0 |       0 |       0 | 4-11                                                
  get-provider-name.js           |      40 |     37.5 |      50 |      40 | 8-12                                                
  license.js                     |   66.67 |       50 |   33.33 |   66.67 | 23,39,48                                            
  load-script.js                 |       0 |        0 |       0 |       0 | 2-12                                                
  local.js                       |      75 |       50 |      50 |      75 | 8                                                   
  locales.js                     |       0 |      100 |       0 |       0 | 1-15                                                
  prepare-search-query-params.js |     100 |      100 |     100 |     100 |                                                     
  resampling.js                  |     100 |      100 |     100 |     100 |                                                     
  search-query-transform.js      |     100 |       88 |     100 |     100 | 73,135-141                                          
  send-message.js                |       0 |        0 |       0 |       0 | 2-14                                                
  session-id.js                  |       0 |        0 |       0 |       0 | 4-38                                                
  sixpack.js                     |   69.05 |    56.52 |   71.43 |   68.29 | 14,18,23,38,42,46,67,91-104                         
  string-to-boolean.js           |      75 |    85.71 |     100 |   85.71 | 19                                                  
---------------------------------|---------|----------|---------|---------|-----------------------------------------------------

Test Suites: 48 passed, 48 total
Tests:       6 skipped, 233 passed, 239 total
Snapshots:   0 total
Time:        15.263 s
```
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
