### PR TITLE
Remove hardcoded scrollbar styles, fixed header, and hide sidebar on non search views

### DIFF
--- a/src/components/VHeader/VHeader.vue
+++ b/src/components/VHeader/VHeader.vue
@@ -15,7 +15,8 @@
         to="/"
         class="rounded-sm ring-offset-1 focus:outline-none focus-visible:ring focus-visible:ring-pink -ms-2 inline-flex items-center hover:bg-yellow mr-auto"
         :class="{
-          'pe-3': !isSearchRoute || (isSearchRoute && !isHeaderScrolled),
+          'pe-3 md:pe-0': isSearchRoute && !isHeaderScrolled,
+          'md:pe-3': !isSearchRoute,
         }"
       >
         <VLogoLoader :status="isFetching ? 'loading' : 'idle'" />

--- a/src/components/VHeader/VHeader.vue
+++ b/src/components/VHeader/VHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    class="fixed top-0 flex py-4 px-4 md:px-7 items-stretch z-40 w-full bg-white md:gap-x-2"
+    class="sticky top-0 flex py-4 px-4 md:px-7 items-stretch z-40 w-full bg-white md:gap-x-2"
     :class="{
       'border-b border-white': !isHeaderScrolled && !isMenuOpen,
       'border-b border-dark-charcoal-20':
@@ -13,11 +13,9 @@
     <div class="one-third items-stretch flex">
       <NuxtLink
         to="/"
-        class="rounded-sm ring-offset-1 focus:outline-none focus-visible:ring focus-visible:ring-pink -ms-2 inline-flex items-center hover:bg-yellow"
+        class="rounded-sm ring-offset-1 focus:outline-none focus-visible:ring focus-visible:ring-pink -ms-2 inline-flex items-center hover:bg-yellow mr-auto"
         :class="{
-          'md:pe-3': !isHeaderScrolled || !isSearchRoute,
-          'md:px-0': isSearchRoute,
-          'me-10 lg:me-30': !isSearchRoute,
+          'pe-3': !isSearchRoute || (isSearchRoute && !isHeaderScrolled),
         }"
       >
         <VLogoLoader :status="isFetching ? 'loading' : 'idle'" />

--- a/src/components/VHeader/VHeader.vue
+++ b/src/components/VHeader/VHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    class="sticky top-0 flex py-4 px-4 md:px-7 items-stretch z-40 w-full bg-white md:gap-x-2"
+    class="flex py-4 px-4 md:px-7 items-stretch z-40 w-full bg-white md:gap-x-2"
     :class="{
       'border-b border-white': !isHeaderScrolled && !isMenuOpen,
       'border-b border-dark-charcoal-20':

