### PR TITLE
Add download button to the single audio result page

### DIFF
--- a/src/components/AudioTrack/layouts/Full.vue
+++ b/src/components/AudioTrack/layouts/Full.vue
@@ -2,7 +2,7 @@
   <div class="full-track w-full">
     <slot name="controller" />
 
-    <div class="flex flex-row space-between mx-16 my-6">
+    <div class="flex flex-row justify-between mx-16 my-6">
       <div class="left-content flex flex-row items-center gap-6">
         <slot name="play-pause" />
 
@@ -28,8 +28,10 @@
         </div>
       </div>
 
-      <!-- TODO: Download dropdown -->
-      <div class="right-content bg-pink h-12 w-30 rounded-sm ml-auto" />
+      <DownloadButton
+        class="right-content h-14 flex"
+        :formats="getFormats(audio)"
+      />
     </div>
   </div>
 </template>
@@ -52,9 +54,30 @@ export default {
       }
       return '--:--'
     }
-
+    /**
+     * Creates a list of { extension_name, download_url } objects
+     * for DownloadButton
+     * @param {AudioDetail} audio
+     */
+    const getFormats = (audio) => {
+      let formats = [
+        { extension_name: audio.filetype, download_url: audio.url },
+      ]
+      if (audio.alt_files) {
+        console.log('audio has alt_files')
+        formats = formats.concat(
+          audio.alt_files.map((altFile) => ({
+            extension_name: altFile.extension,
+            download_url: altFile.url,
+          }))
+        )
+        console.log('formats: ', formats)
+      }
+      return formats
+    }
     return {
       timeFmt,
+      getFormats,
     }
   },
 }

--- a/src/components/DropdownButton.vue
+++ b/src/components/DropdownButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative block max-w-min">
+  <div class="relative flex max-w-min">
     <!-- rounded-X-none is required to fight Edge UA styles that apply a 2px border radius to all `button` elements -->
     <div class="flex">
       <slot
@@ -11,7 +11,7 @@
       <button
         ref="dropdownButton"
         type="button"
-        class="dropdown-button ml-1 rounded-r-sm rounded-l-none"
+        class="dropdown-button ml-1 rounded-r-sm rounded-l-none w-14"
         :class="{ 'dropdown-button-active': isOpen }"
         aria-haspopup="menu"
         :aria-label="safeDropdownAriaLabel"

--- a/src/data/sample-audio-responses.json
+++ b/src/data/sample-audio-responses.json
@@ -30,6 +30,7 @@
             "name": "vocal"
           }
         ],
+        "filetype": "mp3",
         "fields_matched": ["tags.name"],
         "genres": ["classical", "gospel"],
         "detail_url": "http://localhost:8000/v1/audio/8071128a-bebc-4c24-823d-6e26a2e6dfe2",
@@ -58,6 +59,7 @@
             "name": "vocal"
           }
         ],
+        "filetype": "mp3",
         "fields_matched": ["tags.name"],
         "genres": ["metal"],
         "detail_url": "http://localhost:8000/v1/audio/73e00493-9189-42ed-955b-4f9d26d0d9f4",
@@ -250,6 +252,14 @@
       "name": "Distance & Temps",
       "url": "https://www.jamendo.com/album/1290/distance-and-temps"
     },
+    "alt_files": [{
+      "extension": "flac",
+      "url": "https://mp3d.jamendo.com/download/track/8561/flac"
+      },
+      {
+      "extension": "mp31",
+      "url": "https://mp3d.jamendo.com/download/track/8561/mp31"
+    }],
     "duration": 248000,
     "detail_url": "http://localhost:8000/v1/audio/242c1a4c-0623-436c-a600-7847412d28b6",
     "related_url": "http://localhost:8000/v1/audio/242c1a4c-0623-436c-a600-7847412d28b6/recommendations"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #270 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds `DownloadButton` component to the Single audio result page: 

![download_audio](https://user-images.githubusercontent.com/15233243/135868375-54f0dae2-531a-4536-804c-8d75ef799a77.gif)

Currently, the file extension is being set in the Catalog as `mp3`. However, Jamendo provides two types of `mp3` of different quality. Should we also set the filetype as mp31 and mp32 as Jamendo does?


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
