### PR TITLE
Remove events from `VAudioThumbnail` stories

### DIFF
--- a/src/components/VAudioThumbnail/meta/VAudioThumbnail.stories.mdx
+++ b/src/components/VAudioThumbnail/meta/VAudioThumbnail.stories.mdx
@@ -8,20 +8,12 @@ import {
 
 import VAudioThumbnail from '~/components/VAudioThumbnail/VAudioThumbnail.vue'
 
-<Meta
-  title="Components/VAudioThumbnail"
-  components={VAudioThumbnail}
-  argTypes={{
-    toggle: {
-      action: 'toggle',
-    },
-  }}
-/>
+<Meta title="Components/VAudioThumbnail" components={VAudioThumbnail} />
 
 export const Template = (args, { argTypes }) => ({
   template: `
     <div class="w-30">
-      <VAudioThumbnail v-bind="$props" v-on="$props"/>
+      <VAudioThumbnail v-bind="$props"/>
     </div>
   `,
   components: { VAudioThumbnail },


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The PR removes the `toggle` arg-type and the `v-on` bindings from the `VAudioThumbnail` stories as it does not emit any events.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
