### PR TITLE
Keep single image fetch state local

### DIFF
--- a/src/store-modules/search-store.js
+++ b/src/store-modules/search-store.js
@@ -212,18 +212,16 @@ const actions = (AudioService, ImageService) => ({
       sessionId: rootState.user.usageSessionId,
     })
 
-    commit(FETCH_START_MEDIA, { mediaType: IMAGE })
     commit(SET_IMAGE, { image: {} })
     return ImageService.getMediaDetail(params)
       .then(({ data }) => {
-        commit(FETCH_END_MEDIA, { mediaType: IMAGE })
         commit(SET_IMAGE, { image: data })
       })
       .catch((error) => {
         if (error.response && error.response.status === 404) {
           commit(MEDIA_NOT_FOUND, { mediaType: IMAGE })
         } else {
-          dispatch(HANDLE_MEDIA_ERROR, { mediaType: IMAGE, error })
+          throw new Error(`Error fetching the image: ${error}`)
         }
       })
   },

--- a/test/unit/specs/store/search-store.spec.js
+++ b/test/unit/specs/store/search-store.spec.js
@@ -455,12 +455,8 @@ describe('Search Store', () => {
         FETCH_IMAGE
       ]
       action({ commit, dispatch, state, rootState }, params).then(() => {
-        expect(commit).toBeCalledWith(FETCH_START_MEDIA, { mediaType: IMAGE })
         expect(commit).toBeCalledWith(SET_IMAGE, { image: {} })
-        expect(commit).toBeCalledWith(FETCH_END_MEDIA, { mediaType: IMAGE })
-
         expect(commit).toBeCalledWith(SET_IMAGE, { image: imageDetailData })
-
         expect(imageServiceMock.getMediaDetail).toBeCalledWith(params)
 
         done()
@@ -507,7 +503,6 @@ describe('Search Store', () => {
       const params = { id: 'foo' }
       const action = store.actions(failedMock, failedMock)[FETCH_IMAGE]
       action({ commit, dispatch, state, rootState }, params).then(() => {
-        expect(commit).toBeCalledWith(FETCH_START_MEDIA, { mediaType: IMAGE })
         expect(commit).toBeCalledWith(MEDIA_NOT_FOUND, { mediaType: IMAGE })
 
         done()


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #280 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR removes saving the fetch state (`isFetching` and `isFetchingError`) for the single image result from the main Vuex store (`search-store`). This makes the named variables only responsible for keeping the information related to the Search results.
The fetch state for single image is available as `$fetchState` in `photos/_id.vue`. Keeping it local is good because only one part of the app needs to access it.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
