### PR TITLE
Fix another missing dependency lodash.set

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lodash.findindex": "^4.6.0",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
+    "lodash.set": "^4.3.2",
     "lodash.sortby": "^4.7.0",
     "lodash.throttle": "^4.1.1",
     "node-html-parser": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,7 @@ specifiers:
   lodash.findindex: ^4.6.0
   lodash.isempty: ^4.4.0
   lodash.isequal: ^4.5.0
+  lodash.set: ^4.3.2
   lodash.sortby: ^4.7.0
   lodash.throttle: ^4.1.1
   node-html-parser: ^5.1.0
@@ -103,6 +104,7 @@ dependencies:
   lodash.findindex: 4.6.0
   lodash.isempty: 4.4.0
   lodash.isequal: 4.5.0
+  lodash.set: 4.3.2
   lodash.sortby: 4.7.0
   lodash.throttle: 4.1.1
   node-html-parser: 5.1.0
@@ -12366,6 +12368,10 @@ packages:
 
   /lodash.mergewith/4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+    dev: false
+
+  /lodash.set/4.3.2:
+    resolution: {integrity: sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=}
     dev: false
 
   /lodash.sortby/4.7.0:

--- a/src/locales/scripts/ngx-json-to-json.js
+++ b/src/locales/scripts/ngx-json-to-json.js
@@ -1,4 +1,4 @@
-const set = require('lodash/set')
+const set = require('lodash.set')
 
 /**
  * Convert an NGX-Translate object to a nested JSON object


### PR DESCRIPTION
## Description

I'm not sure how we missed this but this node script depended on a lodash subpackage when lodash isn't explicitly declared as a dependency. I switched to the standalone `lodash.set` instead of `loadash/set` and installed it.

Perhaps another dependency has a peerdep of lodash that isn't installed in prod or something?

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