--- a/src/components/VScrollButton.vue
+++ b/src/components/VScrollButton.vue
@@ -36,10 +36,7 @@ export default {
   },
   methods: {
     scrollToTop() {
-      const elementToScroll = this.isFilterVisible
-        ? this.$el.parentElement.parentElement
-        : this.$el.closest('main')
-      elementToScroll.scrollTo({
+      this.$el.parentElement.scrollTo({
         top: 0,
         left: 0,
         behavior: 'smooth',

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -4,16 +4,13 @@
     <TranslationStatusBanner />
     <VHeader v-if="!isHomeRoute" />
     <main
-      ref="mainRef"
       class="main embedded overflow-x-hidden"
       :class="{
         'has-sidebar': isSidebarVisible,
-        'mt-[81px]': !headerHasTwoRows,
-        'mt-[145px]': headerHasTwoRows,
       }"
     >
       <Nuxt ref="mainContentRef" class="min-w-0 main-page" />
-      <VSidebarTarget class="sidebar" />
+      <VSidebarTarget v-show="!isHomeRoute" class="sidebar" />
     </main>
     <VModalTarget class="modal" />
   </div>
@@ -76,17 +73,11 @@ const embeddedPage = {
     const scrollY = ref(0)
     const { isScrolled: isMainContentScrolled, y: mainContentY } =
       useScroll(mainContentRef)
-    const { isScrolled: isMainScrolled, y: mainY } = useScroll(mainRef)
-    watch(
-      [isMainContentScrolled, isMainScrolled],
-      ([isMainContentScrolled, isMainScrolled]) => {
-        isHeaderScrolled.value = isSidebarVisible.value
-          ? isMainContentScrolled
-          : isMainScrolled
-      }
-    )
-    watch([mainContentY, mainY], ([mainContentY, mainY]) => {
-      scrollY.value = isSidebarVisible.value ? mainContentY : mainY
+    watch([isMainContentScrolled], ([isMainContentScrolled]) => {
+      isHeaderScrolled.value = isMainContentScrolled
+    })
+    watch([mainContentY], ([mainContentY]) => {
+      scrollY.value = mainContentY
     })
     const showScrollButton = computed(() => scrollY.value > 70)
 
@@ -118,70 +109,23 @@ export default embeddedPage
   grid-template-rows: auto 1fr;
 }
 
-.main:not(.has-sidebar) {
-  overflow-y: scroll;
-}
-.main.has-sidebar {
+.main {
   display: grid;
-  overflow: hidden;
   grid-template-columns: 1fr 316px;
-}
-.main.has-sidebar > * {
   height: 100%;
-  overflow-y: scroll;
-}
-.main-page,
-.modal {
-  /* Works on Firefox */
-  scrollbar-width: thin;
-  scrollbar-color: white transparent;
-}
-@media (min-width: 768px) {
-  .main,
-  .main-page,
-  .modal {
-    scrollbar-color: transparent transparent;
-  }
-  .main:hover,
-  .main-page:hover,
-  .modal:hover {
-    scrollbar-color: #eae9ea transparent;
-  }
+  overflow: hidden;
 }
 
-.sidebar {
-  scrollbar-color: #eae9ea #f3f2f2;
+.main > * {
+  overflow-y: scroll;
+  min-height: 100%;
 }
-/* Works on Chrome, Edge, and Safari */
-.main-page::-webkit-scrollbar,
-.sidebar::-webkit-scrollbar {
-  width: 0.5rem;
+
+.main > *:first-child {
+  grid-column: span 2;
 }
-.main-page::-webkit-scrollbar-track {
-  background-color: white;
-}
-.main-page::-webkit-scrollbar-thumb {
-  background-color: #6f6e6e;
-  border-radius: 0.25rem;
-}
-.main::-webkit-scrollbar {
-  background-color: white;
-  width: 0.5rem;
-}
-.main::-webkit-scrollbar-track {
-  background-color: white;
-}
-.main::-webkit-scrollbar-thumb {
-  background-color: #6f6e6e;
-  border-radius: 0.25rem;
-}
-.sidebar::-webkit-scrollbar {
-  background-color: #f3f2f2;
-  width: 0.5rem;
-}
-.sidebar::-webkit-scrollbar-thumb {
-  background-color: #6f6e6e;
-  border-radius: 0.25rem;
-  color: #3e58e1;
+
+.main.has-sidebar > *:first-child {
+  grid-column: 1;
 }
 </style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -10,7 +10,7 @@
       }"
     >
       <Nuxt ref="mainContentRef" class="min-w-0 main-page" />
-      <VSidebarTarget v-show="!isHomeRoute" class="sidebar" />
+      <VSidebarTarget class="sidebar" />
     </main>
     <VModalTarget class="modal" />
   </div>

--- a/src/styles/base/layout.sass
+++ b/src/styles/base/layout.sass
@@ -514,9 +514,3 @@ $section-padding-large: 18rem 1.5rem
       padding: $section-padding-medium
     &.is-large
       padding: $section-padding-large
-
-.embedded .section
-  max-width: calc(940px + 2 * 0.5rem)
-  margin-left: auto
-  margin-right: auto
-  padding: 3rem 0.5rem


### PR DESCRIPTION
Makes some small adjustments to css grid and the header, along with removing the hardcoded scrollbar styles. 

The main improvement here is that when the sidebar isn't visible, the first column (the main content) will span both grid cells.

The 'main' element is always full height, and it either has 1 full-width child that can scroll, or two (the sidebar added) that scroll independently.