### PR TITLE
Always show search title, even when search has no results

### DIFF
--- a/src/components/VItemGroup/VItem.vue
+++ b/src/components/VItemGroup/VItem.vue
@@ -114,7 +114,6 @@ export default defineComponent({
     const isFocused = ref(false)
     const isInPopover = inject(VPopoverContentContextKey, false)
     const contextProps = inject(VItemGroupContextKey)
-    console.log('vitem', contextProps)
 
     if (isInPopover && contextProps.bordered) {
       warn('Bordered popover items are not supported')

--- a/src/components/VSearchGrid.vue
+++ b/src/components/VSearchGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="">
     <header
-      v-if="query.q && isSupported && !noresult"
+      v-if="query.q && isSupported"
       class="mt-4"
       :class="isAllView ? 'mb-10' : 'mb-8'"
     >
@@ -26,28 +26,11 @@
 </template>
 
 <script>
-import { computed, useContext } from '@nuxtjs/composition-api'
-import { ALL_MEDIA, AUDIO, IMAGE } from '~/constants/media'
+import { computed } from '@nuxtjs/composition-api'
+import { resultsCount } from '~/composables/use-i18n-utilities'
+import { supportedContentTypes } from '~/constants/media'
 
 import VMetaSearchForm from '~/components/VMetaSearch/VMetaSearchForm.vue'
-
-const i18nKeys = {
-  [ALL_MEDIA]: {
-    noResult: 'browse-page.all-no-results',
-    result: 'browse-page.all-result-count',
-    more: 'browse-page.all-result-count-more',
-  },
-  [AUDIO]: {
-    noResult: 'browse-page.audio-no-results',
-    result: 'browse-page.audio-result-count',
-    more: 'browse-page.audio-result-count-more',
-  },
-  [IMAGE]: {
-    noResult: 'browse-page.image-no-results',
-    result: 'browse-page.image-result-count',
-    more: 'browse-page.image-result-count-more',
-  },
-}
 
 export default {
   name: 'VSearchGrid',
@@ -74,14 +57,6 @@ export default {
     },
   },
   setup(props) {
-    const { i18n } = useContext()
-    const shouldShowMeta = computed(() => {
-      return (
-        props.supported &&
-        props.query.q.trim() !== '' &&
-        !props.fetchState.isFetching
-      )
-    })
     /**
      * The translated string showing how many results were found for
      * this media type.
@@ -90,13 +65,7 @@ export default {
      */
     const mediaCount = computed(() => {
       if (!props.supported) return
-
-      const count = props.resultsCount
-      const countKey =
-        count === 0 ? 'noResult' : count >= 10000 ? 'more' : 'result'
-      const i18nKey = i18nKeys[props.query.mediaType][countKey]
-      const localeCount = count.toLocaleString(i18n.locale)
-      return i18n.tc(i18nKey, count, { localeCount })
+      return resultsCount(props.resultsCount, props.query.mediaType)
     })
 
     const noresult = computed(() => {
@@ -107,7 +76,7 @@ export default {
         : false
     })
     const isSupported = computed(() => {
-      return props.searchType === 'all' ? true : props.supported
+      return supportedContentTypes.includes(props.searchType)
     })
     const metaSearchFormType = computed(() => {
       return props.searchType === 'all' ? 'image' : props.searchType
@@ -119,7 +88,6 @@ export default {
     return {
       mediaCount,
       noresult,
-      shouldShowMeta,
       isSupported,
       metaSearchFormType,
       isAllView,


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #670 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR removes the check for `noresult` in the search results page to always show the search term as a page title. This prevents layout shifts.

It also removes unused functions, and uses constants to check for content type supported status, and removes a stray log.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app and search for something that doesn't exist :) See that layout doesn't shift, although the skeletons and the meta search form appear and then disappear (this should be addressed in a separate PR).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
