### PR TITLE
Fix placeholder replacement

### DIFF
--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2021-10-15T17:05:38+00:00\n"
+"POT-Creation-Date: 2021-10-21T17:13:21+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -18,7 +18,7 @@ msgctxt "interpunct"
 msgid "•"
 msgstr ""
 
-#: src/components/DownloadButton.vue:13
+#: src/components/DownloadButton.vue:14
 msgctxt "download-button.download"
 msgid "Download"
 msgstr ""
@@ -44,7 +44,7 @@ msgctxt "migration-notice.read"
 msgid "Read more"
 msgstr ""
 
-#: src/components/DropdownButton.vue:66
+#: src/components/DropdownButton.vue:71
 msgctxt "dropdown-button.aria.arrow-label"
 msgid "Dropdown"
 msgstr ""
@@ -1514,33 +1514,33 @@ msgctxt "meta-search-page.use"
 msgid " Use "
 msgstr ""
 
-#: src/pages/meta-search.vue:82
+#: src/pages/meta-search.vue:80
 msgctxt "meta-search-page.why.title"
 msgid "Why did you build this?"
 msgstr ""
 
-#: src/pages/meta-search.vue:84
+#: src/pages/meta-search.vue:82
 msgctxt "meta-search-page.why.content"
 msgid "For many years, CC has offered its users a dedicated search portal for searching platforms that have CC licensing filters built in. These platforms included Europeana, Google Images, Flickr, Jamendo, Open Clip Art Library, SpinXpress, Wikimedia Commons, YouTube, ccMixter, and SoundCloud. The search experience looked like this:"
 msgstr ""
 
-#: src/pages/meta-search.vue:92
+#: src/pages/meta-search.vue:90
 msgctxt "meta-search-page.why.new"
 msgid "For users of the legacy CC Meta Search site, the Meta Search feature on Openverse will look familiar. The goal was to ensure that the functionality is not lost, but is updated and embedded within our new search engine for openly licensed content. In addition, the Meta Search feature builds on this functionality, allowing us to quickly add new sources to Meta Search as we discover them, and support new content types in the future, as we expand."
 msgstr ""
 
-#: src/pages/meta-search.vue:97
+#: src/pages/meta-search.vue:95
 msgctxt "meta-search-page.why.aria-label"
 msgid "feedback"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/pages/meta-search.vue:94
+#: src/pages/meta-search.vue:92
 msgctxt "meta-search-page.why.feedback-suggestions"
 msgid "We hope you enjoy, and if you have suggestions for improvement, leave us ###feedback###."
 msgstr ""
 
-#: src/pages/meta-search.vue:99
+#: src/pages/meta-search.vue:97
 msgctxt "meta-search-page.why.feedback-link"
 msgid "feedback"
 msgstr ""
@@ -1561,7 +1561,7 @@ msgctxt "meta-search-page.new.issue"
 msgid "issue"
 msgstr ""
 
-#: src/pages/meta-search.vue:77
+#: src/pages/meta-search.vue:75
 msgctxt "meta-search-page.new.email"
 msgid "email"
 msgstr ""

--- a/src/locales/scripts/get-translations.js
+++ b/src/locales/scripts/get-translations.js
@@ -41,7 +41,7 @@ const replacePlaceholders = (json) => {
     return null
   }
   if (typeof json === 'string') {
-    return json.replace(/###([a-zA-Z-]*)###/, '{$1}')
+    return json.replace(/###([a-zA-Z-]*)###/g, '{$1}')
   }
   let currentJson = { ...json }
 

--- a/src/locales/scripts/valid-locales.json
+++ b/src/locales/scripts/valid-locales.json
@@ -78,6 +78,13 @@
     "file": "es-co.json"
   },
   {
+    "code": "es-do",
+    "name": "Spanish (Dominican Republic)",
+    "iso": "es",
+    "wpLocale": "es_DO",
+    "file": "es-do.json"
+  },
+  {
     "code": "es-ec",
     "name": "Spanish (Ecuador)",
     "iso": "es",


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #340 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the bug in which only the first `###placeholder###` in an `ngx` translated string was converted into the expected `{placeholder}` form. The fix was adding the `g` global flag to the regex expression.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
First, to see the problem, you can checkout main branch, run `npm i18n:get-translations`, and search for `###` in the locales folder. You will see that there are `###` placeholders left in the json files.
Then, when you checkout this branch, run  `npm i18n:get-translations`, and search for `###` in the locales folder, you should see that these placeholders are only found in the `pot` files.
i18n:get-translations

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
