### PR TITLE
Unify number localization strategy across the app.

### DIFF
--- a/src/composables/use-get-locale-formatted-number.js
+++ b/src/composables/use-get-locale-formatted-number.js
@@ -1,0 +1,27 @@
+import { useContext } from '@nuxtjs/composition-api'
+
+export const EASTERN_ARABIC_NUMERAL_LOCALES = ['ar', 'fa', 'ckb', 'ps']
+
+/**
+ * Guards number formatting to prevent using Eastern Arabic Numerals,
+ * instead always using Western Arabic Numerals but still respecting
+ * the locale preferences for delimiters.
+ *
+ * @returns {(n: number) => string}
+ */
+export const useGetLocaleFormattedNumber = () => {
+  const { i18n } = useContext()
+
+  /**
+   * @param {number} n The number to format
+   */
+  return (n) => {
+    let { locale } = i18n
+
+    if (EASTERN_ARABIC_NUMERAL_LOCALES.some((l) => locale.startsWith(l))) {
+      locale = 'en-gb'
+    }
+
+    return n.toLocaleString(locale)
+  }
+}

--- a/src/composables/use-get-locale-formatted-number.js
+++ b/src/composables/use-get-locale-formatted-number.js
@@ -1,6 +1,17 @@
 import { useContext } from '@nuxtjs/composition-api'
 
