### PR TITLE
Show deprecated licenses 

### DIFF
--- a/src/components/License/VLicense.vue
+++ b/src/components/License/VLicense.vue
@@ -17,24 +17,21 @@
         :size="4"
       />
     </div>
-    <span
-      v-if="!hideName"
-      class="name"
-      :aria-label="$t(`license-readable-names.${license}`)"
-    >
-      {{ $t(`license-names.${license}`) }}
+    <span v-if="!hideName" class="name" :aria-label="licenseName.readable">
+      {{ licenseName.full }}
     </span>
   </div>
 </template>
 
 <script>
-import { computed } from '@nuxtjs/composition-api'
+import { computed, useContext } from '@nuxtjs/composition-api'
 
 import VIcon from '~/components/VIcon/VIcon.vue'
 
 import {
   ALL_LICENSES,
   CC_LICENSES,
+  DEPRECATED_LICENSES,
   LICENSE_ICON_MAPPING,
 } from '~/constants/license.js'
 
@@ -79,12 +76,34 @@ export default {
     },
   },
   setup(props) {
-    const icons = computed(() =>
-      props.license.split(/[-\s]/).map((term) => LICENSE_ICON_MAPPING[term])
+    const { i18n } = useContext()
+    const isDeprecated = computed(() =>
+      DEPRECATED_LICENSES.includes(props.license)
     )
+    const icons = computed(() => {
+      if (isDeprecated.value) {
+        return []
+      }
+      return props.license
+        .split(/[-\s]/)
+        .map((term) => LICENSE_ICON_MAPPING[term])
+    })
     const isCC = computed(
       () => CC_LICENSES.includes(props.license) || props.license === 'cc0'
     )
+    /**
+     * @type {import('@nuxtjs/composition-api').ComputedRef<{ readable: string, full: string }>}
+     */
+    const licenseName = computed(() => {
+      if (isDeprecated.value) {
+        return { readable: props.license, full: props.license }
+      } else {
+        return {
+          readable: i18n.t(`license-readable-names.${props.license}`),
+          full: i18n.t(`license-names.${props.license}`),
+        }
+      }
+    })
 
     return {
       ccLogo,
@@ -99,6 +118,7 @@ export default {
 
       icons,
       isCC,
+      licenseName,
     }
   },
 }

--- a/src/constants/license.js
+++ b/src/constants/license.js
@@ -9,7 +9,13 @@ export const CC_LICENSES = [
 
 export const NON_CC_LICENSES = ['cc0', 'pdm']
 
-export const ALL_LICENSES = [...CC_LICENSES, ...NON_CC_LICENSES]
+export const DEPRECATED_LICENSES = ['nc-sampling+']
+
+export const ALL_LICENSES = [
+  ...CC_LICENSES,
+  ...NON_CC_LICENSES,
+  ...DEPRECATED_LICENSES,
+]
 
 export const LICENSE_ICON_MAPPING = {
   by: 'by',

--- a/src/constants/license.js
+++ b/src/constants/license.js
@@ -9,7 +9,7 @@ export const CC_LICENSES = [
 
 export const NON_CC_LICENSES = ['cc0', 'pdm']
 
-export const DEPRECATED_LICENSES = ['nc-sampling+']
+export const DEPRECATED_LICENSES = ['nc-sampling+', 'sampling+']
 
 export const ALL_LICENSES = [
   ...CC_LICENSES,

--- a/test/unit/specs/components/v-license.spec.js
+++ b/test/unit/specs/components/v-license.spec.js
@@ -6,6 +6,13 @@ describe('VLicense', () => {
     props: {
       license: 'by',
     },
+    mocks: {
+      $nuxt: {
+        context: {
+          i18n: { t: (val) => val },
+        },
+      },
+    },
   }
 
   it('should render the license name and icons', () => {


### PR DESCRIPTION


## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
There are several CC licenses that [have been retired](https://creativecommons.org/retiredlicenses/), and their use is no longer recommended. In the [discussion about them](https://github.com/WordPress/openverse/discussions/71), we have agreed to show the license names and their icons on search result page and the single result page, but not have specific filters for them.

This PR adds a list of deprecated licenses, and shows only their names "as is" on the frontend, to fix the errors with `VLicense` component on audio page.
Future PRs should add icons and more deprecated licenses to the array. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run `pnpm run dev` and search for some audios. 'Cat' search returns some audios from freesound.org that are under `Sampling+` deprecated license. These items should not cause errors with these changes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
