### PR TITLE
Fix global audio syncing and seeking issues

### DIFF
--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -220,6 +220,12 @@ export default defineComponent({
      * into our local audio, then we need to initialize
      * the local state syncing from the audio object
      * to our local refs.
+     *
+     * This lives here instead of closer to where `localAudio`
+     * is defined because `initLocalAudio` and several of
+     * the functions it depends on also all depend on the
+     * `localAudio` variable. This is the earliest in
+     * `setup` that this can be called.
      */
     if (localAudio) initLocalAudio()
 

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -35,7 +35,7 @@ import {
   useStore,
   watch,
   onUnmounted,
-  onMounted,
+  useRoute,
 } from '@nuxtjs/composition-api'
 
 import { useActiveAudio } from '~/composables/use-active-audio'
@@ -48,7 +48,7 @@ import VRowLayout from '~/components/VAudioTrack/layouts/VRowLayout.vue'
 import VBoxLayout from '~/components/VAudioTrack/layouts/VBoxLayout.vue'
 import VGlobalLayout from '~/components/VAudioTrack/layouts/VGlobalLayout.vue'
 
-import { ACTIVE } from '~/constants/store-modules'
+import { ACTIVE, MEDIA } from '~/constants/store-modules'
 import {
   PAUSE_ACTIVE_MEDIA_ITEM,
   SET_ACTIVE_MEDIA_ITEM,
@@ -59,7 +59,7 @@ const propTypes = {
    * the information about the track, typically from a track's detail endpoint
    */
   audio: {
-    type: /** @type {import('@nuxtjs/composition-api').PropType<{ url: string, duration: number, id: string }>} */ (
+    type: /** @type {import('@nuxtjs/composition-api').PropType<import('~/store/types').AudioDetail>} */ (
       Object
     ),
     required: /** @type {true} */ (true),
@@ -116,67 +116,15 @@ export default defineComponent({
    */
   setup(props) {
     const store = useStore()
+    const route = useRoute()
 
     const activeAudio = useActiveAudio()
-    /**
-     * We can only create the local audio object on the client,
-     * so the initialization of this variable is hidden inside
-     * the `onMounted` hook.
-     *
-     * Rather than initialize everything for this component
-     * inside the onMounted hook, we can just use a closure
-     * around this variable to make everything else present
-     * on the top level of the setup function's scope and limit
-     * the behavior of the `onMounted` hook to just initializing
-     * the audio object for this instance.
-     *
-     * However, when navigating to an audio result page, if
-     * the globally active audio already matches the result
-     * that was clicked on, hijack that object instead and
-     * treat it as the local audio for this instance.
-     *
-     * @type {HTMLAudioElement | undefined}
-     * */
-    let localAudio =
-      activeAudio.obj.value?.src === props.audio.url
-        ? activeAudio.obj.value
-        : undefined
 
     const status = ref('paused')
     const currentTime = ref(0)
 
-    const updateTimeLoop = () => {
-      if (localAudio && status.value === 'playing') {
-        currentTime.value = localAudio.currentTime
-        window.requestAnimationFrame(updateTimeLoop)
-      }
-    }
-
-    const setPlaying = () => {
-      status.value = 'playing'
-      activeAudio.obj.value = localAudio
-      store.commit(`${ACTIVE}/${SET_ACTIVE_MEDIA_ITEM}`, {
-        type: 'audio',
-        id: props.audio.id,
-      })
-      updateTimeLoop()
-    }
-    const setPaused = () => {
-      status.value = 'paused'
-      store.commit(`${ACTIVE}/${PAUSE_ACTIVE_MEDIA_ITEM}`)
-    }
-    const setPlayed = () => (status.value = 'played')
-    const setTimeWhenPaused = () => {
-      if (status.value !== 'playing' && localAudio) {
-        currentTime.value = localAudio.currentTime
-        if (status.value === 'played') {
-          // Set to pause to remove replay icon
-          status.value = 'paused'
-        }
-      }
-    }
-
-    onMounted(() => {
+    const initLocalAudio = () => {
+      // Preserve existing local audio if we plucked it from the global active audio
       if (!localAudio) localAudio = new Audio(props.audio.url)
 
       localAudio.addEventListener('play', setPlaying)
@@ -216,16 +164,103 @@ export default defineComponent({
       }
 
       currentTime.value = localAudio.currentTime
-    })
+    }
+
+    /**
+     * We can only create the local audio object on the client,
+     * so the initialization of this variable is hidden inside
+     * the `initLocalAudio` function which is only called when
+     * playback is first requested or when the track if first seeked.
+     *
+     * However, when navigating to an audio result page, if
+     * the globally active audio already matches the result
+     * that was clicked on, hijack that object instead and
+     * treat it as the local audio for this instance.
+     *
+     * @type {HTMLAudioElement | undefined}
+     * */
+    let localAudio =
+      activeAudio.obj.value?.src === props.audio.url
+        ? activeAudio.obj.value
+        : undefined
+
+    const updateTimeLoop = () => {
+      if (localAudio && status.value === 'playing') {
+        currentTime.value = localAudio.currentTime
+        window.requestAnimationFrame(updateTimeLoop)
+      }
+    }
+
+    const setPlaying = () => {
+      status.value = 'playing'
+      activeAudio.obj.value = localAudio
+      store.commit(`${ACTIVE}/${SET_ACTIVE_MEDIA_ITEM}`, {
+        type: 'audio',
+        id: props.audio.id,
+      })
+      updateTimeLoop()
+    }
+    const setPaused = () => {
+      status.value = 'paused'
+      store.commit(`${ACTIVE}/${PAUSE_ACTIVE_MEDIA_ITEM}`)
+    }
+    const setPlayed = () => (status.value = 'played')
+    const setTimeWhenPaused = () => {
+      if (status.value !== 'playing' && localAudio) {
+        currentTime.value = localAudio.currentTime
+        if (status.value === 'played') {
+          // Set to pause to remove replay icon
+          status.value = 'paused'
+        }
+      }
+    }
+
+    /**
+     * If we're transforming the globally active audio
+     * into our local audio, then we need to initialize
+     * the local state syncing from the audio object
+     * to our local refs.
+     */
+    if (localAudio) initLocalAudio()
 
     onUnmounted(() => {
-      localAudio?.removeEventListener('play', setPlaying)
-      localAudio?.removeEventListener('pause', setPaused)
-      localAudio?.removeEventListener('ended', setPlayed)
-      localAudio?.removeEventListener('timeupdate', setTimeWhenPaused)
+      if (!localAudio) return
+
+      localAudio.removeEventListener('play', setPlaying)
+      localAudio.removeEventListener('pause', setPaused)
+      localAudio.removeEventListener('ended', setPlayed)
+      localAudio.removeEventListener('timeupdate', setTimeWhenPaused)
+
+      if (
+        route.value.params.id == props.audio.id ||
+        store.getters[`${MEDIA}/results`]?.items?.[props.audio.id]
+      ) {
+        /**
+         * If switching to any route other than the single result
+         * route for this track, pause it. Otherwise, let it keep
+         * playing to introduce a "seamless" feeling beween the
+         * search results page and the single result page.
+         *
+         * This handles going from the search page to the single
+         * result page for a different track than is currently playing.
+         * It also handles the same interaction for related audio.
+         * Also for related audio, it will handle pausing any related
+         * audio when navigating back from the single result page
+         * to the search results page.
+         *
+         * Also, if the currently playing audio is present in the
+         * existing list of search results, then also let it keep
+         * playing.
+         */
+        return
+      }
+
+      localAudio.pause()
     })
 
     const play = () => {
+      // delay initializing the local audio element until playback is requested
+      if (!localAudio) initLocalAudio()
       localAudio?.play()
     }
     const pause = () => localAudio?.pause()
@@ -268,7 +303,15 @@ export default defineComponent({
      * @param {number} frac
      */
     const handleSeeked = (frac) => {
-      if (!localAudio) return
+      if (!localAudio) initLocalAudio()
+      /**
+       * Calling initLocalAudio will guarantee localAudio
+       * to be an HTMLAudioElement, but we can't prove that
+       * to TypeScript without jumping through some tricky
+       * hoops (using `assert`) or adding unnecessary
+       * runtime checks.
+       */
+      // @ts-ignore
       localAudio.currentTime = frac * duration.value
     }
 

--- a/src/components/VAudioTrack/VGlobalAudioTrack.vue
+++ b/src/components/VAudioTrack/VGlobalAudioTrack.vue
@@ -89,7 +89,7 @@ const propTypes = {
  * controls to play, pause or seek to a point on the track.
  */
 export default defineComponent({
-  name: 'VAudioTrack',
+  name: 'VGlobalAudioTrack',
   components: {
     VPlayPause,
     VWaveform,

--- a/src/composables/use-active-audio.js
+++ b/src/composables/use-active-audio.js
@@ -1,0 +1,8 @@
+import { ref } from '@nuxtjs/composition-api'
+
+/** @type {import('@nuxtjs/composition-api').Ref<HTMLAudioElement | undefined>} */
+const obj = ref(undefined)
+
+export function useActiveAudio() {
+  return Object.freeze({ obj })
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,6 @@
     "target": "esnext",
     "module": "esnext",
     "lib": ["dom", "esnext"],
-    "declaration": true,
-    "declarationMap": true,
     "noEmit": true,
     "isolatedModules": true,
     "skipLibCheck": true,
@@ -31,10 +29,11 @@
       "~/*": ["./src/*"],
       "~~/*": ["./*"]
     },
-    "baseUrl": "./"
+    "baseUrl": "."
   },
   "include": [
     "src/composables/types.js",
-    "src/composables/use-event-listener-outside.js"
+    "src/composables/use-event-listener-outside.js",
+    "src/composables/use-active-audio.js"
   ]
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #653 by @sarayourfriend
Closes #632 by @sarayourfriend — All audio tracks on the page buffer immediately so there's no longer a delay between playing them... do we need to prevent audio from loading until the "play" button is hit on it or it is seeked? Probably so.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Switches to using a global ref for the currently active audio track and swapping between multiple audio elements (one per track on the page, aside from the global track).

Some notes/key concepts:

1. We derive all state from the state of the audio object, whether the global "active audio" or the local audio. This means our state is updated when the local audio object emits the corresponding events. The only exception to this is the current time. I originally implemented this to always update the `currentTime` ref (which is used for displaying the play progress on the waveform) using the `timeupdate` event exclusively. But to achieve a smooth animation, when a track is playing, we'll update the `currentTime` ref in a `requestAnimationFrame` loop. `timeupdate` is still used to update the current time when the audio is not playing (for example if it is seeked while it is paused or ended). Otherwise the `timeupdate` event is ignored when the track is playing.
2. The `GlobalAudioTrack` and `AudioTrack` components share much of the same logic. At a glance it does appear that some of this stuff could be abstracted and I did spend a short amount of time thinking about how to do this. However, most of the "simple" ideas for how to do this, were thwarted by various issues with syncing global and local state selectively. The current implementation works, and while there is some duplicated code, most of it is subtly different. The approaching deadline for the audio release means spending time on refactoring this PR right now is pretty low value. If we decide to spend more time on this in the future, it could alleviate the maintainability burden of these two components, as long as we're sure their implementations won't diverge in the future. Given the already existing subtle differences between the two, I'd make a pretty confident bet that trying to abstract these behaviors into a shared utility would present difficulties in the future.
3. The local audio track has to be careful not to use the `Audio` object on the server. I tried to minimize the amount of code that was shifted into the `onMounted` hook, mostly because putting everything in there seems like an organizational misstep. If we did move everything in there, however, we could probably get rid of a lot of the optional chaining on the `localAudio` variable, but it seems like a small victory that could cause delays in mounting the component that are easily avoided (thanks to ergonomic features like optional chaining).
4. I tried to add explanatory comments to any logic that was non-obvious or could be implemented in different ways but needed to be done the way I did. If there's anything else that warrants explanation, let me know and I am happy to add more comments.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch and run `pnpm dev`.

Visit an audio result page like http://localhost:8443/search/audio?q=birds and play around with seeking, playing, pausing, replaying tracks, both with and without the global audio player. Also make sure to test navigation between the search results and single result pages.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [Not possible yet] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
