### PR TITLE
Make audio/image pages without ids show a 404

### DIFF
--- a/src/components/VFourOhFour.vue
+++ b/src/components/VFourOhFour.vue
@@ -1,0 +1,130 @@
+<template>
+  <main class="bg-yellow h-screen relative page-404 overflow-x-hidden">
+    <NuxtLink to="/" class="relative z-10 text-dark-charcoal">
+      <span class="sr-only">{{ $t('404.link-title') }}</span>
+      <OpenverseLogo
+        aria-hidden="true"
+        class="pt-6 lg:pt-8 ms-6 lg:ms-10 w-30 h-auto"
+      />
+    </NuxtLink>
+    <Oops
+      aria-hidden="true"
+      class="absolute opacity-5 fill-dark-charcoal -mt-[10%] -ml-[20%] lg:mx-auto w-[140%] lg:w-full px-6 lg:px-16 z-0 pointer-events-none"
+    />
+    <header
+      class="absolute lg:max-w-2xl space-y-4 lg:space-y-6 top-1/4 z-10 left-0 right-0 mx-auto px-6 lg:px-0"
+    >
+      <h1 class="mb-6 lg:mb-10 lg:leading-tight text-3xl lg:text-6xl">
+        {{ $t('404.title') }}
+      </h1>
+      <p class="font-semibold">
+        <i18n path="404.main">
+          <template #link>
+            <NuxtLink
+              class="underline text-current hover:text-current active:text-current"
+              to="/"
+            >
+              {{ $t('404.link-title') }}
+            </NuxtLink>
+          </template>
+        </i18n>
+      </p>
+      <VSearchBar
+        :value="searchTerm"
+        :label-text="$t('404.search-placeholder')"
+        field-id="404-search"
+        :placeholder="$t('404.search-placeholder')"
+        @input="setSearchTerm"
+        @submit="handleSearch"
+      />
+    </header>
+  </main>
+</template>
+
+<script>
+import {
+  defineComponent,
+  ref,
+  useContext,
+  useRouter,
+} from '@nuxtjs/composition-api'
+import { MEDIA, SEARCH } from '~/constants/store-modules'
+import { FETCH_MEDIA, UPDATE_QUERY } from '~/constants/action-types'
+
+import Oops from '~/assets/oops.svg?inline'
+import OpenverseLogo from '~/assets/logo.svg?inline'
+import VSearchBar from '~/components/VHeader/VSearchBar/VSearchBar'
+
+const VFourOhFour = defineComponent({
+  name: 'VFourOhFour',
+  components: {
+    OpenverseLogo,
+    Oops,
+    VSearchBar,
+  },
+  props: ['error'],
+  setup() {
+    const { app, store } = useContext()
+    const router = useRouter()
+
+    const searchTerm = ref('')
+    const setSearchTerm = (value) => {
+      searchTerm.value = value
+    }
+
+    const handleSearch = async () => {
+      if (searchTerm.value === '') return
+
+      await store.dispatch(`${SEARCH}/${UPDATE_QUERY}`, {
+        q: searchTerm.value,
+      })
+      await store.dispatch(`${MEDIA}/${FETCH_MEDIA}`, {
+        query: { q: searchTerm.value },
+      })
+
+      router.push(
+        app.localePath({
+          path: `/search`,
+          query: { q: searchTerm.value },
+        })
+      )
+    }
+
+    return {
+      searchTerm,
+      setSearchTerm,
+      handleSearch,
+    }
+  },
+  head: {
+    meta: [
+      {
+        hid: 'theme-color',
+        name: 'theme-color',
+        content: '#ffe033',
+      },
+    ],
+  },
+})
+export default VFourOhFour
+</script>
+
+<style>
+/* Override the default search bar styles.
+   Maybe in the future this would warrant a
+   variant of the searchbar, but that seems
+   excessive for this one-off usage.
+*/
+.page-404 .search-bar > div:not(:focus):not(:focus-within) {
+  border-color: black;
+}
+.page-404
+  .search-bar:not(:hover)
+  button:not(:hover):not(:focus):not(:focus-within) {
+  border-color: black;
+  border-inline-start-color: transparent;
+}
+.page-404 .search-bar button {
+  border-width: 1px;
+}
+</style>

--- a/src/layouts/error.vue
+++ b/src/layouts/error.vue
@@ -1,131 +1,16 @@
 <template>
