### PR TITLE
Use the correct list of filters for All content

### DIFF
--- a/src/store/search.js
+++ b/src/store/search.js
@@ -11,7 +11,7 @@ import {
   ALL_MEDIA,
   AUDIO,
   IMAGE,
-  supportedMediaTypes,
+  supportedContentTypes,
   VIDEO,
 } from '~/constants/media'
 import {
@@ -468,7 +468,7 @@ const mutations = {
    * @param {'all'|'audio'|'image'|'video'} searchType
    */
   [CLEAR_OTHER_MEDIA_TYPE_FILTERS](state, { searchType }) {
-    const mediaTypesToClear = supportedMediaTypes.filter(
+    const mediaTypesToClear = supportedContentTypes.filter(
       (media) => media !== searchType
     )
 

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -33,7 +33,10 @@ import {
   SET_SEARCH_TYPE,
 } from '~/constants/mutation-types'
 
-// The order of the keys here is the same as in the side filter display
+/**
+ * List of filters available for each content type. The order of the keys
+ * is the same as in the filter checklist display (sidebar or modal).
+ */
 export const mediaFilterKeys = {
   image: [
     'licenseTypes',

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -60,8 +60,12 @@ export const mediaFilterKeys = {
   all: ['licenseTypes', 'licenses', 'searchBy', 'mature'],
 }
 
+/**
+ * A list of filters that are only used for the specific content type.
+ * This is used to clear filters from other content types when changing the content type.
+ */
 export const mediaSpecificFilters = {
-  all: ['licenses', 'licenseTypes', 'searchBy', 'mature'],
+  all: [],
   image: [
     'imageCategories',
     'imageExtensions',
@@ -453,7 +457,6 @@ function getMediaTypeFilters({ filters, mediaType, includeMature = false }) {
   return mediaTypeFilters
 }
 
-// Make sure when redirecting after applying a filter, we stick to the right tab (i.e, "/search/video", "/search/audio", etc.)
 const mutations = {
   /**
    * After a search type is changed, unchecks all the filters that are not

--- a/src/utils/search-query-transform.js
+++ b/src/utils/search-query-transform.js
@@ -1,5 +1,5 @@
 import clonedeep from 'lodash.clonedeep'
-import { mediaSpecificFilters } from '~/store/search'
+import { mediaFilterKeys } from '~/store/search'
 import getParameterByName from './get-parameter-by-name'
 import { ALL_MEDIA } from '~/constants/media'
 
@@ -19,11 +19,7 @@ const filterPropertyMappings = {
   mature: 'mature',
 }
 
-const getMediaFilterTypes = (searchType) => {
-  return searchType === ALL_MEDIA
-    ? [...mediaSpecificFilters.all]
-    : [...mediaSpecificFilters.all, ...mediaSpecificFilters[searchType]]
-}
+const getMediaFilterTypes = (contentType) => [...mediaFilterKeys[contentType]]
 // {
 //   license: 'cc0,pdm,by,by-sa,by-nc,by-nd,by-nc-sa,by-nc-nd',
 //   imageCategories: 'photograph,illustration,digitized_artwork',


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the mixup between the `mediaFilterKeys` and `mediaSpecificFilters` objects in the `search` store.

The first is used to keep all the filter types that are used for the content type, and the second has a list of filters that are only used for the specific content type, and not used in other content types (such as `duration` for audio).

One of the places where the `mediaSpecificFilters` was used was the `search/CLEAR_OTHER_MEDIA_TYPE_FILTERS`. This action is dispatched when changing a content type to clear filters that do not apply to current content type. So, when changing from "All Content" to "Images", it would set all the filters that are specific for "All Content" and "Audio" to not checked. With the bug that is fixed here, it would also uncheck the following filters: `['licenses', 'licenseTypes', 'searchBy', 'mature']`. And because `mature` filter is not an object, but a boolean, it would crash when iterated over, as the `state.filters['mature']` is not an array here, so we can't use `map` here:
```
    Object.keys(state.filters).forEach((filterType) => {
      if (filterKeysToClear.includes(filterType)) {
        state.filters[filterType] = state.filters[filterType].map((f) => ({
          ...f,
          checked: false,
        }))
      }
    })
```
This did not actually cause an crash because we were only clearing the `supportedMediaTypes`, and not the `supportedContentTypes` (i.e. did not include `ALL_MEDIA`).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Simply running the unit and e2e tests should be enough.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
