### PR TITLE
Add `dir` text direction attribute to layouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nuxt/components": "^2.1.6",
         "@nuxtjs/composition-api": "^0.27.0",
-        "@nuxtjs/i18n": "^7.0.1",
+        "@nuxtjs/i18n": "^7.0.3",
         "@nuxtjs/sentry": "^5.0.3",
         "@nuxtjs/sitemap": "^2.4.0",
         "@nuxtjs/svg": "^0.1.12",
@@ -39,7 +39,7 @@
         "sass": "^1.34.0",
         "sass-loader": "^10.1.1",
         "uuid": "^8.3.2",
-        "vue-i18n": "^8.24.3"
+        "vue-i18n": "^8.26.5"
       },
       "devDependencies": {
         "@babel/runtime-corejs3": "^7.15.3",
@@ -74,7 +74,7 @@
         "postcss": "^8.3.6",
         "prettier": "^2.2.1",
         "tailwindcss": "^2.2.7",
-        "vue-i18n-extract": "^1.2.0",
+        "vue-i18n-extract": "^2.0.0",
         "vue-jest": "^3.0.7"
       },
       "engines": {
@@ -202,11 +202,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
       "dependencies": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.6",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -345,35 +345,35 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -484,11 +484,11 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -2627,13 +2627,13 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2651,17 +2651,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2681,9 +2681,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -4981,21 +4981,22 @@
       }
     },
     "node_modules/@nuxtjs/i18n": {
-      "version": "7.0.1",
-      "integrity": "sha512-3BnUiKM94Cp5gjl3HVLyynsFIbo5fNaIm7f49AsfqJkQaAwEM40S+Jssu8doIIAnuctFNLuaqSuKV2fDUZFp1g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/i18n/-/i18n-7.1.0.tgz",
+      "integrity": "sha512-g8ynhA7JYZTwQXr+KQElDWe4zqB58k3fJhzjyse96S7SUtnday49P28oIakW+GKC5VzXNJqoE/lHFz7NteeVug==",
       "dependencies": {
-        "@babel/parser": "^7.14.9",
-        "@babel/traverse": "^7.14.9",
+        "@babel/parser": "^7.15.8",
+        "@babel/traverse": "^7.15.4",
         "@intlify/vue-i18n-extensions": "^1.0.2",
         "@intlify/vue-i18n-loader": "^1.1.0",
         "cookie": "^0.4.1",
         "devalue": "^2.0.1",
         "is-https": "^4.0.0",
-        "js-cookie": "^3.0.0",
+        "js-cookie": "^3.0.1",
         "klona": "^2.0.4",
         "lodash.merge": "^4.6.2",
-        "ufo": "^0.7.7",
-        "vue-i18n": "^8.25.0"
+        "ufo": "^0.7.9",
+        "vue-i18n": "^8.26.5"
       }
     },
     "node_modules/@nuxtjs/i18n/node_modules/is-https": {
@@ -5003,15 +5004,12 @@
       "integrity": "sha512-FeMLiqf8E5g6SdiVJsPcNZX8k4h2fBs1wp5Bb6uaNxn58ufK1axBqQZdmAQsqh0t9BuwFObybrdVJh6MKyPlyg=="
     },
     "node_modules/@nuxtjs/i18n/node_modules/js-cookie": {
-      "version": "3.0.0",
-      "integrity": "sha512-oUbbplKuH07/XX2YD2+Q+GMiPpnVXaRz8npE7suhBH9QEkJe2W7mQ6rwuMXHue3fpfcftQwzgyvGzIHyfCSngQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@nuxtjs/i18n/node_modules/vue-i18n": {
-      "version": "8.25.0",
-      "integrity": "sha512-ynhcL+PmTxuuSE1T10htiSXzjBozxYIE3ffbM1RfgAkVbr/v1SP+9Mi/7/uv8ZVV1yGuKjFAYp9BXq+X7op6MQ=="
     },
     "node_modules/@nuxtjs/sentry": {
       "version": "5.0.3",
@@ -12012,6 +12010,15 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.11",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.11.tgz",
+      "integrity": "sha512-m4xrA2MKfid6uDV2j2+0mXrtPGxlvAW0y+7Gnn2P8WVMSG+4e4tcoYX++94ZPblPfpBccJ5e7HvKdghlX5yiDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacache": {
@@ -37886,30 +37893,42 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
     },
     "node_modules/vue-i18n": {
-      "version": "8.24.3",
-      "integrity": "sha512-uKAYzGbwGIJndY7JwhQwIGi1uyvErWkBfFwooOtjcNnIfMbAR49ad5dT/MiykrJ9pCcgvnocFjFsNLtTzyW+rg=="
+      "version": "8.26.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.26.5.tgz",
+      "integrity": "sha512-qYqfsFd8v2QFSLDAabqXXXpwjGvkuqJtTWqRpZPXpAFO6PArGH4A9vSplnA0HLmnB8km7OB5ZSdP8lkkX0rLew=="
     },
     "node_modules/vue-i18n-extract": {
-      "version": "1.2.0",
-      "integrity": "sha512-k8FxCUE00wWrgDz8MX9XwfE6GlK59GTQGGoz+NRte+H+Cn/QkxSrOBehd9OuiYr9RGBapZl2sCghPa6L7EwcqQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vue-i18n-extract/-/vue-i18n-extract-2.0.4.tgz",
+      "integrity": "sha512-a2N9HBp1sSNErvjGDnRHWvXxKAy4DypoN91Pc4Seu9nDx4axBFY1ZGzlwUsL19HDR1n7YC7C233h/bAEnReK6Q==",
       "dev": true,
       "dependencies": {
-        "commander": "^6.1.0",
+        "cac": "^6.7.3",
         "dot-object": "^2.1.4",
         "glob": "^7.1.6",
         "is-valid-glob": "^1.0.0",
-        "js-yaml": "^3.14.0"
+        "js-yaml": "^4.1.0"
       },
       "bin": {
         "vue-i18n-extract": "bin/vue-i18n-extract.js"
       }
     },
-    "node_modules/vue-i18n-extract/node_modules/commander": {
-      "version": "6.2.1",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+    "node_modules/vue-i18n-extract/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/vue-i18n-extract/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "engines": {
-        "node": ">= 6"
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/vue-inbrowser-compiler-utils": {
@@ -39717,11 +39736,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
       "requires": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.6",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -39824,29 +39843,29 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -39930,11 +39949,11 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -40019,9 +40038,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA=="
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA=="
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.14.5",
@@ -41456,13 +41475,13 @@
       }
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -41476,17 +41495,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -41502,9 +41521,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -43340,21 +43359,22 @@
       }
     },
     "@nuxtjs/i18n": {
-      "version": "7.0.1",
-      "integrity": "sha512-3BnUiKM94Cp5gjl3HVLyynsFIbo5fNaIm7f49AsfqJkQaAwEM40S+Jssu8doIIAnuctFNLuaqSuKV2fDUZFp1g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/i18n/-/i18n-7.1.0.tgz",
+      "integrity": "sha512-g8ynhA7JYZTwQXr+KQElDWe4zqB58k3fJhzjyse96S7SUtnday49P28oIakW+GKC5VzXNJqoE/lHFz7NteeVug==",
       "requires": {
-        "@babel/parser": "^7.14.9",
-        "@babel/traverse": "^7.14.9",
+        "@babel/parser": "^7.15.8",
+        "@babel/traverse": "^7.15.4",
         "@intlify/vue-i18n-extensions": "^1.0.2",
         "@intlify/vue-i18n-loader": "^1.1.0",
         "cookie": "^0.4.1",
         "devalue": "^2.0.1",
         "is-https": "^4.0.0",
-        "js-cookie": "^3.0.0",
+        "js-cookie": "^3.0.1",
         "klona": "^2.0.4",
         "lodash.merge": "^4.6.2",
-        "ufo": "^0.7.7",
-        "vue-i18n": "^8.25.0"
+        "ufo": "^0.7.9",
+        "vue-i18n": "^8.26.5"
       },
       "dependencies": {
         "is-https": {
@@ -43362,12 +43382,9 @@
           "integrity": "sha512-FeMLiqf8E5g6SdiVJsPcNZX8k4h2fBs1wp5Bb6uaNxn58ufK1axBqQZdmAQsqh0t9BuwFObybrdVJh6MKyPlyg=="
         },
         "js-cookie": {
-          "version": "3.0.0",
-          "integrity": "sha512-oUbbplKuH07/XX2YD2+Q+GMiPpnVXaRz8npE7suhBH9QEkJe2W7mQ6rwuMXHue3fpfcftQwzgyvGzIHyfCSngQ=="
-        },
-        "vue-i18n": {
-          "version": "8.25.0",
-          "integrity": "sha512-ynhcL+PmTxuuSE1T10htiSXzjBozxYIE3ffbM1RfgAkVbr/v1SP+9Mi/7/uv8ZVV1yGuKjFAYp9BXq+X7op6MQ=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+          "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
         }
       }
     },