-  <main class="bg-yellow h-screen relative page-404 overflow-x-hidden">
-    <NuxtLink to="/" class="relative z-10 text-dark-charcoal">
-      <span class="sr-only">{{ $t('404.link-title') }}</span>
-      <OpenverseLogo
-        aria-hidden="true"
-        class="pt-6 lg:pt-8 ms-6 lg:ms-10 w-30 h-auto"
-      />
-    </NuxtLink>
-    <Oops
-      aria-hidden="true"
-      class="absolute opacity-5 fill-dark-charcoal -mt-[10%] -ml-[20%] lg:mx-auto w-[140%] lg:w-full px-6 lg:px-16 z-0 pointer-events-none"
-    />
-    <header
-      class="absolute lg:max-w-2xl space-y-4 lg:space-y-6 top-1/4 z-10 left-0 right-0 mx-auto px-6 lg:px-0"
-    >
-      <h1 class="mb-6 lg:mb-10 lg:leading-tight text-3xl lg:text-6xl">
-        {{ $t('404.title') }}
-      </h1>
-      <p class="font-semibold">
-        <i18n path="404.main">
-          <template #link>
-            <NuxtLink
-              class="underline text-current hover:text-current active:text-current"
-              to="/"
-            >
-              {{ $t('404.link-title') }}
-            </NuxtLink>
-          </template>
-        </i18n>
-      </p>
-      <VSearchBar
-        :value="searchTerm"
-        :label-text="$t('404.search-placeholder')"
-        field-id="404-search"
-        :placeholder="$t('404.search-placeholder')"
-        @input="setSearchTerm"
-        @submit="handleSearch"
-      />
-    </header>
-  </main>
+  <VFourOhFour :error="error" />
 </template>
 
 <script>
-import {
-  defineComponent,
-  ref,
-  useContext,
-  useRouter,
-} from '@nuxtjs/composition-api'
-import { MEDIA, SEARCH } from '~/constants/store-modules'
-import { FETCH_MEDIA, UPDATE_QUERY } from '~/constants/action-types'
-
-import Oops from '~/assets/oops.svg?inline'
-import OpenverseLogo from '~/assets/logo.svg?inline'
-import VSearchBar from '~/components/VHeader/VSearchBar/VSearchBar'
+import { defineComponent } from '@nuxtjs/composition-api'
+import VFourOhFour from '~/components/VFourOhFour.vue'
 
 const Error = defineComponent({
   name: 'ErrorPage',
-  components: {
-    OpenverseLogo,
-    Oops,
-    VSearchBar,
-  },
+  components: { VFourOhFour },
   layout: 'blank',
   props: ['error'],
-  setup() {
-    const { app, store } = useContext()
-    const router = useRouter()
-
-    const searchTerm = ref('')
-    const setSearchTerm = (value) => {
-      searchTerm.value = value
-    }
-
-    const handleSearch = async () => {
-      if (searchTerm.value === '') return
-
-      await store.dispatch(`${SEARCH}/${UPDATE_QUERY}`, {
-        q: searchTerm.value,
-      })
-      await store.dispatch(`${MEDIA}/${FETCH_MEDIA}`, {
-        query: { q: searchTerm.value },
-      })
-
-      router.push(
-        app.localePath({
-          path: `/search`,
-          query: { q: searchTerm.value },
-        })
-      )
-    }
-
-    return {
-      searchTerm,
-      setSearchTerm,
-      handleSearch,
-    }
-  },
-  head: {
-    meta: [
-      {
-        hid: 'theme-color',
-        name: 'theme-color',
-        content: '#ffe033',
-      },
-    ],
-  },
 })
 export default Error
 </script>
-
-<style>
-/* Override the default search bar styles.
-   Maybe in the future this would warrant a
-   variant of the searchbar, but that seems
-   excessive for this one-off usage.
-*/
-.page-404 .search-bar > div:not(:focus):not(:focus-within) {
-  border-color: black;
-}
-.page-404
-  .search-bar:not(:hover)
-  button:not(:hover):not(:focus):not(:focus-within) {
-  border-color: black;
-  border-inline-start-color: transparent;
-}
-.page-404 .search-bar button {
-  border-width: 1px;
-}
-</style>

--- a/src/pages/audio/index.vue
+++ b/src/pages/audio/index.vue
@@ -1,0 +1,11 @@
+<template><VFourOhFour /></template>
+
+<script>
+import { defineComponent } from '@vue/composition-api'
+import VFourOhFour from '~/components/VFourOhFour.vue'
+
+export default defineComponent({
+  components: { VFourOhFour },
+  layout: 'blank',
+})
+</script>

--- a/src/pages/image/index.vue
+++ b/src/pages/image/index.vue
@@ -1,0 +1,11 @@
+<template><VFourOhFour /></template>
+
+<script>
+import { defineComponent } from '@vue/composition-api'
+import VFourOhFour from '~/components/VFourOhFour.vue'
+
+export default defineComponent({
+  components: { VFourOhFour },
+  layout: 'blank',
+})
+</script>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #496 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds an `index.vue` to the `image` and `audio` page directories so that we can render a 404 page when a single result route without an id is hit.

I'm not sure if this is really the _right_ way to do this... I couldn't find any solid evidence about this and redirecting to `/404` seems incorrect for some reason. If we prefer that though, we can do that instead of this. I do like that this is a little more on the "declarative" side of things rather than programatically testing the route.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the branch and run `pnpm dev`. Visit `/image/` without an id and `/audio/` without an id and verify that they show the 404 page.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
