### PR TITLE
All results audio tabbing, single result link, and play/pause fixes

### DIFF
--- a/src/components/VAllResultsGrid/VAudioCell.vue
+++ b/src/components/VAllResultsGrid/VAudioCell.vue
@@ -1,11 +1,10 @@
 <template>
-  <NuxtLink
-    :to="localePath(`/audio/${audio.id}`)"
-    class="block focus:bg-white focus:border-tx focus:ring focus:ring-pink focus:outline-none focus:shadow-ring rounded-sm"
-    @click.native="navigateToSinglePage(audio)"
-  >
-    <VAudioTrack :audio="audio" layout="box" size="full" />
-  </NuxtLink>
+  <VAudioTrack
+    :audio="audio"
+    layout="box"
+    size="full"
+    @boxedAudioClick="navigateToSinglePage"
+  />
 </template>
 
 <script>
@@ -17,17 +16,10 @@ export default defineComponent({
   components: { VAudioTrack },
   props: ['audio'],
   setup() {
-    const { i18n } = useContext()
+    const { app } = useContext()
     const router = useRouter()
-    const navigateToSinglePage = (audio) => (/** @type MouseEvent */ event) => {
-      if (!event.metaKey && !event.ctrlKey) {
-        event.preventDefault()
-        const detailRoute = i18n.localeRoute({
-          name: 'AudioDetailPage',
-          params: { id: audio.id, location: window.scrollY },
-        })
-        router.push(detailRoute)
-      }
+    const navigateToSinglePage = (audio) => {
+      router.push(app.localePath({ path: `/audio/${audio.id}` }))
     }
 
     return {

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -67,6 +67,7 @@ const propTypes = {
   /**
    * the arrangement of the contents on the canvas; This determines the
    * overall L&F of the audio component.
+   * @todo This type def should be extracted for reuse across components
    */
   layout: {
     type: /** @type {import('@nuxtjs/composition-api').PropType<'full' | 'box' | 'row' | 'global'>} */ (

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -3,6 +3,8 @@
     class="audio-track"
     :aria-label="$t('audio-track.aria-label')"
     role="region"
+    v-bind="layoutBasedProps"
+    v-on="layoutBasedListeners"
   >
     <Component :is="layoutComponent" :audio="audio" :size="size">
       <template #controller="waveformProps">
@@ -18,6 +20,7 @@
 
       <template #play-pause="playPauseProps">
         <VPlayPause
+          ref="playPauseRef"
           :status="status"
           v-bind="playPauseProps"
           @toggle="handleToggle"
@@ -112,7 +115,7 @@ export default defineComponent({
     VGlobalLayout,
   },
   props: propTypes,
-  setup(props) {
+  setup(props, { emit }) {
     const store = useStore()
     const route = useRoute()
 
@@ -329,6 +332,47 @@ export default defineComponent({
     }
     const layoutComponent = computed(() => layoutMappings[props.layout])
 
+    /**
+     * A ref used on the play/pause button,
+     * so we can capture clicks and skip
+     * sending an event to the boxed layout.
+     */
+    const playPauseRef = ref(null)
+
+    /**
+     * These layout-conditional props and listeners allow us
+     * to set properties on the parent element depending on
+     * the layout in use. This is currently relevant for the
+     * boxed layout exclusively.
+     */
+    const isBoxed = computed(() => props.layout === 'box')
+    const layoutBasedProps = computed(() => {
+      if (!isBoxed.value) return {}
+      return {
+        tabindex: isBoxed.value ? 0 : -1,
+        class:
+          'block focus:bg-white focus:border-tx focus:ring focus:ring-pink focus:outline-none focus:shadow-ring rounded-sm overflow-hidden cursor-pointer',
+      }
+    })
+    const layoutBasedListeners = computed(() => {
+      if (!isBoxed.value) return {}
+      return {
+        click: (event) => {
+          // Emit an event when the boxed layout is clicked
+          // unless the click is on the play/pause button
+          if (event.target === playPauseRef?.value?.$el) return
+          emit('boxedAudioClick', props.audio)
+        },
+        keydown: (event) => {
+          // 32 is Spacebar
+          if (event.keyCode !== 32) return
+          event.preventDefault()
+          status.value = status.value === 'playing' ? 'paused' : 'playing'
+          handleToggle(status.value)
+        },
+      }
+    })
+
     return {
       status,
       message,
@@ -339,6 +383,11 @@ export default defineComponent({
       duration,
 
       layoutComponent,
+
+      layoutBasedProps,
+      layoutBasedListeners,
+
+      playPauseRef,
     }
   },
 })

--- a/src/components/VAudioTrack/VGlobalAudioTrack.vue
+++ b/src/components/VAudioTrack/VGlobalAudioTrack.vue
@@ -57,6 +57,7 @@ const propTypes = {
   /**
    * the arrangement of the contents on the canvas; This determines the
    * overall L&F of the audio component.
+   * @todo This type def should be extracted for reuse across components
    */
   layout: {
     type: /** @type {import('@nuxtjs/composition-api').PropType<'full' | 'box' | 'row' | 'global'>} */ (

--- a/src/components/VAudioTrack/VPlayPause.vue
+++ b/src/components/VAudioTrack/VPlayPause.vue
@@ -1,6 +1,7 @@
 <template>
   <VIconButton
     v-bind="$attrs"
+    :tabindex="layout === 'box' ? -1 : 0"
     class="play-pause flex-shrink-0 bg-dark-charcoal border-dark-charcoal text-white disabled:opacity-70"
     :icon-props="{ iconPath: icon }"
     :aria-label="$t(label)"
@@ -36,6 +37,20 @@ export default defineComponent({
     status: {
       type: String,
       validator: (val) => ['playing', 'paused', 'played'].includes(val),
+    },
+    /**
+     * The parent audio layout currently in use
+     * @todo This type def should be extracted for reuse across components
+     */
+    layout: {
+      type: /** @type {import('@nuxtjs/composition-api').PropType<'full' | 'box' | 'row' | 'global'>} */ (
+        String
+      ),
+      default: 'full',
+      /**
+       * @param {string} val
+       */
+      validator: (val) => ['full', 'box', 'row', 'global'].includes(val),
     },
   },
   data() {

--- a/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -20,7 +20,7 @@
         </div>
 
         <div class="hidden player md:flex flex-row">
-          <slot name="play-pause" size="small" />
+          <slot name="play-pause" size="small" layout="box" />
           <slot name="controller" :features="[]" />
         </div>
       </div>

--- a/src/components/VIconButton/VIconButton.vue
+++ b/src/components/VIconButton/VIconButton.vue
@@ -5,7 +5,11 @@
     :type="type"
     v-on="$listeners"
   >
-    <VIcon :class="[...iconSizeClasses]" v-bind="iconProps" />
+    <VIcon
+      class="pointer-events-none"
+      :class="[...iconSizeClasses]"
+      v-bind="iconProps"
+    />
   </button>
 </template>
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #662 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

- Spacebar or play button click to play/pause on boxed audio
- Click or enter to visit single result

We probably still need to announce to screen reader users that space will play/pause and click will visit the single result. There may be a way to do what I'm doing _and_ wrap in a NuxtLink for improved usability.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
