### PR TITLE
Persist search term across pages

### DIFF
--- a/src/components/NavSection.vue
+++ b/src/components/NavSection.vue
@@ -139,13 +139,13 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 
 import Dropdown from '~/components/Dropdown'
 import VIcon from '~/components/VIcon/VIcon.vue'
 
-import { UPDATE_QUERY } from '~/constants/action-types'
-import { SEARCH } from '~/constants/store-modules'
+import { FETCH_MEDIA, UPDATE_QUERY } from '~/constants/action-types'
+import { MEDIA, SEARCH } from '~/constants/store-modules'
 
 import OpenverseLogo from '~/assets/logo.svg?inline'
 import externalLinkIcon from '~/assets/icons/external-link.svg'
@@ -168,17 +168,24 @@ export default {
     externalLinkIcon,
   }),
   computed: {
+    ...mapState(SEARCH, ['query']),
     navSearchPlaceholder() {
       return this.$t('header.placeholder')
     },
   },
+  mounted() {
+    this.form.searchTerm = this.query.q
+  },
   methods: {
     ...mapActions(SEARCH, { setSearchTerm: UPDATE_QUERY }),
+    ...mapActions(MEDIA, { fetchMedia: FETCH_MEDIA }),
     onSubmit() {
       const q = this.form.searchTerm
+      const mediaType = this.query.mediaType
       this.setSearchTerm({ q })
+      this.fetchMedia({ q, mediaType })
       const newPath = this.localePath({
-        path: '/search',
+        path: `/search/${mediaType}`,
         query: { q },
       })
       this.$router.push(newPath)

--- a/test/unit/specs/components/nav-section.spec.js
+++ b/test/unit/specs/components/nav-section.spec.js
@@ -3,13 +3,9 @@ import render from '../../test-utils/render'
 import { createLocalVue } from '@vue/test-utils'
 import NavSection from '~/components/NavSection'
 import { UPDATE_QUERY } from '~/constants/action-types'
+import { IMAGE } from '~/constants/media'
 
 describe('NavSection', () => {
-  it('should render correct contents', () => {
-    const wrapper = render(NavSection, { stubs: { NuxtLink: true } })
-    expect(wrapper.find('nav').vm).toBeDefined()
-  })
-
   it('dispatches an action when the form is submitted', async () => {
     const localVue = createLocalVue()
     localVue.use(Vuex)
@@ -18,6 +14,9 @@ describe('NavSection', () => {
       modules: {
         search: {
           namespaced: true,
+          state: {
+            query: { q: 'foo', mediaType: IMAGE },
+          },
           actions: {
             [UPDATE_QUERY]: dispatchMock,
           },
@@ -37,10 +36,9 @@ describe('NavSection', () => {
     }
 
     const wrapper = render(NavSection, options)
-    await wrapper.setData({ form: { searchTerm: 'foo' } })
     wrapper.find('.search-form').trigger('submit')
     expect(routerMock.push).toHaveBeenCalledWith({
-      path: '/search',
+      path: '/search/image',
       query: { q: 'foo' },
     })
     const dispatchArgs = dispatchMock.mock.calls[0][1]


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #348 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR persists the search term (and search media type) across the pages. So, if the user has entered a search term, it will stay there even if the user opens the Single result page or any of the content pages (e.g. About).

In Redesign, there will be a single search input that will automatically have the same search term. This is just a temporary quick fix.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app using `npm run dev`, search for something, and click on a single image.
You should see that the search input in the header has your search term in it.
Open 'About' page, and you should see the same search term there as well.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