@@ -48661,6 +48678,12 @@
     "bytes": {
       "version": "3.0.0",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "cac": {
+      "version": "6.7.11",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.11.tgz",
+      "integrity": "sha512-m4xrA2MKfid6uDV2j2+0mXrtPGxlvAW0y+7Gnn2P8WVMSG+4e4tcoYX++94ZPblPfpBccJ5e7HvKdghlX5yiDA==",
+      "dev": true
     },
     "cacache": {
       "version": "15.0.6",
@@ -68453,25 +68476,37 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
     },
     "vue-i18n": {
-      "version": "8.24.3",
-      "integrity": "sha512-uKAYzGbwGIJndY7JwhQwIGi1uyvErWkBfFwooOtjcNnIfMbAR49ad5dT/MiykrJ9pCcgvnocFjFsNLtTzyW+rg=="
+      "version": "8.26.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.26.5.tgz",
+      "integrity": "sha512-qYqfsFd8v2QFSLDAabqXXXpwjGvkuqJtTWqRpZPXpAFO6PArGH4A9vSplnA0HLmnB8km7OB5ZSdP8lkkX0rLew=="
     },
     "vue-i18n-extract": {
-      "version": "1.2.0",
-      "integrity": "sha512-k8FxCUE00wWrgDz8MX9XwfE6GlK59GTQGGoz+NRte+H+Cn/QkxSrOBehd9OuiYr9RGBapZl2sCghPa6L7EwcqQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vue-i18n-extract/-/vue-i18n-extract-2.0.4.tgz",
+      "integrity": "sha512-a2N9HBp1sSNErvjGDnRHWvXxKAy4DypoN91Pc4Seu9nDx4axBFY1ZGzlwUsL19HDR1n7YC7C233h/bAEnReK6Q==",
       "dev": true,
       "requires": {
-        "commander": "^6.1.0",
+        "cac": "^6.7.3",
         "dot-object": "^2.1.4",
         "glob": "^7.1.6",
         "is-valid-glob": "^1.0.0",
-        "js-yaml": "^3.14.0"
+        "js-yaml": "^4.1.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "6.2.1",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@nuxt/components": "^2.1.6",
     "@nuxtjs/composition-api": "^0.27.0",
-    "@nuxtjs/i18n": "^7.0.1",
+    "@nuxtjs/i18n": "^7.0.3",
     "@nuxtjs/sentry": "^5.0.3",
     "@nuxtjs/sitemap": "^2.4.0",
     "@nuxtjs/svg": "^0.1.12",
@@ -64,7 +64,7 @@
     "sass": "^1.34.0",
     "sass-loader": "^10.1.1",
     "uuid": "^8.3.2",
-    "vue-i18n": "^8.24.3"
+    "vue-i18n": "^8.26.5"
   },
   "devDependencies": {
     "@babel/runtime-corejs3": "^7.15.3",
@@ -99,7 +99,7 @@
     "postcss": "^8.3.6",
     "prettier": "^2.2.1",
     "tailwindcss": "^2.2.7",
-    "vue-i18n-extract": "^1.2.0",
+    "vue-i18n-extract": "^2.0.0",
     "vue-jest": "^3.0.7"
   },
   "engines": {

--- a/src/components/LocaleSelector.vue
+++ b/src/components/LocaleSelector.vue
@@ -16,12 +16,13 @@
         </svg>
       </span>
       <div class="select">
-        <select ref="select" aria-labelledby="locale-label" @change="setLocale">
-          <option :key="$i18n.locale" :value="$i18n.locale">
-            {{ $i18n.localeProperties.name }}
-          </option>
+        <select
+          ref="select"
+          v-model="currentLocale"
+          aria-labelledby="locale-label"
+        >
           <option
-            v-for="locale in otherAvailableLocales"
+            v-for="locale in $i18n.locales"
             :key="locale.code"
             :value="locale.code"
           >
@@ -50,13 +51,13 @@ export default {
     }
   },
   computed: {
-    otherAvailableLocales() {
-      return this.$i18n.locales.filter((i) => i.code !== this.$i18n.locale)
-    },
-  },
-  methods: {
-    setLocale(event) {
-      this.$i18n.setLocale(event.target.value)
+    currentLocale: {
+      get() {
+        return this.$i18n.locale
+      },
+      set(val) {
+        this.$i18n.setLocale(val)
+      },
     },
   },
 }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -12,7 +12,7 @@ const defaultPage = {
   name: 'default',
   layout: 'default',
   head() {
-    return this.$nuxtI18nHead({ addSeoAttributes: true })
+    return this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true })
   },
 }
 export default defaultPage

