### PR TITLE
Add width and height properties to images

### DIFF
--- a/src/components/VAllResultsGrid/VImageCellSquare.vue
+++ b/src/components/VAllResultsGrid/VImageCellSquare.vue
@@ -13,12 +13,12 @@
     >
       <img
         ref="img"
-        class="w-full h-full object-cover rounded-sm"
+        class="w-full h-full object-cover rounded-sm bg-dark-charcoal-10 text-dark-charcoal-10"
         loading="lazy"
         :alt="image.title"
         :src="getImageUrl(image)"
-        :width="image.width"
-        :height="image.height"
+        :width="250"
+        :height="250"
         itemprop="thumbnailUrl"
         @error="onImageLoadError($event, image)"
       />

--- a/src/components/VImageGrid/VImageCell.vue
+++ b/src/components/VImageGrid/VImageCell.vue
@@ -19,7 +19,7 @@
         :alt="image.title"
         :src="getImageUrl(image)"
         :width="imgWidth"
-        :height="imageight"
+        :height="imgHeight"
         @load="getImgDimension"
         @error="onImageLoadError($event, image)"
       />

--- a/src/components/VImageGrid/VImageCell.vue
+++ b/src/components/VImageGrid/VImageCell.vue
@@ -1,7 +1,7 @@
 <template>
   <VLink
     :href="'/image/' + image.id"
-    class="w-full block group relative overflow-hidden rounded-sm focus:ring-[3px] focus:ring-pink focus:ring-offset-[3px] focus:outline-none"
+    class="w-full block group relative overflow-hidden rounded-sm focus:ring-[3px] focus:ring-pink focus:ring-offset-[3px] focus:outline-none bg-dark-charcoal-10 text-dark-charcoal-10"
     :aria-label="image.title"
     :style="`width: ${containerAspect * widthBasis}px;flex-grow: ${
       containerAspect * widthBasis
@@ -18,6 +18,8 @@
         class="margin-auto block w-full"
         :alt="image.title"
         :src="getImageUrl(image)"
+        :width="imgWidth"
+        :height="imageight"
         @load="getImgDimension"
         @error="onImageLoadError($event, image)"
       />


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #1034 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Adds width and height properties to images, as well as setting the background to grey while they are loading. We _could_ and maybe _should_ wait to display images until they are loaded, and show the skeleton components while they are loading, but this still makes an improvement to the current loading appearance via the grey backgrounds. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Observe the appearance of the all results grid and image results views while loading.

> before

![CleanShot 2022-03-02 at 18 46 14@2x](https://user-images.githubusercontent.com/6351754/156472970-485eef37-7561-417e-b248-3002807957dc.png)

![CleanShot 2022-03-02 at 18 46 35@2x](https://user-images.githubusercontent.com/6351754/156472976-83d969f8-49fd-450a-a18d-317166b90a52.png)


> after (loading appearance while on a throttled 4g connection)

![CleanShot 2022-03-02 at 19 21 26@2x](https://user-images.githubusercontent.com/6351754/156472946-26a7dd1f-d4ae-41eb-a2d7-034b8425e77e.png)

![CleanShot 2022-03-02 at 19 19 11@2x](https://user-images.githubusercontent.com/6351754/156472947-54d7e983-b713-495d-90df-b2f13a90253a.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
