### PR TITLE
Expose `close` to popover content via slot props

### DIFF
--- a/src/components/ImageDetails/VPhotoDetails.vue
+++ b/src/components/ImageDetails/VPhotoDetails.vue
@@ -30,17 +30,11 @@
       </p>
 
       <VPopover
-        ref="reportPopoverRef"
         :z-index="20"
         :aria-label="$t('photo-details.content-report.title')"
       >
         <template #trigger="{ a11yProps }">
-          <VButton
-            v-bind="a11yProps"
-            variant="plain"
-            class="mt-2"
-            @click="reportForm.toggleVisibility"
-          >
+          <VButton v-bind="a11yProps" variant="plain" class="mt-2">
             {{ $t('photo-details.content-report.title') }}
             <VIcon
               :icon-path="icons.flag"
@@ -48,13 +42,15 @@
             />
           </VButton>
         </template>
-        <VContentReportForm
-          :image="image"
-          :provider-name="providerName"
-          data-testid="content-report-form"
-          class="mt-2 text-left w-80 whitespace-normal"
-          @close-form="reportForm.close()"
-        />
+        <template #default="{ close }">
+          <VContentReportForm
+            :image="image"
+            :provider-name="providerName"
+            data-testid="content-report-form"
+            class="mt-2 text-left w-80 whitespace-normal"
+            @close-form="close"
+          />
+        </template>
       </VPopover>
     </div>
     <div
@@ -214,8 +210,6 @@ export default {
     const router = useRouter()
     const sketchFabfailure = ref(false)
     const activeTab = ref(0)
-    const isReportFormVisible = ref(false)
-    const reportPopoverRef = ref(null)
 
     const imgUrl = computed(() => {
       return isLoaded.value ? props.image.url : props.thumbnail
@@ -259,19 +253,6 @@ export default {
     }
     const setActiveTab = (tabIdx) => (activeTab.value = tabIdx)
 
-    const onCloseReportForm = () => {
-      isReportFormVisible.value = false
-      if (reportPopoverRef.value) {
-        reportPopoverRef.value?.close()
-      }
-    }
-    const toggleReportFormVisibility = () => {
-      if (isReportFormVisible.value && reportPopoverRef.value) {
-        reportPopoverRef.value?.close()
-      }
-      isReportFormVisible.value = !isReportFormVisible.value
-    }
-
     const sendEvent = (eventType) => {
       const eventData = {
         eventType,
@@ -290,7 +271,6 @@ export default {
       isLoaded,
       sketchFabUid,
       sketchFabfailure,
-      isReportFormVisible,
       goBackToSearchResults,
       linkClicked: {
         photoSource: onPhotoSourceLinkClicked,
@@ -299,10 +279,6 @@ export default {
       license: {
         url: licenseUrl.value,
         fullName: fullLicenseName.value,
-      },
-      reportForm: {
-        close: onCloseReportForm,
-        toggleVisibility: toggleReportFormVisibility,
       },
       icons: {
         chevronLeft,
@@ -315,7 +291,6 @@ export default {
       setActiveTab,
 
       providerName,
-      reportPopoverRef,
     }
   },
 }

--- a/src/components/VHeader/VPageMenu/VDesktopPageMenu.vue
+++ b/src/components/VHeader/VPageMenu/VDesktopPageMenu.vue
@@ -1,19 +1,15 @@
 <template>
-  <VPopover
-    ref="pageMenuPopover"
-    class="flex mx-2 items-stretch"
-    :label="$t('header.aria.menu')"
-  >
+  <VPopover class="flex mx-2 items-stretch" :label="$t('header.aria.menu')">
     <template #trigger="{ a11yProps }">
       <VPageMenuButton :a11y-props="a11yProps" />
     </template>
-    <VPageList layout="vertical" @click="closeMenu" />
+    <template #default="{ close }">
+      <VPageList layout="vertical" @click="close" />
+    </template>
   </VPopover>
 </template>
 
 <script>
-import { ref } from '@nuxtjs/composition-api'
-
 import VPopover from '~/components/VPopover/VPopover.vue'
 import VPageMenuButton from '~/components/VHeader/VPageMenu/VPageMenuButton.vue'
 import VPageList from '~/components/VHeader/VPageMenu/VPageList.vue'
@@ -24,23 +20,6 @@ export default {
     VPageMenuButton,
     VPageList,
     VPopover,
-  },
-  setup() {
-    const pageMenuPopover = ref(null)
-
-    /**
-     * Only the contentMenuPopover needs to be closed programmatically
-     */
-    const closeMenu = () => {
-      if (pageMenuPopover.value) {
-        pageMenuPopover.value.close()
-      }
-    }
-
-    return {
-      pageMenuPopover,
-      closeMenu,
-    }
   },
 }
 </script>

--- a/src/components/VPopover/VPopover.vue
+++ b/src/components/VPopover/VPopover.vue
@@ -30,7 +30,7 @@
       :aria-labelledby="labelledBy"
     >
       <!-- @slot The content of the popover -->
-      <slot name="default" />
+      <slot name="default" :controls="{ close }" />
     </VPopoverContent>
   </div>
 </template>

--- a/src/components/VPopover/VPopover.vue
+++ b/src/components/VPopover/VPopover.vue
@@ -29,8 +29,11 @@
       :aria-label="label"
       :aria-labelledby="labelledBy"
     >
-      <!-- @slot The content of the popover -->
-      <slot name="default" :controls="{ close }" />
+      <!--
+        @slot The content of the popover
+          @binding {function} close
+      -->
+      <slot name="default" :close="close" />
     </VPopoverContent>
   </div>
 </template>

--- a/src/components/VPopover/meta/VPopover.stories.js
+++ b/src/components/VPopover/meta/VPopover.stories.js
@@ -54,9 +54,9 @@ const ControlStory = (args, { argTypes }) => ({
       <template #trigger="{ visible, a11yProps }">
         <VButton :pressed="visible" v-bind="a11yProps">{{ visible ? 'Close' : 'Open' }}</VButton>
       </template>
-      <template #default="{ controls }">
+      <template #default="{ close }">
         <div class="p-4">
-        <VButton @click="controls.close">Close popover</VButton>
+        <VButton @click="close">Close popover</VButton>
         </div>
       </template>
     </VPopover>

--- a/src/components/VPopover/meta/VPopover.stories.js
+++ b/src/components/VPopover/meta/VPopover.stories.js
@@ -47,6 +47,25 @@ const SinglePopoverStory = (args, { argTypes }) => ({
 export const Default = SinglePopoverStory.bind({})
 Default.args = {}
 
+const ControlStory = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  template: `
+    <VPopover>
+      <template #trigger="{ visible, a11yProps }">
+        <VButton :pressed="visible" v-bind="a11yProps">{{ visible ? 'Close' : 'Open' }}</VButton>
+      </template>
+      <template #default="{ controls }">
+        <div class="p-4">
+        <VButton @click="controls.close">Close popover</VButton>
+        </div>
+      </template>
+    </VPopover>
+  `,
+})
+
+export const Control = ControlStory.bind({})
+Control.args = {}
+
 const TwoPopoverStory = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #725 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR exposes `close` as a slot prop to VPopover content. The default slot can access the `close` function by tapping into the `controls` slot prop.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the branch and run the Storybook.
1. Play with the "Control" story under "Components/VPopover".

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
