### PR TITLE
Fix prop name mismatch

### DIFF
--- a/src/components/VSearchGrid.vue
+++ b/src/components/VSearchGrid.vue
@@ -18,7 +18,7 @@
     <VMetaSearchForm
       v-if="!fetchState.isFetching"
       :type="metaSearchFormType"
-      :has-no-result="hasNoResult"
+      :has-no-results="hasNoResults"
       :query="query"
       :is-supported="isSupported"
     />
@@ -35,17 +35,23 @@
 import { computed } from '@nuxtjs/composition-api'
 
 import { ALL_MEDIA, IMAGE, supportedSearchTypes } from '~/constants/media'
-
 import { NO_RESULT } from '~/constants/errors'
 
 import VMetaSearchForm from '~/components/VMetaSearch/VMetaSearchForm.vue'
 import VErrorSection from '~/components/VErrorSection/VErrorSection.vue'
 import VErrorImage from '~/components/VErrorSection/VErrorImage.vue'
 import VNoResults from '~/components/VErrorSection/VNoResults.vue'
+import VSearchResultsTitle from '~/components/VSearchResultsTitle.vue'
 
 export default {
   name: 'VSearchGrid',
-  components: { VErrorSection, VMetaSearchForm, VErrorImage, VNoResults },
+  components: {
+    VErrorSection,
+    VMetaSearchForm,
+    VErrorImage,
+    VNoResults,
+    VSearchResultsTitle,
+  },
   props: {
     supported: {
       type: Boolean,
@@ -70,7 +76,7 @@ export default {
     },
   },
   setup(props) {
-    const hasNoResult = computed(() => {
+    const hasNoResults = computed(() => {
       // noResult is hard-coded for search types that are not currently
       // supported by Openverse built-in search
       return props.supported
@@ -88,7 +94,7 @@ export default {
     })
 
     return {
-      hasNoResult,
+      hasNoResults,
       isSupported,
       metaSearchFormType,
       isAllView,


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes console warnings :)

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
`VMetaSearchForm` expects a prop called `has-no-results`, but parent passes a prop without the `s`: `has-no-result`. This causes error and warning in the console. 
`VSearchResultsTitle` component import is also added.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the app and see that there are no more warnings in the console when you open a search page.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
