### PR TITLE
Potential solution for DownloadButton height

### DIFF
--- a/src/components/AudioTrack/PlayPause.vue
+++ b/src/components/AudioTrack/PlayPause.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     type="button"
-    class="play-pause flex items-center justify-center bg-dark-charcoal text-white transition-shadow duration-100 ease-linear disabled:opacity-70 focus:outline-none focus-visible:ring focus-visible:ring-offset-2 focus-visible:ring-pink"
+    class="play-pause flex-shrink-0 flex items-center justify-center bg-dark-charcoal text-white transition-shadow duration-100 ease-linear disabled:opacity-70 focus:outline-none focus-visible:ring focus-visible:ring-offset-2 focus-visible:ring-pink"
     @click="handleClick"
   >
     <span class="sr-only">{{ label }}</span>

--- a/src/components/AudioTrack/layouts/Full.vue
+++ b/src/components/AudioTrack/layouts/Full.vue
@@ -2,8 +2,8 @@
   <div class="full-track w-full">
     <slot name="controller" />
 
-    <div class="flex flex-row justify-between mx-16 my-6">
-      <div class="left-content flex flex-row items-center gap-6">
+    <div class="flex flex-row justify-between items-top mx-16 my-6">
+      <div class="left-content flex flex-row items-top gap-6">
         <slot name="play-pause" />
 
         <div class="audio-info">

--- a/src/components/DropdownButton.vue
+++ b/src/components/DropdownButton.vue
@@ -146,7 +146,7 @@ export default DropdownButton
 
 <style lang="css" scoped>
 .dropdown-button {
-  @apply flex items-center justify-center bg-pink text-white font-bold p-2 px-4 transition-shadow duration-100 ease-linear disabled:opacity-70 focus:outline-none focus-visible:ring focus-visible:ring-offset-2 focus-visible:ring-pink hover:bg-dark-pink no-underline appearance-none;
+  @apply flex items-center justify-center bg-pink text-white font-bold p-4 leading-6 transition-shadow duration-100 ease-linear disabled:opacity-70 focus:outline-none focus-visible:ring focus-visible:ring-offset-2 focus-visible:ring-pink hover:bg-dark-pink no-underline appearance-none;
 }
 
 .dropdown-button-active {


### PR DESCRIPTION
Just a demo of a potential solution for the issue @obulat and I were discussing in https://github.com/WordPress/openverse-frontend/pull/288#discussion_r726159228

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
