### PR TITLE
Add missing strings

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -517,7 +517,13 @@
     "provider-label": "Provider",
     "source-label": "Source",
     "loading": "Loading...",
-    "related-error": "Error fetching related media"
+    "related-error": "Error fetching related media",
+    "aria": {
+      "attribution": {
+        "license": "read more about the license",
+        "tool": "read more about the tool"
+      }
+    }
   },
   "photo-details": {
     "back": "Back to search results",

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-01-17T14:14:29+00:00\n"
+"POT-Creation-Date: 2022-01-18T06:42:25+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -338,12 +338,12 @@ msgid "Back to search results"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/ImageDetails/VPhotoDetails.vue:59
+#: src/components/ImageDetails/VPhotoDetails.vue:57
 msgctxt "photo-details.creator"
 msgid "by ###name###"
 msgstr ""
 
-#: src/components/ImageDetails/VPhotoDetails.vue:146
+#: src/components/ImageDetails/VPhotoDetails.vue:144
 msgctxt "photo-details.weblink"
 msgid "Go to image's website"
 msgstr ""
@@ -390,7 +390,7 @@ msgid "###provider### form"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/ImageDetails/VPhotoDetails.vue:69
+#: src/components/ImageDetails/VPhotoDetails.vue:67
 msgctxt "photo-details.aria.creator-url"
 msgid "author ###creator###"
 msgstr ""
@@ -512,7 +512,7 @@ msgctxt "photo-details.survey.answer"
 msgid "by answering a few questions."
 msgstr ""
 
-#: src/components/ImageDetails/VPhotoDetails.vue:102
+#: src/components/ImageDetails/VPhotoDetails.vue:100
 msgctxt "photo-details.information.title"
 msgid "Information"
 msgstr ""
@@ -551,7 +551,7 @@ msgctxt "photo-details.information.pixels"
 msgid "pixels"
 msgstr ""
 
-#: src/components/ImageDetails/VPhotoDetails.vue:91
+#: src/components/ImageDetails/VPhotoDetails.vue:89
 msgctxt "photo-details.reuse.title"
 msgid "Reuse"
 msgstr ""
@@ -571,6 +571,16 @@ msgstr ""
 #: src/components/AudioDetails/VRelatedAudio.vue:18
 msgctxt "media-details.related-error"
 msgid "Error fetching related media"
+msgstr ""
+
+#: src/components/MediaInfo/MediaLicense.vue:32
+msgctxt "media-details.aria.attribution.license"
+msgid "read more about the license"
+msgstr ""
+
+#: src/components/MediaInfo/MediaLicense.vue:51
+msgctxt "media-details.aria.attribution.tool"
+msgid "read more about the tool"
 msgstr ""
 
 #: src/components/MediaInfo/MediaReuse.vue:3
@@ -1135,7 +1145,7 @@ msgid "All"
 msgstr ""
 
 msgctxt "search-tab.image"
-msgid "Image"
+msgid "Images"
 msgstr ""
 
 msgctxt "search-tab.audio"
@@ -1144,6 +1154,14 @@ msgstr ""
 
 msgctxt "search-tab.video"
 msgid "Video"
+msgstr ""
+
+msgctxt "search-tab.see-image"
+msgid "See all images"
+msgstr ""
+
+msgctxt "search-tab.see-audio"
+msgid "See all audio"
 msgstr ""
 
 msgctxt "error.occurred"
@@ -2031,18 +2049,18 @@ msgctxt "header.api-nav-item"
 msgid "API"
 msgstr ""
 
-#: src/components/VHeader/VHeader.vue:189
+#: src/components/VHeader/VHeader.vue:194
 msgctxt "header.loading"
 msgid "Loading..."
 msgstr ""
 
-#: src/components/VHeader/VFilterButton.vue:85
+#: src/components/VHeader/VFilterButton.vue:82
 msgctxt "header.filter-button.simple"
 msgid "Filters"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VHeader/VFilterButton.vue:80
+#: src/components/VHeader/VFilterButton.vue:77
 msgctxt "header.filter-button.with-count"
 msgid "###count### Filter | ###count### Filters"
 msgstr ""


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This is a quick fix for i18n strings that are missing in audio page attribution components.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app and open Audio search (localhost:8443/search/audio?q=cat) and audio single result page. You should not see any i18n warnings in the console, except for the license name warnings (`[vue-i18n] Cannot translate the value of keypath 'license-names.nc-sampling+'. Use the value of keypath as default.`), which should be fixed by #619.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
