### PR TITLE
Notices for Jamendo tracks when seeking is impossible

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -122,6 +122,7 @@ export default {
     { src: '~/plugins/ga.js', mode: 'client' },
     { src: '~/plugins/url-change.js' },
     { src: '~/plugins/migration-notice.js' },
+    { src: '~/plugins/ua-parse.js' },
   ],
   css: [
     '~/styles/tailwind.css',

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "clipboard": "^2.0.8",
     "core-js": "^3.16.1",
     "deepmerge": "^4.2.2",
+    "express-useragent": "^1.0.15",
     "filesize": "^8.0.2",
     "focus-trap": "^6.7.1",
     "focus-trap-vue": "1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ specifiers:
   eslint-plugin-unicorn: ^35.0.0
   eslint-plugin-vue: ^7.8.0
   eslint-plugin-vuejs-accessibility: ^0.6.1
+  express-useragent: ^1.0.15
   filesize: ^8.0.2
   focus-trap: ^6.7.1
   focus-trap-vue: 1.1.1
@@ -97,6 +98,7 @@ dependencies:
   clipboard: 2.0.8
   core-js: 3.19.3
   deepmerge: 4.2.2
+  express-useragent: 1.0.15
   filesize: 8.0.6
   focus-trap: 6.7.1
   focus-trap-vue: 1.1.1_focus-trap@6.7.1
@@ -9498,6 +9500,11 @@ packages:
       jest-message-util: 27.4.2
       jest-regex-util: 27.4.0
     dev: true
+
+  /express-useragent/1.0.15:
+    resolution: {integrity: sha512-eq5xMiYCYwFPoekffMjvEIk+NWdlQY9Y38OsTyl13IvA728vKT+q/CSERYWzcw93HGBJcIqMIsZC5CZGARPVdg==}
+    engines: {node: '>=4.5'}
+    dev: false
 
   /express/4.17.1:
     resolution: {integrity: sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==}

--- a/src/components/VAudioTrack/VWaveform.vue
+++ b/src/components/VAudioTrack/VWaveform.vue
@@ -149,6 +149,14 @@
     >
       {{ message }}
     </div>
+
+    <!-- Seek disabled message overlay -->
+    <div
+      v-if="seekDisabledNotice"
+      class="invisible group-hover:visible group-focus:visible absolute w-full inset-0 flex items-center justify-center font-bold text-xsm bg-yellow/75 z-40"
+    >
+      {{ seekDisabledNotice }}
+    </div>
   </div>
 </template>
 
@@ -215,6 +223,14 @@ export default defineComponent({
     features: {
       type: Array,
       default: () => ['timestamps', 'seek'],
+    },
+    /**
+     * An object of notices to display when a feature is disabled.
+     * `'timestamp'`, `'duration'`, `'seek'`.
+     */
+    featureNotices: {
+      type: Object,
+      default: () => {},
     },
   },
   emits: [
@@ -296,6 +312,9 @@ export default defineComponent({
     const showDuration = computed(() => props.features.includes('duration'))
     const showTimestamps = computed(() => props.features.includes('timestamps'))
     const isSeekable = computed(() => props.features.includes('seek'))
+
+    /* Feature notices */
+    const seekDisabledNotice = computed(() => props.featureNotices?.seek)
 
     /* State */
 
@@ -486,6 +505,8 @@ export default defineComponent({
       showDuration,
       showTimestamps,
       isSeekable,
+
+      seekDisabledNotice,
 
       isReady,
       isInteractive,

--- a/src/components/VAudioTrack/layouts/VRowLayout.vue
+++ b/src/components/VAudioTrack/layouts/VRowLayout.vue
@@ -74,7 +74,8 @@
         <slot name="play-pause" :size="isLarge ? 'medium' : 'large'" />
         <slot
           name="controller"
-          :features="['timestamps', 'duration', 'seek']"
+          :features="features"
+          :feature-notices="featureNotices"
         />
       </div>
     </div>
@@ -82,7 +83,9 @@
 </template>
 
 <script>
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+import { computed, defineComponent, useContext } from '@nuxtjs/composition-api'
+import { useBrowserIsBlink } from '~/composables/use-browser-detection'
+
 import VAudioThumbnail from '~/components/VAudioThumbnail/VAudioThumbnail.vue'
 import VLicense from '~/components/License/VLicense.vue'
 
@@ -95,6 +98,15 @@ export default defineComponent({
   props: ['audio', 'size'],
   setup(props) {
     /* Utils */
+    const browserIsBlink = useBrowserIsBlink()
+    const { i18n } = useContext()
+
+    const featureNotices = {}
+    const features = ['timestamps', 'duration', 'seek']
+    if (browserIsBlink && props.audio.source === 'jamendo') {
+      features.pop()
+      featureNotices.seek = i18n.t('audio-track.messages.blink_seek_disabled')
+    }
 
     /**
      * Format the time as hh:mm:ss, dropping the hour part if it is zero.
@@ -116,6 +128,9 @@ export default defineComponent({
 
     return {
       timeFmt,
+
+      features,
+      featureNotices,
 
       isSmall,
       isMedium,

--- a/src/composables/use-browser-detection.js
+++ b/src/composables/use-browser-detection.js
@@ -1,0 +1,11 @@
+import { useContext } from '@nuxtjs/composition-api'
+
+export const useBrowserDetection = () => {
+  const { app } = useContext()
+  return app.$ua
+}
+
+export const useBrowserIsBlink = () => {
+  const browser = useBrowserDetection()
+  return browser.isChrome || browser.isEdge || browser.isOpera
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -639,6 +639,7 @@
   "audio-track": {
     "aria-label": "Audio Player",
     "messages": {
+      "blink_seek_disabled": "Seeking for Jamendo tracks is limited to Firefox and Safari.",
       "err_aborted": "You aborted playback.",
       "err_network": "A network error occurred.",
       "err_decode": "Could not decode audio.",

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-01-20T15:32:46+00:00\n"
+"POT-Creation-Date: 2022-01-21T15:40:19+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -192,6 +192,11 @@ msgctxt "audio-track.creator"
 msgid "by ###creator###"
 msgstr ""
 
+#: src/components/VAudioTrack/layouts/VRowLayout.vue:108
+msgctxt "audio-track.messages.blink_seek_disabled"
+msgid "Seeking for Jamendo tracks is limited to Firefox and Safari."
+msgstr ""
+
 msgctxt "audio-track.messages.err_aborted"
 msgid "You aborted playback."
 msgstr ""
@@ -213,7 +218,7 @@ msgid "Loading..."
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioThumbnail/VAudioThumbnail.vue:142
+#: src/components/VAudioThumbnail/VAudioThumbnail.vue:102
 msgctxt "audio-thumbnail.alt"
 msgid "Cover art for \"###title###\" by ###creator###"
 msgstr ""
@@ -224,7 +229,7 @@ msgid "Audio seek bar"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VWaveform.vue:533
+#: src/components/VAudioTrack/VWaveform.vue:554
 msgctxt "waveform.current-time"
 msgid "###time### seconds"
 msgstr ""
@@ -758,7 +763,7 @@ msgid "Load more results"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/ImageGrid/ImageGrid.vue:53
+#: src/components/ImageGrid/ImageGrid.vue:56
 msgctxt "browse-page.fetching-error"
 msgid "Error fetching ###type###:"
 msgstr ""
@@ -850,12 +855,12 @@ msgctxt "browse-page.search-form.placeholder"
 msgid "Search all ###type###"
 msgstr ""
 
-#: src/components/ImageGrid/ImageGrid.vue:52
+#: src/components/ImageGrid/ImageGrid.vue:55
 msgctxt "browse-page.search-form.image"
 msgid "images"
 msgstr ""
 
-#: src/components/VAllResultsGrid/VAllResultsGrid.vue:133
+#: src/components/VAllResultsGrid/VAllResultsGrid.vue:134
 msgctxt "browse-page.search-form.audio"
 msgid "audio"
 msgstr ""
@@ -923,6 +928,10 @@ msgstr ""
 
 msgctxt "filters.title"
 msgid "Filters"
+msgstr ""
+
+msgctxt "filters.filter-by"
+msgid "Filter By"
 msgstr ""
 
 #. Do not translate words between ### ###.
@@ -1991,22 +2000,18 @@ msgctxt "footer.navigation.terms"
 msgid "Terms"
 msgstr ""
 
-#: src/components/NavSection.vue:71
 msgctxt "header.about-nav-item"
 msgid "Our Story"
 msgstr ""
 
-#: src/components/NavSection.vue:79
 msgctxt "header.source-nav-item"
 msgid "Sources"
 msgstr ""
 
-#: src/components/NavSection.vue:103
 msgctxt "header.search-guide-nav-item"
 msgid "Search Guide"
 msgstr ""
 
-#: src/components/NavSection.vue:111
 msgctxt "header.meta-search-nav-item"
 msgid "Meta Search"
 msgstr ""
@@ -2015,7 +2020,6 @@ msgctxt "header.privacy-nav-item"
 msgid "Privacy"
 msgstr ""
 
-#: src/components/NavSection.vue:119
 msgctxt "header.feedback-nav-item"
 msgid "Feedback"
 msgstr ""
@@ -2024,37 +2028,31 @@ msgctxt "header.support-nav-item"
 msgid "Support Us"
 msgstr ""
 
-#: src/components/NavSection.vue:134
 msgctxt "header.extension-nav-item"
 msgid "Web extension"
 msgstr ""
 
-#: src/components/NavSection.vue:173
 msgctxt "header.placeholder"
 msgid "Search all content"
 msgstr ""
 
-#: src/components/NavSection.vue:88
 msgctxt "header.licenses-nav-item"
 msgid "The Licenses"
 msgstr ""
 
-#: src/components/NavSection.vue:63
 msgctxt "header.about-tab"
 msgid "About"
 msgstr ""
 
-#: src/components/NavSection.vue:95
 msgctxt "header.resources-tab"
 msgid "Resources"
 msgstr ""
 
-#: src/components/NavSection.vue:128
 msgctxt "header.api-nav-item"
 msgid "API"
 msgstr ""
 
-#: src/components/VHeader/VHeader.vue:206
+#: src/components/VHeader/VHeader.vue:213
 msgctxt "header.loading"
 msgid "Loading..."
 msgstr ""
@@ -2082,22 +2080,19 @@ msgctxt "header.notification.okay"
 msgid "OK"
 msgstr ""
 
-#: src/components/NavSection.vue:6
 msgctxt "header.aria.primary"
 msgid "primary"
 msgstr ""
 
-#: src/components/NavSection.vue:23
+#: src/components/VHeader/VPageMenu/VDesktopPageMenu.vue:5
 msgctxt "header.aria.menu"
 msgid "menu"
 msgstr ""
 
-#: src/components/NavSection.vue:43
 msgctxt "header.aria.search"
 msgid "search"
 msgstr ""
 
-#: src/components/NavSection.vue:50
 msgctxt "header.aria.sr-search"
 msgid "search button"
 msgstr ""
@@ -2126,12 +2121,11 @@ msgctxt "hero.brand"
 msgid "Openverse"
 msgstr ""
 
-#: src/components/VHeroSection.vue:6
 msgctxt "hero.title"
 msgid "Search for content to reuse"
 msgstr ""
 
-#: src/components/VHeroSection.vue:9
+#: src/pages/index.vue:21
 msgctxt "hero.subtitle"
 msgid "Browse through over 600 million items to reuse"
 msgstr ""
@@ -2146,7 +2140,6 @@ msgctxt "hero.search-type.image"
 msgid "Images"
 msgstr ""
 
-#: src/components/VHeroSection.vue:40
 msgctxt "hero.search-type.prompt"
 msgid "I would like to find:"
 msgstr ""
@@ -2156,12 +2149,10 @@ msgctxt "hero.search-type.all"
 msgid "All"
 msgstr ""
 
-#: src/components/VHeroSection.vue:24
 msgctxt "hero.aria.search"
 msgid "search"
 msgstr ""
 
-#: src/components/VHeroSection.vue:50
 msgctxt "hero.aria.caption"
 msgid "about cc licenses"
 msgstr ""
@@ -2196,12 +2187,10 @@ msgctxt "hero.disclaimer.license"
 msgid "Creative Commons license"
 msgstr ""
 
-#: src/components/VHeroSection.vue:28
 msgctxt "hero.search.placeholder"
 msgid "Search all content"
 msgstr ""
 
-#: src/components/VHeroSection.vue:35
 msgctxt "hero.search.button"
 msgid "Search"
 msgstr ""

--- a/src/plugins/ua-parse.js
+++ b/src/plugins/ua-parse.js
@@ -1,0 +1,16 @@
+import useragent from 'express-useragent'
+
+export default function (context, inject) {
+  let userAgent
+
+  if (typeof context.req !== 'undefined') {
+    userAgent = context.req.headers['user-agent']
+  } else if (typeof navigator !== 'undefined') {
+    userAgent = navigator.userAgent
+  }
+
+  const ua = useragent.parse(userAgent)
+
+  context.$ua = ua
+  inject('ua', ua)
+}

--- a/test/unit/specs/components/AudioTrack/audio-track.spec.js
+++ b/test/unit/specs/components/AudioTrack/audio-track.spec.js
@@ -3,6 +3,10 @@ import { render } from '@testing-library/vue'
 import Vuei18n from 'vue-i18n'
 import Vuex from 'vuex'
 
+jest.mock('~/composables/use-browser-detection', () => ({
+  useBrowserIsBlink: jest.fn(() => false),
+}))
+
 const enMessages = require('~/locales/en.json')
 const useVueI18n = (vue) => {
   vue.use(Vuei18n)
@@ -46,6 +50,7 @@ const configureVue = (vue) => {
   return {
     i18n,
     store,
+    /** @todo Create a better mock that can be configured to test this behavior.  */
   }
 }
 
@@ -128,9 +133,9 @@ describe('AudioTrack', () => {
 
   it('should show audio title as main page title', () => {
     const { getByText } = render(VAudioTrack, options, configureVue)
-    const element = getByText(props.audio.title)
-    expect(element).toBeInstanceOf(HTMLHeadingElement)
-    expect(element.tagName).toEqual('H1')
+    // Title text appears multiple times in the track, so need to specify selector
+    const element = getByText(props.audio.title, { selector: 'H1' })
+    expect(element).toBeInTheDocument()
   })
 
   it('should show audio creator with link', () => {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #680 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Adds a `featureNotices` feature to the audio track so custom messages can be displayed when any given feature isn't active. It's a bit of an extra abstraction but felt cleaner and simpler than writing some specific hack for this functionality.

## a11y info

When the waveform is disabled, it is no longer focusable, so when users tab from the play button they are sent straight to the next play button. This means they are not explicitly informed about the disabled seek bar, but they're also not incorrectly able to focus the waveform or anything worse like that. I'm not sure how to best approach the _ideal_ solution to this.

## Caveats

I couldn't get our UA detection to run server-only, which I would have liked. Perhaps this could be refactored in the future to add the parsed UA information to a Vuex store instead of injecting it into the Nuxt context, which would preserve the data on client-side renders after the initial server render, but alas, I tried that and wasn't able to get it to work either. For whatever reason it seemed my mutation wouldn't run.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Visit an audio results page in Chrome or Edge and observe the hover effect on a Jamendo track.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
