### PR TITLE
Set default English locale correctly

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -175,9 +175,13 @@ export default {
   i18n: {
     locales: [
       {
+        // unique identifier for the locale in Vue i18n
         code: 'en',
         name: 'English',
+        // ISO code used for SEO purposes (html lang attribute)
         iso: 'en',
+        // wp_locale as found in GlotPress
+        wpLocale: 'en_US',
         file: 'en.json',
       },
       ...(locales ?? []),
@@ -204,6 +208,7 @@ export default {
     dsn:
       process.env.SENTRY_DSN ||
       'https://3f3e05dbe6994c318d1bf1c8bfcf71a1@o288582.ingest.sentry.io/1525413',
+    disabled: process.env.NODE_ENV !== 'production',
     lazy: true,
   },
   tailwindcss: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -208,7 +208,6 @@ export default {
     dsn:
       process.env.SENTRY_DSN ||
       'https://3f3e05dbe6994c318d1bf1c8bfcf71a1@o288582.ingest.sentry.io/1525413',
-    disabled: process.env.NODE_ENV !== 'production',
     lazy: true,
   },
   tailwindcss: {

--- a/src/mixins/i18n-sync.js
+++ b/src/mixins/i18n-sync.js
@@ -5,20 +5,28 @@ export default {
   methods: {
     /**
      * Handles messages of type `localeSet` received by the `iframe`. Any
-     * other message types will by discarded.
+     * other message types will be discarded.
      *
-     * @param {string} type - the nature of the message received
-     * @param {{ locale: string, lang: string }} value - the data sent with the message
+     * @param {string} type - the nature of the message received.
+     * @param {Object} value - the data sent with the message.
+     * @param {string} value.locale - wpLocale code of the locale, e.g. 'en_US'.
+     * @param {string} value.lang - the iso code for language
+     * (and sometimes country), e.g. 'en-US'.
+     * Default lang value on wp.org is 'en', and on wp.org/openverse - 'en-US'.
+     * @param {'rtl'|'ltr'} [value.dir] - the locale text direction.
      */
-    localeMsgHandler({ data: { type, value } }) {
+    async localeMsgHandler({ data: { type, value } }) {
       if (type !== 'localeSet') return
-
+      // If the locale set by wp.org is 'en_US', not 'en', this is not necessary.
+      const wpLocaleValue = value.locale === 'en' ? 'en_US' : value.locale
       const locale = this.$i18n.locales.find(
-        (item) => item.wpLocale === value.locale
+        (item) => item.wpLocale === wpLocaleValue
       )
       if (locale) {
-        this.$i18n.setLocale(locale.code)
-        document.documentElement.lang = value.lang
+        await this.$i18n.setLocale(locale.code)
+        document.documentElement.lang = locale.wpLocale.replace('_', '-')
+        // Always set `dir` property, default to 'ltr'
+        document.documentElement.dir = locale.dir === 'rtl' ? 'rtl' : 'ltr'
       }
     },
   },


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #308 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a `wpLocale` property to the default English locale. This makes it possible to set the locale cookie when the message from wp theme is received.  It also adds the default locale as a fallback for 'en'. I am not sure if it's necessary because I can't test what locale is passed from wp theme in production, but the `lang` property on HTML on wp.org site is set to `en`, unlike the `lang` property on wp.org/openverse, which is set to `en-US` by default, so I added the fallback to be sure.

### How locales are set
When you go to `wp.org/openverse`, the wp theme sets the wp `locale` property, and the `lang` and `dir` properties on the `html` element based on the subdomain. For Openverse currently only English subdomain is available, but other subdomains will be used soon.

_I found the list of subdomains for different languages for wp.org [in pattern-directory repository](https://github.com/WordPress/pattern-directory/blob/ff09c1afe4fad91686b9d41b508b5fc4cdfa7c13/.wp-env/data/wporg_locales.sql). Most of them are the same as the `slug` property in GlotPress locale list, but some are not (for example, Brazilian Portuguese site is at br.wordpress.org, although the `slug` for it is `pt-br`)._

The Nuxt app layouts, on mounting, send a message to the wp theme, which then sends the message with `locale`, `lang` and `dir` properties.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
This is going to be difficult :) 
1. Run the Openverse WordPress theme ([excellent instructions in the wp.org repo](https://github.com/WordPress/wordpress.org/tree/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse)).
2. Remove any i18n-redirected cookies in your browser.
2. Don't forget to change the Openverse embed to the local Nuxt app that should be running at localhost:8443 on this page: http://localhost:8888/wp-admin/customize.php.
3. See that the `i18n-redirected` cookie is set to `en`.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
