### PR TITLE
Disallow all link components except `<VLink>` with eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,26 @@ module.exports = {
       'warn',
       { required: { some: ['nesting', 'id'] } },
     ],
+    /**
+     * Custom rule to disallow raw `<a></a>` tag usage.
+     * Learn more about vue-eslint-parser's AST syntax:
+     * https://github.com/vuejs/vue-eslint-parser/blob/master/docs/ast.md
+     */
+    'vue/no-restricted-syntax': [
+      'error',
+      {
+        selector: 'VElement[name="a"]',
+        message: 'Use the <VLink> component instead of a raw <a> tag.',
+      },
+      {
+        selector: 'VElement[name="nuxtlink"]',
+        message: 'Use the <VLink> component instead of <NuxtLink>.',
+      },
+      {
+        selector: 'VElement[name="routerlink"]',
+        message: 'Use the <VLink> component instead of <RouterLink>.',
+      },
+    ],
     'unicorn/filename-case': ['error', { case: 'kebabCase' }],
   },
   settings: {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #871 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds a custom vue eslint rule disallowing usage of raw `<a>` tags and encouraging the use of `<VLink>` instead.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Try adding this code `<a href="cool">cool</a>` to any Vue component in a text editor where you receive eslint messages and observe the correct eslint error:

<img width="742" alt="CleanShot 2022-02-20 at 21 06 16@2x" src="https://user-images.githubusercontent.com/6351754/154877836-5eee0121-59f2-41d8-b9e9-93c2bc0ff50d.png">

Suggestions are welcome regarding the error message or lint rule implementation. I didn't dive into the vue-eslint AST[^1] too deeply so there may be a more specific rule we'd like to use.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

[^1]: https://github.com/vuejs/vue-eslint-parser/blob/master/docs/ast.md