### PR TITLE
Set default size of VAudioTrack with a computed property

### DIFF
--- a/src/components/VAllResultsGrid/VAudioCell.vue
+++ b/src/components/VAllResultsGrid/VAudioCell.vue
@@ -2,7 +2,6 @@
   <VAudioTrack
     :audio="audio"
     layout="box"
-    size="full"
     @boxedAudioClick="navigateToSinglePage"
   />
 </template>

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -6,7 +6,7 @@
     v-bind="layoutBasedProps"
     v-on="layoutBasedListeners"
   >
-    <Component :is="layoutComponent" :audio="audio" :size="size">
+    <Component :is="layoutComponent" :audio="audio" :size="_size">
       <template #controller="waveformProps">
         <VWaveform
           v-bind="waveformProps"
@@ -91,7 +91,6 @@ const propTypes = {
     type: /** @type {import('@nuxtjs/composition-api').PropType<'s' | 'm' | 'l'>} */ (
       String
     ),
-    default: 'm',
     /**
      * @param {string} val
      */
@@ -346,6 +345,16 @@ export default defineComponent({
     const layoutComponent = computed(() => layoutMappings[props.layout])
 
     /**
+     * Sets default size if not provided.
+     */
+    const _size = computed(() => {
+      if (isBoxed && !props.size) {
+        return null
+      }
+      return 'm'
+    })
+
+    /**
      * A ref used on the play/pause button,
      * so we can capture clicks and skip
      * sending an event to the boxed layout.
@@ -396,6 +405,7 @@ export default defineComponent({
       duration,
 
       layoutComponent,
+      _size,
 
       layoutBasedProps,
       layoutBasedListeners,

--- a/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div :style="{ width }">
-    <!-- Should be wrapped by a fixed width parent -->
+    <!-- The width is determined by the parent element is the 'size' property is not specified -->
     <div
       class="box-track group relative bg-yellow h-0 w-full pt-full rounded-sm"
     >

--- a/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -47,8 +47,9 @@ export default defineComponent({
         l: 13.25,
         m: 12.25,
         s: 9.75,
-      }[props.size ?? 'm']
-      return `${magnitude}rem`
+      }[props.size]
+
+      return props.size ? `${magnitude}rem` : null
     })
 
     return {

--- a/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div :style="{ width }">
-    <!-- The width is determined by the parent element is the 'size' property is not specified -->
+    <!-- The width is determined by the parent element if the 'size' property is not specified. -->
     <div
       class="box-track group relative bg-yellow h-0 w-full pt-full rounded-sm"
     >


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #721 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR makes the default size for the boxed layout `null` instead of `'m'` (preserved for all other layouts if not explicitly specified) with a computed property, this way we avoid the warning for an invalid prop and it still looks good in the All search results grid, as no fixed `width` is applied.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Follow instructions on the related issue and observe no more warnings are shown, maintaining the normal aspect of the all search results grid.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [-] I added or updated tests for the changes I made (if applicable).
- [-] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
