### PR TITLE
Replace `@` imports with `~` imports

### DIFF
--- a/src/components/FooterSection.vue
+++ b/src/components/FooterSection.vue
@@ -67,8 +67,8 @@
 </template>
 
 <script>
-import GoogleAnalytics from '@/analytics/google-analytics'
-import { DonateLinkClick } from '@/analytics/events'
+import GoogleAnalytics from '~/analytics/google-analytics'
+import { DonateLinkClick } from '~/analytics/events'
 
 export default {
   name: 'FooterSection',

--- a/src/components/VContentSwitcher/meta/VContentSwitcherPopover.stories.mdx
+++ b/src/components/VContentSwitcher/meta/VContentSwitcherPopover.stories.mdx
@@ -8,7 +8,7 @@ import {
 
 import { ref } from '@nuxtjs/composition-api'
 
-import VContentSwitcherPopover from '@/components/VContentSwitcher/VContentSwitcherPopover.vue'
+import VContentSwitcherPopover from '~/components/VContentSwitcher/VContentSwitcherPopover.vue'
 
 <Meta
   title="Components/VContentSwitcherPopover"

--- a/src/pages/search/audio.vue
+++ b/src/pages/search/audio.vue
@@ -35,7 +35,7 @@ import VAudioTrack from '~/components/VAudioTrack/VAudioTrack.vue'
 import VLoadMore from '~/components/VLoadMore.vue'
 
 import { propTypes } from './search-page.types'
-import { isMinScreen } from '@/composables/use-media-query'
+import { isMinScreen } from '~/composables/use-media-query'
 
 const AudioSearch = defineComponent({
   name: 'AudioSearch',


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In the interest of consistency this PR replaces the few instances of `@` imports with `~`. Vue CLI apps generally tend to use `@` as the alias for the `src` dir, but Nuxt seems to [support both equally](https://nuxtjs.org/docs/configuration-glossary/configuration-alias/) so there's really no reason to favour one over the other. Since `~` is more commonly used in the code, using that as the standard causes minimum disruption.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the PR and run the dev server.
1. It should start.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
