### PR TITLE
Add replay action and played state to audio track

### DIFF
--- a/src/assets/icons/replay.svg
+++ b/src/assets/icons/replay.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path id="icon" fill-rule="evenodd" clip-rule="evenodd" d="M12 8V11L8 7L12 3V6C15.3137 6 18 8.68629 18 12C18 15.3137 15.3137 18 12 18C8.68629 18 6 15.3137 6 12H8C8 14.2091 9.79086 16 12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8Z" fill="currentcolor"/>
+</svg>

--- a/src/components/AudioTrack/AudioController.vue
+++ b/src/components/AudioTrack/AudioController.vue
@@ -61,7 +61,7 @@ export default {
     status: {
       type: String,
       required: true,
-      validator: (val) => ['playing', 'paused'].includes(val),
+      validator: (val) => ['playing', 'paused', 'played'].includes(val),
     },
     /**
      * the CSS classes to apply on the waveform; This can take any form
@@ -84,8 +84,13 @@ export default {
     // Sync status from parent to player and store
     watch(
       () => props.status,
-      (status) => {
+      (status, prevStatus) => {
         if (!audioEl.value) return
+
+        if (prevStatus === 'played' && status === 'playing') {
+          // If going from played to playing, then reset the time to the beginning. Let the regular logic handle actually triggering the playing of the audio
+          audioEl.value.currentTime = 0
+        }
 
         switch (status) {
           case 'playing':
@@ -146,6 +151,10 @@ export default {
 
       currentTime.value = audioEl.value.currentTime
       duration.value = audioEl.value.duration
+
+      if (currentTime.value >= duration.value) {
+        emit('finished')
+      }
     }
     const updateTimeLoop = () => {
       updateTime()
@@ -169,6 +178,7 @@ export default {
       if (audioEl.value && duration.value) {
         audioEl.value.currentTime = duration.value * frac
         updateTime()
+        emit('seeked')
       }
     }
 

--- a/src/components/AudioTrack/AudioTrack.vue
+++ b/src/components/AudioTrack/AudioTrack.vue
@@ -16,6 +16,8 @@
           v-bind="controllerProps"
           :audio="audio"
           @ready="handleReady"
+          @finished="status = 'played'"
+          @seeked="handleSeeked"
         />
       </template>
 
@@ -87,6 +89,12 @@ export default {
 
     const status = ref('paused')
 
+    const handleSeeked = () => {
+      if (status.value === 'played') {
+        status.value = 'paused'
+      }
+    }
+
     /* Metadata readiness */
 
     const isReady = ref(false)
@@ -104,6 +112,7 @@ export default {
 
     return {
       status,
+      handleSeeked,
 
       isReady,
       handleReady,

--- a/src/components/AudioTrack/PlayPause.vue
+++ b/src/components/AudioTrack/PlayPause.vue
@@ -12,8 +12,7 @@
       aria-hidden="true"
       focusable="false"
     >
-      <use v-if="isPlaying" :href="`${icons.pause}#icon`" />
-      <use v-else :href="`${icons.play}#icon`" />
+      <use :href="`${icon}#icon`" />
     </svg>
   </button>
 </template>
@@ -21,6 +20,27 @@
 <script>
 import playIcon from '~/assets/icons/play.svg'
 import pauseIcon from '~/assets/icons/pause.svg'
+import replayIcon from '~/assets/icons/replay.svg'
+
+/**
+ * @param {'playing' | 'paused' | 'played'} status
+ */
+const getLabelFromStatus = (status) => {
+  switch (status) {
+    case 'playing':
+      return 'play-pause.pause'
+    case 'paused':
+      return 'play-pause.play'
+    case 'played':
+      return 'play-pause.replay'
+  }
+}
+
+const STATUS_TO_ICON = {
+  playing: pauseIcon,
+  paused: playIcon,
+  played: replayIcon,
+}
 
 /**
  * Displays the control for switching between the playing and paused states of
@@ -38,21 +58,18 @@ export default {
      */
     status: {
       type: String,
-      validator: (val) => ['playing', 'paused'].includes(val),
+      validator: (val) => ['playing', 'paused', 'played'].includes(val),
     },
   },
-  data: () => ({
-    icons: {
-      play: playIcon,
-      pause: pauseIcon,
-    },
-  }),
   computed: {
     isPlaying() {
       return this.status === 'playing'
     },
     label() {
-      return this.$t(this.isPlaying ? 'play-pause.pause' : 'play-pause.play')
+      return this.$t(getLabelFromStatus(this.status))
+    },
+    icon() {
+      return STATUS_TO_ICON[this.status]
     },
   },
   methods: {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #289 by @zackkrida 

## Description
Adds a new `played` state to the AudioTrack triggered when the current time of the audio matches or exceeds the duration of the audio. When seeking during this state, it toggles back to `paused`. When hitting the play/pause button during the state, it will restart the audio from the beginning.


https://user-images.githubusercontent.com/24264157/136586058-cf0fe93a-fb29-4ce1-a555-40cd132e09c2.mov

I tried to implement this in the least intrusive way possible... In the course of that I added two new events to the AudioControlled (`finished` and `seeked`). The `seeked` event is probably the most problematic as it doesn't emit the timestamp or anything like that, which you could argue would make sense for a `seeked` event to do. But it wasn't necessary for this particular application of that event I was sort of thinking of a YAGNI kind of thing, to keep the event as minimal as possible for the time being. If in the future we need to add the timestamp it would be trivial to do (but I'm also open to adding it now if folks think it would make more sense that way, even though it's not needed for this particular instance).

I tried to think of a few different approaches to solving this problem but then all eventually hit dead ends... this was the least intrusive version of these changes I could come up with.

## Testing Instructions
Checkout this PR and run `npm run storybook` and navigate to `/?path=/story/components-audio-track--default-story`. Play around with the audio track and the new replay functionality and verify that the existing behavior continues to work (especially seeking) and that the new replay behavior works and makes sense.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
