### PR TITLE
Only prevent default on waveform events when it will be explicitly handled

### DIFF
--- a/src/components/VAudioTrack/VWaveform.vue
+++ b/src/components/VAudioTrack/VWaveform.vue
@@ -437,7 +437,13 @@ export default defineComponent({
         emit('seeked', currentFrac.value + delta)
       }
     }
+
+    const willBeHandled = (event) =>
+      ['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event)
+
     const handleKeys = (event) => {
+      if (!willBeHandled(event)) return
+
       event.preventDefault()
       if (['ArrowLeft', 'ArrowRight'].includes(event.key))
         return handleArrowKeys(event)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #623  by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Fixes keyboard navigation through the Waveform component by only preventing default on events when they will be explicitly handled by the component. Before all events were having `preventDefault` called on them regardless of whether they were actually handled by the component. This was causing `tab` events to not follow the default behavior.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the branch and run `pnpm dev` and visit http://localhost:8443/audio/632d0076-fdbd-4919-8b8f-b498ef246ee8. Confirm that you're able to tab into and out of the waveform.

Note: There is a separate bug where the current seeking and play/pause behavior of the waveform doesn't actually work. I've opened a [separate issue for that](https://github.com/WordPress/openverse-frontend/issues/628) as it seems slightly lower priority than this a11y breaking bug.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable). (They don't exist for this component due to limitations in JSDom and audio file loading... we'll need to write e2e tests for this eventually)
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
