### PR TITLE
Allow focusing specific element when opening modal

### DIFF
--- a/src/components/VContentSwitcher/VContentTypes.vue
+++ b/src/components/VContentSwitcher/VContentTypes.vue
@@ -25,9 +25,9 @@ import useContentType from '~/composables/use-content-type'
 
 import VItemGroup from '~/components/VItemGroup/VItemGroup.vue'
 import VContentItem from '~/components/VContentSwitcher/VContentItem.vue'
-import { computed } from '@nuxtjs/composition-api'
+import { computed, defineComponent } from '@nuxtjs/composition-api'
 
-export default {
+export default defineComponent({
   name: 'VContentTypes',
   components: { VItemGroup, VContentItem },
   props: {
@@ -58,5 +58,5 @@ export default {
       handleClick,
     }
   },
-}
+})
 </script>

--- a/src/components/VContentSwitcher/VMobileMenuModal.vue
+++ b/src/components/VContentSwitcher/VMobileMenuModal.vue
@@ -15,9 +15,11 @@
       :trigger-element="triggerRef"
       :hide="close"
       :aria-label="$t('header.filter-button.simple')"
+      :initial-focus-element="initialFocusElement"
     >
       <nav class="p-6" aria-labelledby="content-switcher-heading">
         <VContentTypes
+          ref="contentTypesNode"
           size="small"
           :active-item="content.activeType.value"
           @select="selectItem"
@@ -29,7 +31,13 @@
 </template>
 
 <script>
-import { onMounted, reactive, ref, watch } from '@nuxtjs/composition-api'
+import {
+  onMounted,
+  reactive,
+  ref,
+  watch,
+  computed,
+} from '@nuxtjs/composition-api'
 import { useBodyScrollLock } from '~/composables/use-body-scroll-lock'
 import useContentType from '~/composables/use-content-type'
 import usePages from '~/composables/use-pages'
