### PR TITLE
Use distroless and explore space saving measures for final production image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,4 +38,5 @@ vercel.json
 *.md
 LICENSE
 
-
+Dockerfile
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ storybook-static
 /src/locales/scripts/untranslated-locales.json
 /src/locales/scripts/wp-locales.json
 .zshrc
+.pnpm-store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 # ==
-# builder
+# installer
 # ==
-
-# application builder
-FROM node:16 AS builder
+# dependency installer
+FROM node:16 AS installer
 
 WORKDIR /usr/app
 
@@ -18,6 +17,15 @@ COPY .npmrc .
 # install dependencies including local development tools
 RUN pnpm install --frozen-lockfile --store-dir=./pnpm-store
 
+
+# ==
+# builder
+# ==
+# build the application
+FROM installer AS builder
+
+WORKDIR /usr/app
+
 # copy the rest of the content
 COPY . /usr/app
 
@@ -26,6 +34,17 @@ ENV NUXT_TELEMETRY_DISABLED=1
 
 # build the application and generate a distribution package
 RUN pnpm run build
+
+
+# ==
+# local development
+# ==
+# local development image; depends on mounting local files to the container at /usr/app
+FROM installer AS dev
+
+WORKDIR /usr/app
+
+RUN pnpm run dev
 
 
 # ==

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,11 @@ RUN ls node_modules | grep -v nuxt | xargs rm -rf
 # production
 # ==
 # application package (for production)
-FROM gcr.io/distroless/nodejs-debian11:16-debug AS app
+FROM gcr.io/distroless/nodejs-debian11:16 AS app
 
 WORKDIR /usr/app
+
+USER nonroot
 
 # copy package.json and package-lock.json files
 COPY package.json .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,5 @@ services:
       # HOST is necessary for Nuxt + Docker
       HOST: 0.0.0.0
       PORT: 8443
+    volumes:
+      - .:/usr/app


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Proof of concept build of the production docker image using `distroless` for the final base image. To be fair, `distroless` by itself would only cut the image size by like 4 MB compared to using alpine... but I've also applied some other space saving techniques like removing all the `node_modules` we don't need for running the app.

Kind of an annoying part of Nuxt deployments is that your "dev" dependencies and regular dependencies are pretty muddled. I bet we could do some more careful experimentation of what is actually literally needed for running the production application and move everything else to `devDependencies`. Then we could skip the step where we trash all the dependencies that don't have `nuxt` in their name (which is admittedly probably not the safest strategy :sweat_smile:)

In any case, it definitely runs locally. I'd be curious to see the image deployed to staging maybe just to test the whole app. There are CORS errors when you run it locally but those exist for the existing production image as well. Otherwise it appears to run fine.

Here's the stats:


* Before
```
openverse-frontend                              latest          7416fb178348   4 seconds ago        496MB
```

* After
```
openverse-frontend                              latest          ba673154e585   4 minutes ago    288MB
```

**Update:**

I realized I'd accidentally take the measurement using the `debug` base image. Here's the actual built image size when using the non-debug image:

```
openverse-frontend                              latest          5a38af745e8f   54 seconds ago   287MB
```

1 more MB saved :wink: 

So yeah, almost cuts the image in half. It's still huge... but that's node for you :confused: 

### Takeaways

Regardless of whether we decide to use `distroless` for the deployed image (which I think we should consider, it seems to be best practice along with running the application as a nonroot user) we can definitely do a better job at managing the dependencies we copy over and furthermore making sure to copy the `pnpm-store` between the base images so that we're not re-downloading dependencies on every `pnpm install` layer: that should be able to just happen a single time in the `builder` image.

We're also not using a non-root user in the current production image. This PR does do that and it appears to not cause any problems.

cc @rbadillap for all that; you're the best person to advise on what the positive takeaways from this experiment are :slightly_smiling_face: 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch and run `docker build . --target app -t openverse-frontend:latest`. Wait for the build to happen, then run `docker run -it --rm openverse-frontend:latest` and confirm that the app starts and that you can hit it locally (albeit with CORS errors).

You can use `docker images | grep openverse-frontend` to check the resulting image size.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
