### PR TITLE
Add interaction styles to the content switcher

### DIFF
--- a/src/components/VButton.vue
+++ b/src/components/VButton.vue
@@ -232,7 +232,7 @@ export default VButton
 
 <style module>
 .button {
-  @apply flex items-center rounded-sm justify-center transition-shadow duration-100 ease-linear disabled:opacity-70 focus:outline-none focus-visible:ring no-underline appearance-none ring-offset-1;
+  @apply flex items-center rounded-sm justify-center transition-shadow duration-100 ease-linear disabled:opacity-70 focus:outline-none no-underline appearance-none ring-offset-1;
 }
 
 .button[disabled='disabled'],
@@ -257,7 +257,7 @@ a.button {
 }
 
 .primary {
-  @apply bg-pink text-white focus-visible:ring-pink hover:bg-dark-pink hover:text-white;
+  @apply bg-pink text-white focus-visible:ring focus-visible:ring-pink hover:bg-dark-pink hover:text-white;
 }
 
 .primary-pressed {
@@ -265,7 +265,7 @@ a.button {
 }
 
 .secondary {
-  @apply bg-dark-charcoal text-white font-bold focus-visible:ring-pink hover:bg-dark-charcoal-80 hover:text-white;
+  @apply bg-dark-charcoal text-white font-bold focus-visible:ring focus-visible:ring-pink hover:bg-dark-charcoal-80 hover:text-white;
 }
 
 .secondary-pressed {
@@ -273,7 +273,7 @@ a.button {
 }
 
 .tertiary {
-  @apply bg-white text-black border border-dark-charcoal-20 focus-visible:border-tx focus-visible:ring-pink ring-offset-0;
+  @apply bg-white text-black border border-dark-charcoal-20 focus-visible:border-tx focus-visible:ring focus-visible:ring-pink ring-offset-0;
 }
 
 .tertiary-pressed {
@@ -281,11 +281,11 @@ a.button {
 }
 
 .action-menu {
-  @apply bg-white text-black border border-tx hover:border-dark-charcoal-20 focus-visible:ring-pink;
+  @apply bg-white text-black border border-tx hover:border-dark-charcoal-20 focus-visible:ring focus-visible:ring-pink;
 }
 
 .action-menu-secondary {
-  @apply bg-white text-black border border-tx hover:border-dark-charcoal-20 focus-visible:ring-pink;
+  @apply bg-white text-black border border-tx hover:border-dark-charcoal-20 focus-visible:ring focus-visible:ring-pink;
 }
 
 .action-menu-secondary-pressed {
@@ -297,15 +297,15 @@ a.button {
 }
 
 .action-menu-muted {
-  @apply bg-dark-charcoal-10 text-black border border-tx hover:border-dark-charcoal-20 focus-visible:ring-pink;
+  @apply bg-dark-charcoal-10 text-black border border-tx hover:border-dark-charcoal-20 focus-visible:ring focus-visible:ring-pink;
 }
 
 .action-menu-muted-pressed {
-  @apply border-tx bg-dark-charcoal text-white focus-visible:ring-pink;
+  @apply border-tx bg-dark-charcoal text-white focus-visible:ring focus-visible:ring-pink;
 }
 
 .grouped {
-  @apply bg-white text-black focus-visible:ring-pink;
+  @apply bg-white text-black;
 }
 
 .grouped-pressed {
@@ -313,7 +313,7 @@ a.button {
 }
 
 .full {
-  @apply w-full font-semibold bg-dark-charcoal-06 focus-visible:ring-pink hover:bg-dark-charcoal-40 hover:text-white;
+  @apply w-full font-semibold bg-dark-charcoal-06 focus-visible:ring focus-visible:ring-pink hover:bg-dark-charcoal-40 hover:text-white;
 }
 
 .full-pressed {
@@ -321,6 +321,6 @@ a.button {
 }
 
 .plain {
-  @apply bg-tx focus-visible:ring-pink;
+  @apply bg-tx focus-visible:ring focus-visible:ring-pink;
 }
 </style>

--- a/src/components/VContentSwitcher/VContentTypes.vue
+++ b/src/components/VContentSwitcher/VContentTypes.vue
@@ -8,6 +8,7 @@
     <VItem
       v-for="(item, idx) in content.types"
       :key="idx"
+      :class="{ 'mb-1': !bordered }"
       :selected="item === activeItem"
       :is-first="idx === 0"
       @click.native="handleClick(item)"

--- a/src/components/VContentSwitcher/VMobileMenuModal.vue
+++ b/src/components/VContentSwitcher/VMobileMenuModal.vue
@@ -24,7 +24,7 @@
           {{ $t('search-type.heading') }}
         </h2>
         <VContentTypes
-          :bordered="false"
+          :bordered="true"
           :active-item="content.activeType.value"
           @select="selectItem"
         />

--- a/src/components/VItemGroup/VItem.vue
+++ b/src/components/VItemGroup/VItem.vue
@@ -14,7 +14,7 @@
     <VButton
       data-item-group-item
       :as="as"
-      class="flex justify-between focus-visible:ring-pink rounded min-w-full"
+      class="flex justify-between rounded min-w-full group relative hover:bg-dark-charcoal-10"
       :class="[$style.button, $style[`${contextProps.direction}-button`]]"
       variant="grouped"
       size="small"
@@ -31,13 +31,14 @@
       @click.native="$emit('click')"
     >
       <div
-        class="flex-grow whitespace-nowrap"
+        class="flex-grow whitespace-nowrap group-focus-visible:ring group-focus-visible:ring-pink my-2 mx-1 rounded"
         :class="$style[`${contextProps.direction}-content`]"
       >
         <slot name="default" />
       </div>
       <VIcon
         v-if="!isInPopover && selected && contextProps.direction === 'vertical'"
+        class="absolute end-5"
         :icon-path="checkmark"
       />
     </VButton>

--- a/src/styles/accent.scss
+++ b/src/styles/accent.scss
@@ -1,10 +1,10 @@
 :root {
   /* Accent color tints checkbox, radio, range and progress. */
-  accent-color: theme('colors.trans-blue');
+  accent-color: theme('colors.pink');
 }
 
 :focus-visible {
-  outline-color: theme('colors.trans-blue');
+  outline-color: theme('colors.pink');
 }
 
 ::selection {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
N/A

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds hover and focus styles to the content switcher items in the popover/modal.
To show a pink outline _inside_ the `VItem`, I had to change the `grouped` button to have an outline inside its `content` instead of the button itself. It might break some other buttons that used `grouped` variant, but I haven't found any.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app and test the content switcher interactions.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
