### PR TITLE
Fix filters modal position in iframe

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -1,22 +1,16 @@
 <template>
   <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
-  <div ref="modal" class="overlay app-modal" @click.self="$emit('close')">
+  <div
+    ref="modal"
+    class="overlay app-modal fixed w-full flex justify-center z-50 bg-dark-charcoal bg-opacity-75"
+    @click.self="$emit('close')"
+  >
     <FocusTrap :active="true">
-      <div class="modal relative" aria-modal="true" role="dialog">
-        <header v-if="title" class="modal-header pt-8 ps-8 pe-4 pb-2">
-          <slot name="header">
-            <h3>{{ title }}</h3>
-          </slot>
-          <button
-            type="button"
-            class="close-button text-gray text-lgr lg:text-base"
-            :aria-label="$t('browse-page.aria.close')"
-            @click="$emit('close')"
-            @keypress.enter="$emit('close')"
-          >
-            <i class="icon cross" />
-          </button>
-        </header>
+      <div
+        class="rounded mt-10 mb-80 min-h-min bg-white"
+        aria-modal="true"
+        role="dialog"
+      >
         <slot default />
       </div>
     </FocusTrap>
@@ -54,54 +48,3 @@ export default {
   },
 }
 </script>
-
-<style lang="scss" scoped>
-.modal {
-  position: relative;
-  margin: 0px auto;
-  max-width: 85vw;
-  max-height: 85vh;
-  overflow-x: hidden;
-  overflow-y: auto;
-  border-radius: 2px;
-  box-shadow: 0 2px 8px 3px;
-  background-color: #fff;
-}
-
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 100%;
-  z-index: 600;
-  background: #00000094;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-around;
-  align-items: flex-start;
-  width: 100%;
-}
-
-.close-button {
-  appearance: none;
-  border: none;
-  height: auto;
-  margin: -20px -20px -20px auto;
-  padding: 20px;
-  background-color: transparent;
-  line-height: 1;
-  cursor: pointer;
-  .icon {
-    height: auto;
-  }
-  &:hover {
-    color: rgb(120, 120, 120);
-  }
-}
-</style>

--- a/src/locales/scripts/wp-locales.json
+++ b/src/locales/scripts/wp-locales.json
@@ -385,7 +385,7 @@
     "facebookLocale": "da_DK",
     "wpLocale": "da_DK",
     "code": "da",
