### PR TITLE
Enable SSR for migration banner

### DIFF
--- a/src/components/VMigrationNotice.vue
+++ b/src/components/VMigrationNotice.vue
@@ -1,5 +1,5 @@
 <template>
-  <VNoticeBar>
+  <VNoticeBar class="cc-ov-migration">
     {{ $t('migration-notice.intro') }}
     <i18n tag="span" path="migration-notice.more">
       <template #read-more>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -20,7 +20,6 @@
 <script>
 import iframeHeight from '~/mixins/iframe-height'
 
-import { NAV } from '~/constants/store-modules'
 import {
   computed,
   provide,
@@ -61,7 +60,7 @@ const embeddedPage = {
     const mainContentRef = ref(null)
     const mainRef = ref(null)
     const { store } = useContext()
-    const isReferredFromCc = store.state[NAV].isReferredFromCc
+    const isReferredFromCc = computed(() => store.state.nav.isReferredFromCc)
 
     const { isVisible: isFilterVisible } = useFilterSidebarVisibility()
     const isMinScreenMd = isMinScreen('md')

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -28,7 +28,7 @@ export default function ({ store, query, route }) {
     })
   }
 
-  if (!process.server && store.state.nav.isReferredFromCc) {
+  if (process.client && store.state.nav.isReferredFromCc) {
     store.commit(`${NAV}/${SET_REFERRED}`, { isReferredFromCc: false })
   }
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -28,7 +28,7 @@ export default function ({ store, query, route }) {
     })
   }
 
-  if (store.state.nav.isReferredFromCc) {
+  if (!process.server) {
     store.commit(`${NAV}/${SET_REFERRED}`, { isReferredFromCc: false })
   }
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -28,7 +28,7 @@ export default function ({ store, query, route }) {
     })
   }
 
-  if (!process.server) {
+  if (!process.server && store.state.nav.isReferredFromCc) {
     store.commit(`${NAV}/${SET_REFERRED}`, { isReferredFromCc: false })
   }
 }

--- a/test/e2e/migration-banner.spec.js
+++ b/test/e2e/migration-banner.spec.js
@@ -1,0 +1,22 @@
+const { test, expect } = require('@playwright/test')
+
+test('shows migration banner on homepage', async ({ page }) => {
+  await page.goto('/?referrer=creativecommons.org')
+
+  const migrationNotice = page.locator('.cc-ov-migration')
+  const message = 'CC Search is now called Openverse'
+
+  await expect(migrationNotice).toContainText(message)
+  await expect(migrationNotice).toBeVisible()
+})
+
+test('migration banner goes away on navigation', async ({ page }) => {
+  await page.goto('/?referrer=creativecommons.org')
+
+  let migrationNotice = page.locator('.cc-ov-migration')
+  await expect(migrationNotice).toBeVisible()
+
+  // Navigate away from the page
+  await page.locator('a.homepage-image').first().click()
+  await expect(migrationNotice).toBeHidden()
+})


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #515 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR enables the migration banner to render via SSR.

## Cause
Nuxt middleware runs once on the server during the first render and subsequent times on the client during routing. On the server, the plugin `migration-notice.js` sets the Vuex state `isReferredByCc` to true, and the middleware immediately sets it to false. So the banner isn't part of the SSR page.

On the client the plugin again sets the Vuex state `isReferredByCc` to true. The middleware already having executed on the server is not run on the client for the first page, so the banner pops in. Further navigation causes the middleware to run and remove the banner (as expected).

By changing the middleware to not run the unset mutation on the server, we are able to ensure that it only has the intended banner clearing effect on the client.

This problem was made harder to debug because the layout was non-reactively using the store state.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the PR and run the dev server.
1. Open the URL http://localhost:8443/search/image?q=cat&referrer=creativecommons.org.
2. Observe that the migration banner is SSR-ed.
3. Navigate to any different page.
4. Observe that the banner goes away and never returns.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
