### PR TITLE
Give clearer feedback for how to fix outdated POT file in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
 
       - name: Check POT files are updated
         shell: bash
-        run: |
-          pnpm i18n:generate-pot
-          exit $(git status -s -uno | wc -l)
+        run: pnpm i18n:generate-pot
 
   unit:
     name: Unit tests

--- a/src/locales/scripts/json-to-pot.js
+++ b/src/locales/scripts/json-to-pot.js
@@ -20,6 +20,12 @@ try {
   }
 
   fs.writeFileSync(fileName, createPotFile(json))
+  if (process.env.CI) {
+    console.error(
+      'Detected uncommitted POT file changes. Please run `pnpm i18n:generate-pot` and commit the updated POT file.'
+    )
+    process.exit(1)
+  }
   console.log(`Successfully wrote pot file to ${fileName}`)
 } catch (err) {
   console.error(err)


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I noticed in https://github.com/WordPress/openverse-frontend/pull/1063 that it's unclear how to fix the failing POT file CI check. This PR adds more explicit feedback with instructions on how to remedy the problem.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the branch. Make a change to the POT file (could be just adding some blank lines somewhere or change a line number, anything except changing the timestamp) and run `CI=1 pnpm i18n:generate-pot` and confirm that it fails with a helpful error message. It should look something like this:

```
➜  openverse-frontend git:(add/better-feedback-ci-pot-file-check) CI=1 pnpm i18n:generate-pot

> openverse-frontend@2.2.1 i18n:generate-pot /home/sara/projects/openverse-frontend
> node src/locales/scripts/json-to-pot

Detected uncommitted POT file changes. Please run `pnpm i18n:generate-pot` and commit the updated POT file.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