-    "translated": 100
+    "translated": 99
   },
   "de_AT": {
     "name": "German (Austria)",
@@ -467,7 +467,7 @@
     "facebookLocale": "el_GR",
     "wpLocale": "el",
     "code": "el",
-    "translated": 0
+    "translated": 9
   },
   "en_AU": {
     "name": "English (Australia)",
@@ -479,7 +479,7 @@
     "googleCode": "en",
     "wpLocale": "en_AU",
     "code": "en-au",
-    "translated": 20
+    "translated": 19
   },
   "en_CA": {
     "name": "English (Canada)",
@@ -491,7 +491,7 @@
     "googleCode": "en",
     "wpLocale": "en_CA",
     "code": "en-ca",
-    "translated": 95
+    "translated": 94
   },
   "en_GB": {
     "name": "English (UK)",
@@ -528,7 +528,7 @@
     "googleCode": "en",
     "wpLocale": "en_ZA",
     "code": "en-za",
-    "translated": 95
+    "translated": 94
   },
   "eo": {
     "name": "Esperanto",
@@ -553,7 +553,7 @@
     "facebookLocale": "es_LA",
     "wpLocale": "es_AR",
     "code": "es-ar",
-    "translated": 100
+    "translated": 99
   },
   "es_CL": {
     "name": "Spanish (Chile)",
@@ -605,7 +605,7 @@
     "facebookLocale": "es_LA",
     "wpLocale": "es_DO",
     "code": "es-do",
-    "translated": 95
+    "translated": 94
   },
   "es_EC": {
     "name": "Spanish (Ecuador)",
@@ -848,7 +848,7 @@
     "facebookLocale": "fr_FR",
     "wpLocale": "fr_FR",
     "code": "fr",
-    "translated": 90
+    "translated": 89
   },
   "frp": {
     "name": "Arpitan",
@@ -941,7 +941,7 @@
     "facebookLocale": "gl_ES",
     "wpLocale": "gl_ES",
     "code": "gl",
-    "translated": 98
+    "translated": 100
   },
   "gu": {
     "name": "Gujarati",
@@ -1101,7 +1101,7 @@
     "facebookLocale": "id_ID",
     "wpLocale": "id_ID",
     "code": "id",
-    "translated": 57
+    "translated": 56
   },
   "ido": {
     "name": "Ido",
@@ -1138,7 +1138,7 @@
     "facebookLocale": "it_IT",
     "wpLocale": "it_IT",
     "code": "it",
-    "translated": 12
+    "translated": 44
   },
   "ja": {
     "name": "Japanese",
@@ -1589,7 +1589,7 @@
     "facebookLocale": "nl_NL",
     "wpLocale": "nl_NL",
     "code": "nl",
-    "translated": 99
+    "translated": 98
   },
   "nn_NO": {
     "name": "Norwegian (Nynorsk)",
@@ -1798,7 +1798,7 @@
     "facebookLocale": "ru_RU",
     "wpLocale": "ru_RU",
     "code": "ru",
-    "translated": 52
+    "translated": 51
   },
   "sa_IN": {
     "name": "Sanskrit",
@@ -1929,7 +1929,7 @@
     "facebookLocale": "sq_AL",
     "wpLocale": "sq",
     "code": "sq",
-    "translated": 99
+    "translated": 98
   },
   "sq_XK": {
     "name": "Shqip (Kosovo)",
@@ -2002,7 +2002,7 @@
     "facebookLocale": "sv_SE",
     "wpLocale": "sv_SE",
     "code": "sv",
-    "translated": 72
+    "translated": 71
   },
   "sw": {
     "name": "Swahili",
@@ -2335,7 +2335,7 @@
     "facebookLocale": "zh_CN",
     "wpLocale": "zh_CN",
     "code": "zh-cn",
-    "translated": 61
+    "translated": 60
   },
   "zh_HK": {
     "name": "Chinese (Hong Kong)",
@@ -2374,7 +2374,7 @@
     "facebookLocale": "zh_TW",
     "wpLocale": "zh_TW",
     "code": "zh-tw",
-    "translated": 30
+    "translated": 29
   },
   "zul": {
     "name": "Zulu",


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #536 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I ripped out some of the modal stuff like the title and close button. We only have one place the modal is used and it doesn't employ the title prop at all so instead of trying to fix something we don't use, I just took it out.

This is definitely a hacky solution but it does work as a holdover until we can figure out a better one.

Unforunately being inside an iframe makes having modals that make any sense and work as expected basically impossible, but we can put in some stop-gap solutions for now.

<img width="664" alt="Captura de Tela 2021-12-17 às 08 04 32" src="https://user-images.githubusercontent.com/24264157/146574545-3f12839a-ce53-4681-98a1-0ed3105c3936.png">

<img width="664" alt="Captura de Tela 2021-12-17 às 08 04 37" src="https://user-images.githubusercontent.com/24264157/146574559-03dd0d85-dcc5-4d73-b7c8-f8fa12ef6a88.png">

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch then run `npm run dev`. Run the wporg-openverse theme following [these instructions](https://github.com/WordPress/wordpress.org/blob/0c2992b5dce25ea6c2c959cf6b41a6a2372a1845/wordpress.org/public_html/wp-content/themes/pub/wporg-openverse/README.md#L9). Visit localhost:8888, do a search and open the filters modal by making your viewport match a small width device.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
