### PR TITLE
Use CSS property `accent-color` to tint form controls

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -146,6 +146,7 @@ export default {
     '~/assets/fonts.css',
     '~/styles/vocabulary.scss',
     '~/styles/global.scss',
+    '~/styles/accent.scss',
   ],
   head,
   env,

--- a/src/styles/accent.scss
+++ b/src/styles/accent.scss
@@ -1,0 +1,22 @@
+:root {
+  /* Accent color tints checkbox, radio, range and progress. */
+  accent-color: theme('colors.trans-blue');
+}
+
+:focus-visible {
+  outline-color: theme('colors.trans-blue');
+}
+
+::selection {
+  /* Using white text because selection background is dark. */
+  @apply bg-trans-blue text-white;
+}
+
+::-webkit-calendar-picker-indicator,
+::-webkit-clear-button,
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button,
+::marker {
+  /* List markers can be tinted as text. */
+  @apply text-trans-blue;
+}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #222 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR sets the `trans-blue` color as the accent color on the HTML root so that it automatically applies to form controls such as
- checkboxes
- radio buttons
- sliders
- progress bars

Other elements such as selections, markers etc. are tinted using the proper CSS rules associated with them.

## Screenshots

With `trans-blue` accent:
![accent](https://user-images.githubusercontent.com/16580576/137726368-60a3c1a4-ca22-413a-a0e8-f4217fe4a1e5.png)

Without accent, default:
![default](https://user-images.githubusercontent.com/16580576/137726380-bf8b2245-012c-422a-baee-67227ccb808d.png)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Spin up the site using `npm run dev`.
2. See the new accent color.
3. In the dev tools toggle off the `accent-color` rule on the HTML root element.
4. See the default accent color.
5. Do step 3 repeatedly to see the slight difference between 2 and 4.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
