### PR TITLE
Move setting search type from subpages into the search page

### DIFF
--- a/src/components/AudioResultsList.vue
+++ b/src/components/AudioResultsList.vue
@@ -52,7 +52,6 @@ import { mapActions, mapState } from 'vuex'
 export default {
   name: 'AudioResultsList',
   props: {
-    query: {},
     includeAnalytics: {
       default: true,
     },
@@ -60,13 +59,13 @@ export default {
   async fetch() {
     if (!this.audios.length) {
       await this.fetchMedia({
-        ...this.$store.state.query,
+        ...this.query,
         mediaType: AUDIO,
       })
     }
   },
   computed: {
-    ...mapState(['audios', 'errorMessage', 'isFilterVisible']),
+    ...mapState(['audios', 'errorMessage', 'isFilterVisible', 'query']),
     ...mapState({
       isFetchingAudios: 'isFetching.audios',
       isFetchingAudiosError: 'isFetchingError.audios',

--- a/src/pages/search.vue
+++ b/src/pages/search.vue
@@ -22,13 +22,20 @@
   </div>
 </template>
 <script>
-import { FETCH_MEDIA, SET_SEARCH_TYPE_FROM_URL } from '~/constants/action-types'
+import {
+  FETCH_MEDIA,
+  SET_SEARCH_TYPE_FROM_URL,
+  UPDATE_SEARCH_TYPE,
+} from '~/constants/action-types'
 import {
   SET_QUERY,
   SET_FILTER_IS_VISIBLE,
   SET_FILTERS_FROM_URL,
 } from '~/constants/mutation-types'
-import { queryStringToQueryData } from '~/utils/search-query-transform'
+import {
+  queryStringToQueryData,
+  queryStringToSearchType,
+} from '~/utils/search-query-transform'
 import local from '~/utils/local'
 import { screenWidth } from '~/utils/get-browser-info'
 import { ALL_MEDIA, IMAGE } from '~/constants/media'
@@ -80,6 +87,7 @@ const BrowsePage = {
     ...mapActions({
       fetchMedia: FETCH_MEDIA,
       setSearchTypeFromUrl: SET_SEARCH_TYPE_FROM_URL,
+      updateSearchType: UPDATE_SEARCH_TYPE,
     }),
     ...mapMutations({
       setQuery: SET_QUERY,
@@ -116,6 +124,10 @@ const BrowsePage = {
         this.$router.push(newPath)
         this.getMediaItems(newQuery, this.mediaType)
       }
+    },
+    $route(route) {
+      const searchType = queryStringToSearchType(route.path)
+      this.updateSearchType({ searchType })
     },
   },
 }

--- a/src/pages/search/audio.vue
+++ b/src/pages/search/audio.vue
@@ -1,19 +1,12 @@
 <!-- noresult is hardcoded since it does not yet support built-in audio search -->
 <template>
   <div id="tab-audio" role="tabpanel" aria-labelledby="audio">
-    <AudioResultsList
-      v-if="supported"
-      :query="query"
-      @onLoadMoreAudios="onLoadMoreAudios"
-    />
+    <AudioResultsList v-if="supported" @onLoadMoreAudios="onLoadMoreAudios" />
     <MetaSearchForm type="audio" :noresult="false" :supported="supported" />
   </div>
 </template>
 
 <script>
-import { UPDATE_SEARCH_TYPE } from '~/constants/action-types'
-import { AUDIO } from '~/constants/media'
-
 export default {
   name: 'AudioSearch',
   data() {
@@ -21,14 +14,6 @@ export default {
       // Only show audio results if non-image results are supported
       supported: process.env.enableAudio,
     }
-  },
-  computed: {
-    query() {
-      return this.$store.state.query
-    },
-  },
-  async mounted() {
-    await this.$store.dispatch(UPDATE_SEARCH_TYPE, { searchType: AUDIO })
   },
   methods: {
     onLoadMoreAudios(searchParams) {

--- a/src/pages/search/image.vue
+++ b/src/pages/search/image.vue
@@ -8,14 +8,8 @@
 </template>
 
 <script>
-import { UPDATE_SEARCH_TYPE } from '~/constants/action-types'
-import { IMAGE } from '~/constants/media'
-
 export default {
   name: 'ImageSearch',
-  async mounted() {
-    await this.$store.dispatch(UPDATE_SEARCH_TYPE, { searchType: IMAGE })
-  },
   methods: {
     onLoadMoreImages(searchParams) {
       this.$emit('onLoadMoreItems', searchParams)

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -8,14 +8,8 @@
 </template>
 
 <script>
-import { UPDATE_SEARCH_TYPE } from '~/constants/action-types'
-import { ALL_MEDIA } from '~/constants/media'
-
 export default {
   name: 'SearchIndex',
-  async mounted() {
-    await this.$store.dispatch(UPDATE_SEARCH_TYPE, { searchType: ALL_MEDIA })
-  },
   methods: {
     onLoadMoreImages(searchParams) {
       this.$emit('onLoadMoreItems', searchParams)

--- a/src/pages/search/video.vue
+++ b/src/pages/search/video.vue
@@ -10,13 +10,7 @@
 </template>
 
 <script>
-import { UPDATE_SEARCH_TYPE } from '~/constants/action-types'
-import { VIDEO } from '~/constants/media'
-
 export default {
   name: 'VideoSearch',
-  async mounted() {
-    await this.$store.dispatch(UPDATE_SEARCH_TYPE, { searchType: VIDEO })
-  },
 }
 </script>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #361 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR moves the detection of search media type, and updating the Vuex Store `searchType` value from the four separate sub-pages (NuxtChild) to the parent search page. It detects the route.path change, and updates the searchType when necesssary.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app, search for 'cat', open the sidebar filters, and watch how it displays the media-specific filters (eg. ImageType for image, Audio Extensions for audio, or nothing for video which is not yet supported) when you change tabs.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