--- a/src/layouts/embedded-with-nav-search.vue
+++ b/src/layouts/embedded-with-nav-search.vue
@@ -17,7 +17,7 @@ const embeddedWithNavSearch = {
   layout: 'embedded-with-nav-search',
   mixins: [iframeHeight, i18nSync],
   head() {
-    return this.$nuxtI18nHead({ addSeoAttributes: true })
+    return this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true })
   },
   computed: { ...mapState('nav', ['isReferredFromCc']) },
 }

--- a/src/layouts/embedded.vue
+++ b/src/layouts/embedded.vue
@@ -17,7 +17,7 @@ const embeddedPage = {
   layout: 'embedded',
   mixins: [iframeHeight, i18nSync],
   head() {
-    return this.$nuxtI18nHead({ addSeoAttributes: true })
+    return this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true })
   },
   computed: { ...mapState('nav', ['isReferredFromCc']) },
 }

--- a/src/layouts/with-nav-search.vue
+++ b/src/layouts/with-nav-search.vue
@@ -12,7 +12,7 @@ const withNavSearch = {
   name: 'with-nav-search',
   layout: 'with-nav-search',
   head() {
-    return this.$nuxtI18nHead({ addSeoAttributes: true })
+    return this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true })
   },
 }
 export default withNavSearch


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #343 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR sets the `dir` attribute to the `<html>` attribute to enable RTL detection from HTML. It `addDirAttribute` property true in the `$nuxtI18nHead` call in the layout components to `true`.
It also updates the i18n-related dependencies to latest versions. 
I have tried setting `$nuxtI18nHead` centrally in the `nuxt.config.js` (which is available since `7.0.3` only, and not available in `7.0.1`, which it took me too long to find out 😭 ). However, it requires quite a lot of refactoring. Since `head` property becomes a function, it is evaluated differently, with the variables from the `nuxt.config.js` file (`meta`, `head`) becoming unavailable.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app using `npm run dev`, and open the stand-alone version in your browser by going to `http://localhost:8443/?embedded=false`. Then, you can change the locale using the dropdown in the footer and notice the change in `hmtl` element's `dir` attribute.
You will also see how much we need tailwind-rtl from #336 to improve the experience, especially for the search box :)
<img width="815" alt="image" src="https://user-images.githubusercontent.com/15233243/138077898-b452f6bd-e421-4c2d-b43e-545a448ab365.png">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