@@ -61,6 +69,8 @@ export default {
     const content = useContentType()
     const pages = usePages()
 
+    /** @type {import('@nuxtjs/composition-api').Ref<import('vue/types/vue').Vue | null>} */
+    const contentTypesNode = ref(null)
     const modalRef = ref(null)
     const triggerContainerRef = ref(null)
 
@@ -76,6 +86,10 @@ export default {
 
     const triggerRef = ref()
     onMounted(() => (triggerRef.value = triggerContainerRef.value?.firstChild))
+
+    const initialFocusElement = computed(() =>
+      contentTypesNode.value?.$el?.querySelector('[aria-checked="true"]')
+    )
 
     watch([visibleRef], ([visible]) => {
       triggerA11yProps['aria-expanded'] = visible
@@ -130,6 +144,8 @@ export default {
       triggerA11yProps,
       visibleRef,
       selectItem,
+      initialFocusElement,
+      contentTypesNode,
     }
   },
 }

--- a/src/components/VModal/VMobileModalContent.vue
+++ b/src/components/VModal/VMobileModalContent.vue
@@ -102,6 +102,12 @@ const VMobileModalContent = defineComponent({
         process.server ? Object : HTMLElement
       ),
     },
+    initialFocusElement: {
+      type: /** @type {import('@nuxtjs/composition-api').PropType<HTMLElement>} */ (
+        process.server ? Object : HTMLElement
+      ),
+      required: false,
+    },
   },
   setup(props, { emit, attrs }) {
     if (!attrs['aria-label'] && !attrs['aria-labelledby']) {
@@ -119,6 +125,7 @@ const VMobileModalContent = defineComponent({
       hideOnClickOutsideRef: propsRefs.hideOnClickOutside,
       hideRef: propsRefs.hide,
       hideOnEscRef: propsRefs.hideOnEsc,
+      initialFocusElementRef: propsRefs.initialFocusElement,
       emit,
     })
 

--- a/src/components/VModal/VModal.vue
+++ b/src/components/VModal/VModal.vue
@@ -22,6 +22,7 @@
       :hide="close"
       :aria-label="label"
       :aria-labelledby="labelledBy"
+      :initial-focus-element="initialFocusElement"
     >
       <slot name="default" />
     </VModalContent>
@@ -86,6 +87,20 @@ export default defineComponent({
      * @default undefined
      */
     labelledBy: { type: String },
+    /**
+     * The element to focus when the modal is opened. If nothing is
+     * passed, then the first tabbable element in the modal content
+     * will be focused. If no tabbable element is found in the modal
+     * content, then the entire modal content itself will be focused.
+     *
+     * @default undefined
+     */
+    initialFocusElement: {
+      type: /** @type {import('@nuxtjs/composition-api').PropType<HTMLElement>} */ (
+        process.server ? Object : HTMLElement
+      ),
+      default: undefined,
+    },
   },
   emits: [
     /**

--- a/src/components/VModal/VModalContent.vue
+++ b/src/components/VModal/VModalContent.vue
@@ -85,6 +85,12 @@ const VModalContent = defineComponent({
         process.server ? Object : HTMLElement
       ),
     },
+    initialFocusElement: {
+      type: /** @type {import('@nuxtjs/composition-api').PropType<HTMLElement>} */ (
+        process.server ? Object : HTMLElement
+      ),
+      required: false,
+    },
   },
   setup(props, { emit, attrs }) {
     if (!attrs['aria-label'] && !attrs['aria-labelledby']) {
@@ -102,6 +108,7 @@ const VModalContent = defineComponent({
       hideOnClickOutsideRef: propsRefs.hideOnClickOutside,
       hideRef: propsRefs.hide,
       hideOnEscRef: propsRefs.hideOnEsc,
+      initialFocusElementRef: propsRefs.initialFocusElement,
       emit,
     })
 

--- a/src/components/VModal/meta/VModal.stories.js
+++ b/src/components/VModal/meta/VModal.stories.js
@@ -1,3 +1,5 @@
+import { ref, computed } from '@nuxtjs/composition-api'
+
 import VModal from '~/components/VModal/VModal.vue'
 import VModalTarget from '~/components/VModal/VModalTarget.vue'
 import VButton from '~/components/VButton.vue'
@@ -13,13 +15,17 @@ export default {
     autoFocusOnHide: 'boolean',
     label: 'text',
     labelledBy: 'text',
+    useCustomInitialFocus: {
+      type: 'boolean',
+      default: false,
+    },
   },
 }
 
 const DefaultStory = (args, { argTypes }) => ({
   template: `
     <div>
-      <VModal v-bind="$props">
+      <VModal v-bind="$props" :initial-focus-element="resolvedInitialFocusElement">
         <template #trigger="{ a11yProps, visible }">
           <VButton v-bind="a11yProps">{{ visible ? 'Modal open' : 'Modal closed' }}</VButton>
         </template>
@@ -42,6 +48,8 @@ const DefaultStory = (args, { argTypes }) => ({
           <p class="pt-5">
             Polymer is a Javascript NoSQL database. Passport. JavaScript web apps. Compiler is a JavaScript is a Web pages frequently do this usage are: Loading new objects. 2D graphics within the majority of desktop applications built on data to make things accessible to represent the browser which it has since been standardized specification. Test-Driven Development. WebGL is said to pages and out, resizing them, etc. Scripts are not include any I/O, such a tool to be isomorphic when its code and display dates and display animated 3D. C. Factory Pattern is a way for Behaviour-Driven Development. API for Behaviour-Driven Development. JSX is a design. Ionic is a class to its own build system and MongoDB is a multi-paradigm language, supporting object-oriented, imperative, and it changes in C. Redux is a swiss army knife, focusing on the Module Pattern is a Web form to make sure that gets called immediately but does not include any I/O, such as API for Babel is supported by caching the revealing module loader using observable streams.
           </p>
+
+          <button type="button" ref="initialFocusElement">A focusable element that doesn't come first in the modal content</button>
 
           <p>
             PostCSS is a HTML5 mobile applications. Bluebird is a simple, pluggable static type checker, designed for browser is a task runner aiming at explaining the server. Native development. Patterns is a framework for dynamic web. Flux is a swiss army knife, focusing on Node. Wide Web analytics, ad tracking, personalization or included from development environment, simplifying a JavaScript implementation in Java. Mediator Pattern is used in and media queries. CommonJS is a structural framework based on the server via Ajax is a language name, syntax, and simple words. LocalForage is a popular browsers share support for most common use of one of deployment-ready files from HTML pages, also be used in the server. Arity is a JavaScript engine. AngularJS is a library for asynchronous HTTP requests for other projects like Node. VMs and the three core technologies of their containing scope. Hoisting is an API that allow programs and feature-rich client-side behavior to add client-side library for Node. Redux is by Nitobi. Rhino, like SpiderMonkey, is a Node.
@@ -76,6 +84,15 @@ const DefaultStory = (args, { argTypes }) => ({
   `,
   components: { VButton, VModal, VModalTarget, VPopover },
   props: Object.keys(argTypes),
+  setup(props) {
+    const initialFocusElement = ref()
+
+    const resolvedInitialFocusElement = computed(() =>
+      props.useCustomInitialFocus ? initialFocusElement.value : undefined
+    )
+
+    return { initialFocusElement, resolvedInitialFocusElement }
+  },
 })
 
 export const Default = DefaultStory.bind({})

--- a/src/composables/use-dialog-content.js
+++ b/src/composables/use-dialog-content.js
@@ -12,6 +12,7 @@ import { useFocusOnBlur } from '~/composables/use-focus-on-blur'
  * @property {boolean} autoFocusOnHideRef
  * @property {boolean} hideOnClickOutsideRef
  * @property {boolean} hideOnEscRef
+ * @property {HTMLElement} initialFocusElementRef
  * @property {() => void} hideRef
  */
 

--- a/src/composables/use-focus-on-show.js
+++ b/src/composables/use-focus-on-show.js
@@ -1,4 +1,4 @@
-import { watch } from '@nuxtjs/composition-api'
+import { ref, watch } from '@nuxtjs/composition-api'
 import { getFirstTabbableIn } from 'reakit-utils/tabbable'
 import { hasFocusWithin } from 'reakit-utils/hasFocusWithin'
 import { ensureFocus } from 'reakit-utils/ensureFocus'
@@ -13,6 +13,7 @@ export const noFocusableElementWarning =
  * @property {import('./types').Ref<HTMLElement>} dialogRef
  * @property {import('./types').Ref<boolean>} visibleRef
  * @property {import('./types').Ref<boolean>} autoFocusOnShowRef
+ * @property {import('./types').Ref<HTMLElement>} initialFocusElementRef
  */
 
 /**
@@ -23,14 +24,22 @@ export const useFocusOnShow = ({
   dialogRef,
   visibleRef,
   autoFocusOnShowRef,
+  initialFocusElementRef = ref(),
 }) => {
   watch(
-    [dialogRef, visibleRef, autoFocusOnShowRef],
+    [dialogRef, visibleRef, autoFocusOnShowRef, initialFocusElementRef],
     /**
-     * @param {[HTMLElement, boolean, boolean]} values
+     * @param {[HTMLElement, boolean, boolean, HTMLElement]} values
      */
-    ([dialog, visible, autoFocusOnShow]) => {
+    ([dialog, visible, autoFocusOnShow, initialFocusElement]) => {
       if (!dialog || !visible || !autoFocusOnShow) return
+
+      if (initialFocusElement) {
+        return ensureFocus(initialFocusElement, {
+          preventScroll: true,
+          isActive,
+        })
+      }
 
       const tabbable = getFirstTabbableIn(dialog, true)
       const isActive = () => hasFocusWithin(dialog)

--- a/src/composables/use-focus-on-show.js
+++ b/src/composables/use-focus-on-show.js
@@ -34,6 +34,8 @@ export const useFocusOnShow = ({
     ([dialog, visible, autoFocusOnShow, initialFocusElement]) => {
       if (!dialog || !visible || !autoFocusOnShow) return
 
+      const isActive = () => hasFocusWithin(dialog)
+
       if (initialFocusElement) {
         return ensureFocus(initialFocusElement, {
           preventScroll: true,
@@ -42,7 +44,6 @@ export const useFocusOnShow = ({
       }
 
       const tabbable = getFirstTabbableIn(dialog, true)
-      const isActive = () => hasFocusWithin(dialog)
 
       if (tabbable) {
         ensureFocus(tabbable, { preventScroll: true, isActive })

--- a/test/unit/specs/components/v-modal.spec.js
+++ b/test/unit/specs/components/v-modal.spec.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import { ref, computed } from '@nuxtjs/composition-api'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
@@ -8,14 +9,26 @@ import VButton from '~/components/VButton.vue'
 
 const TestWrapper = Vue.component('TestWrapper', {
   components: { VModal, VButton, VModalTarget },
+  props: ['useCustomInitialFocus'],
+  setup(props) {
+    const initialFocusElement = ref()
+
+    const resolvedInitialFocusElement = computed(() =>
+      props.useCustomInitialFocus ? initialFocusElement.value : undefined
+    )
+
+    return { initialFocusElement, resolvedInitialFocusElement }
+  },
   template: `
     <div>
-      <VModal label="modal label">
+      <VModal label="modal label" :initial-focus-element="resolvedInitialFocusElement">
         <template #trigger="{ a11yProps, visible }">
           <VButton v-bind="a11yProps">{{ visible }}</VButton>
         </template>
 
         <div>Code is Poetry</div>
+
+        <button ref="initialFocusElement" type="button">Custom initial focus</button>
       </VModal>
       <VModalTarget />
     </div>
@@ -25,6 +38,7 @@ const TestWrapper = Vue.component('TestWrapper', {
 const nextTick = async () =>
   await new Promise((resolve) => setTimeout(resolve, 1))
 
+const getCloseButton = () => screen.getByText('modal.close')
 const getDialog = () => screen.getByRole('dialog')
 const queryDialog = () => screen.queryByRole('dialog')
 const getTrigger = () => screen.getByRole('button')
@@ -56,7 +70,7 @@ describe('VModal', () => {
 
     expect(getDialog()).toBeVisible()
 
-    await userEvent.click(screen.getByText('modal.close'))
+    await userEvent.click(getCloseButton())
     await nextTick()
 
     expect(queryDialog()).toBe(null)
@@ -77,5 +91,21 @@ describe('VModal', () => {
 
     expect(window.scrollTo).toHaveBeenCalledWith(0, scrollY)
     expect(container.ownerDocument.body.style.position).not.toBe('fixed')
+  })
+
+  it('should focus the close button by default', async () => {
+    render(TestWrapper)
+    await doOpen()
+
+    expect(getDialog()).toBeVisible()
+    expect(getCloseButton()).toHaveFocus()
+  })
+
+  it('should focus the explicit initial focus element when specified', async () => {
+    render(TestWrapper, { props: { useCustomInitialFocus: true } })
+    await doOpen()
+
+    expect(getDialog()).toBeVisible()
+    expect(screen.getByText(/custom initial focus/i))
   })
 })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #641 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In order to fix the issue where opening the mobile content type switcher was focusing the wrong element, we needed to update the modal to allow for this behavior to specify the element we want to focus when the content is shown.

Even though we only needed this for the mobile menu content modal, I went ahead and implemented it in the default modal component and added a story control to demonstrate it working in the story.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the branch and run `pnpm dev`. Visit the search page with a narrow width viewport and open the content type switcher using the keyboard. It should focus the active content type button. Be sure to try different content types being selected. It should always focus the active one.

For good measure, run `pnpm storybook` and visit the modal story http://localhost:6006/?path=/story/components-vmodal--default&args=useCustomInitialFocus:true with `useCustomInitialFocus` control set to `true`. Ensure that it focuses the button in the middle of the modal content instead of the default of the first tabbable element (in this case the close button). Toggle the control to `false` and ensure that the close button is focused on that case.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