-export const EASTERN_ARABIC_NUMERAL_LOCALES = ['ar', 'fa', 'ckb', 'ps']
+const WESTERN_ARABIC_NUMERALS = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+]
 
 /**
  * Guards number formatting to prevent using Eastern Arabic Numerals,
@@ -16,10 +27,14 @@ export const useGetLocaleFormattedNumber = () => {
   return (n) => {
     let { locale } = i18n
 
-    if (EASTERN_ARABIC_NUMERAL_LOCALES.some((l) => locale.startsWith(l))) {
-      locale = 'en-gb'
+    const testFormat = n.toLocaleString(locale)
+
+    if (
+      WESTERN_ARABIC_NUMERALS.some((numeral) => testFormat.includes(numeral))
+    ) {
+      return testFormat
     }
 
-    return n.toLocaleString(locale)
+    return n.toLocaleString('en')
   }
 }

--- a/src/composables/use-get-locale-formatted-number.js
+++ b/src/composables/use-get-locale-formatted-number.js
@@ -6,8 +6,6 @@ export const EASTERN_ARABIC_NUMERAL_LOCALES = ['ar', 'fa', 'ckb', 'ps']
  * Guards number formatting to prevent using Eastern Arabic Numerals,
  * instead always using Western Arabic Numerals but still respecting
  * the locale preferences for delimiters.
- *
- * @returns {(n: number) => string}
  */
 export const useGetLocaleFormattedNumber = () => {
   const { i18n } = useContext()

--- a/src/composables/use-i18n-utilities.js
+++ b/src/composables/use-i18n-utilities.js
@@ -1,4 +1,5 @@
 import { useContext } from '@nuxtjs/composition-api'
+import { useGetLocaleFormattedNumber } from '~/composables/use-get-locale-formatted-number'
 
 /**
  * Not using dynamically-generated keys to ensure that
@@ -15,6 +16,8 @@ const i18nKeys = {
  */
 export function useI18nResultsCount() {
   const { i18n } = useContext()
+  const getLocaleFormattedNumber = useGetLocaleFormattedNumber()
+
   /**
    * @param {number} resultsCount
    * @returns {string}
@@ -27,9 +30,7 @@ export function useI18nResultsCount() {
         ? 'more'
         : 'result'
     const fullKey = i18nKeys[countKey]
-    const countLocale =
-      i18n.localeProperties?.dir === 'rtl' ? 'en' : i18n.locale
-    const localeCount = resultsCount.toLocaleString(countLocale)
+    const localeCount = getLocaleFormattedNumber(resultsCount)
     return i18n.tc(fullKey, resultsCount, { localeCount })
   }
   return {

--- a/src/pages/sources.vue
+++ b/src/pages/sources.vue
@@ -133,7 +133,7 @@
               </a>
             </td>
             <td class="number-cell font-semibold">
-              {{ getProviderMediaCount(imageProvider.media_count || 0) }}
+              {{ getLocaleFormattedNumber(imageProvider.media_count || 0) }}
             </td>
           </tr>
         </tbody>
@@ -146,8 +146,7 @@
 import sortBy from 'lodash.sortby'
 import { mapState } from 'vuex'
 import { PROVIDER } from '~/constants/store-modules'
-
-const ARABIC_NUMERAL_LOCALES = ['ar', 'fa', 'ur', 'ckb', 'ps']
+import { useGetLocaleFormattedNumber } from '~/composables/use-get-locale-formatted-number'
 
 const SourcePage = {
   name: 'source-page',
@@ -159,6 +158,11 @@ const SourcePage = {
       },
     }
   },
+  setup() {
+    const getLocaleFormattedNumber = useGetLocaleFormattedNumber()
+
+    return { getLocaleFormattedNumber }
+  },
   computed: {
     ...mapState(PROVIDER, ['imageProviders']),
     sortedProviders() {
@@ -167,20 +171,6 @@ const SourcePage = {
     },
   },
   methods: {
-    /**
-     * @param {number} mediaCount
-     * @return {string} Localized media count
-     */
-    getProviderMediaCount(mediaCount = 0) {
-      let locale = this.$i18n.locale
-      if (ARABIC_NUMERAL_LOCALES.some((l) => locale.startsWith(l))) {
-        // most sites with RTL language with numbers continue to use Western Arabic Numerals whereas `toLocaleString` will use Eastern Arabic Numerals for Arabic and Hebrew by default
-        // Prevent formatting using Eastern Arabic Numerals and use `en-GB` to match the most common decimal and thousands delimiters for those regions
-        // https://en.wikipedia.org/wiki/Decimal_separator#Countries_using_decimal_point
-        locale = 'en-GB'
-      }
-      return mediaCount.toLocaleString(locale)
-    },
     sortTable(field) {
       let direction = 'asc'
       if (field === this.sort.field) {

--- a/test/unit/specs/composables/use-get-locale-formatted-number.spec.js
+++ b/test/unit/specs/composables/use-get-locale-formatted-number.spec.js
@@ -3,10 +3,7 @@ import { render } from '@testing-library/vue'
 import VueI18n from 'vue-i18n'
 import messages from '~/locales/en.json'
 
-import {
-  useGetLocaleFormattedNumber,
-  EASTERN_ARABIC_NUMERAL_LOCALES,
-} from '~/composables/use-get-locale-formatted-number'
+import { useGetLocaleFormattedNumber } from '~/composables/use-get-locale-formatted-number'
 
 const TestWrapper = Vue.component('TestWrapper', {
   props: ['n'],
@@ -31,8 +28,8 @@ describe('use-get-locale-formatted-number', () => {
     },
   })
 
-  it.each(EASTERN_ARABIC_NUMERAL_LOCALES)(
-    'should use en-gb formatting for locales matching %s',
+  it.each(['ar', 'fa', 'ckb', 'ps'])(
+    'should use en formatting for locales like %s that use Eastern Arabic Numerals',
     (locale) => {
       const { container } = render(TestWrapper, {
         mocks: getMockedI18n(locale),
@@ -40,7 +37,7 @@ describe('use-get-locale-formatted-number', () => {
       })
 
       expect(container.firstChild.textContent).toEqual(
-        (1000.01).toLocaleString('en-gb')
+        (1000.01).toLocaleString('en')
       )
       expect(container.firstChild.textContent).not.toEqual(
         (1000.01).toLocaleString(locale)

--- a/test/unit/specs/composables/use-get-locale-formatted-number.spec.js
+++ b/test/unit/specs/composables/use-get-locale-formatted-number.spec.js
@@ -1,0 +1,64 @@
+import Vue from 'vue'
+import { render } from '@testing-library/vue'
+import VueI18n from 'vue-i18n'
+import messages from '~/locales/en.json'
+
+import {
+  useGetLocaleFormattedNumber,
+  EASTERN_ARABIC_NUMERAL_LOCALES,
+} from '~/composables/use-get-locale-formatted-number'
+
+const TestWrapper = Vue.component('TestWrapper', {
+  props: ['n'],
+  setup() {
+    const getLocaleFormattedNumber = useGetLocaleFormattedNumber()
+
+    return { getLocaleFormattedNumber }
+  },
+  template: `<div>{{ getLocaleFormattedNumber(n) }}</div>`,
+})
+
+describe('use-get-locale-formatted-number', () => {
+  const getMockedI18n = (locale) => ({
+    $nuxt: {
+      context: {
+        i18n: new VueI18n({
+          locale,
+          fallbackLocale: 'en',
+          messages: { en: messages },
+        }),
+      },
+    },
+  })
+
+  it.each(EASTERN_ARABIC_NUMERAL_LOCALES)(
+    'should use en-gb formatting for locales matching %s',
+    (locale) => {
+      const { container } = render(TestWrapper, {
+        mocks: getMockedI18n(locale),
+        props: { n: 1000.01 },
+      })
+
+      expect(container.firstChild.textContent).toEqual(
+        (1000.01).toLocaleString('en-gb')
+      )
+      expect(container.firstChild.textContent).not.toEqual(
+        (1000.01).toLocaleString(locale)
+      )
+    }
+  )
+
+  it.each(['pt-br', 'en-us', 'en-gb', 'ru'])(
+    'should use the default formatting for locales not matching eastern arabic numeral locales like %s',
+    (locale) => {
+      const { container } = render(TestWrapper, {
+        mocks: getMockedI18n(locale),
+        props: { n: 1000.01 },
+      })
+
+      expect(container.firstChild.textContent).toEqual(
+        (1000.01).toLocaleString(locale)
+      )
+    }
+  )
+})

--- a/test/unit/specs/composables/use-i18n-utilities.spec.js
+++ b/test/unit/specs/composables/use-i18n-utilities.spec.js
@@ -7,8 +7,8 @@ jest.mock('@nuxtjs/composition-api', () => ({
         resultsCount,
         localeCount,
       }),
+      locale: 'en',
     },
-    locale: 'en',
   }),
 }))
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     /* Module Resolution Options */
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "typeRoots": ["./node_modules/@types"],
+    "typeRoots": ["./typings", "./node_modules/@types"],
     "paths": {
       "~/*": ["./src/*"],
       "~~/*": ["./*"]
@@ -35,6 +35,7 @@
     "src/composables/types.js",
     "src/composables/use-event-listener-outside.js",
     "src/composables/use-active-audio.js",
+    "src/composables/use-get-locale-formatted-number.js",
     "src/utils/key-codes.js"
   ]
 }

--- a/typings/nuxt__types/index.d.ts
+++ b/typings/nuxt__types/index.d.ts
@@ -1,0 +1,8 @@
+import '@nuxt/types'
+import type { IVueI18n } from 'vue-i18n'
+
+declare module '@nuxt/types' {
+  export interface Context {
+    i18n: IVueI18n
+  }
+}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #535 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The issue actually was out-dated, but the solution being used on the search result page differed from the solution used on other parts of the app (namely the sources page).

This PR unifies both approaches and fixes some minor bugs in how the locale was being used for the search results page, and also uses the `en-gb` locale for locales that would have used Eastern arabic numerals.

This also matches the approach taken in Gutenberg for formatting input numbers.

I also managed to get VueI18n into the Nuxt context type so that `useContext`'s return actually includes it, meaning we can add more composables to type checking.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Visit the search page using a locale that uses eastern arabic numerals by default, like `ar` and verify that it is using western arabic numerals instead, like the rest of the locales.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
