### PR TITLE
Fix mature content report submission

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@popperjs/core": "^2.11.2",
     "@tailwindcss/line-clamp": "^0.3.1",
     "@wordpress/is-shallow-equal": "^4.3.1",
-    "axios": "^0.21.2",
+    "axios": "^0.26.1",
     "axios-mock-adapter": "^1.20.0",
     "babel-core": "^7.0.0-bridge.0",
     "build-url": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ specifiers:
   '@vue/test-utils': ^1.1.3
   '@wordpress/is-shallow-equal': ^4.3.1
   autoprefixer: ^10.4.0
-  axios: ^0.21.2
+  axios: ^0.26.1
   axios-mock-adapter: ^1.20.0
   babel-core: ^7.0.0-bridge.0
   babel-jest: ^26.6.3
@@ -109,8 +109,8 @@ dependencies:
   '@popperjs/core': 2.11.2
   '@tailwindcss/line-clamp': 0.3.1_tailwindcss@3.0.9
   '@wordpress/is-shallow-equal': 4.3.1
-  axios: 0.21.4
-  axios-mock-adapter: 1.20.0_axios@0.21.4
+  axios: 0.26.1
+  axios-mock-adapter: 1.20.0_axios@0.26.1
   babel-core: 7.0.0-bridge.0
   build-url: 6.0.1
   case: 1.6.3
@@ -7059,32 +7059,32 @@ packages:
       postcss: 7.0.39
       postcss-value-parser: 4.2.0
 
-  /axios-mock-adapter/1.20.0_axios@0.21.4:
+  /axios-mock-adapter/1.20.0_axios@0.26.1:
     resolution: {integrity: sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==}
     peerDependencies:
       axios: '>= 0.9.0'
     dependencies:
-      axios: 0.21.4
+      axios: 0.26.1
       fast-deep-equal: 3.1.3
       is-blob: 2.1.0
       is-buffer: 2.0.5
     dev: false
 
-  /axios/0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
-    dependencies:
-      follow-redirects: 1.14.6
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /axios/0.21.4_debug@4.3.2:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.6_debug@4.3.2
+      follow-redirects: 1.14.9_debug@4.3.2
     transitivePeerDependencies:
       - debug
     dev: true
+
+  /axios/0.26.1:
+    resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
+    dependencies:
+      follow-redirects: 1.14.9_debug@4.3.2
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /babel-code-frame/6.26.0:
     resolution: {integrity: sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=}
@@ -10393,18 +10393,8 @@ packages:
     resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}
     dev: false
 
-  /follow-redirects/1.14.6:
-    resolution: {integrity: sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
-
-  /follow-redirects/1.14.6_debug@4.3.2:
-    resolution: {integrity: sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==}
+  /follow-redirects/1.14.9_debug@4.3.2:
+    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -10413,7 +10403,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.2
-    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=}

--- a/src/components/VContentReport/VContentReportForm.vue
+++ b/src/components/VContentReport/VContentReportForm.vue
@@ -162,7 +162,7 @@ export default defineComponent({
       // Submit report
       try {
         await service.sendReport({
-          identifier: props.media.identifier,
+          identifier: props.media.id,
           reason: selectedReason.value,
           description: description.value,
         })

--- a/src/components/VContentReport/VContentReportForm.vue
+++ b/src/components/VContentReport/VContentReportForm.vue
@@ -140,11 +140,13 @@ export default defineComponent({
   },
   setup(props) {
     const service = props.reportService || ReportService
+    const description = ref('')
 
     /** @type {import('@nuxtjs/composition-api').Ref<string|null>} */
     const status = ref(statuses.WIP)
+
+    /** @type {import('@nuxtjs/composition-api').Ref<string|null>} */
     const selectedReason = ref(reasons.DMCA)
-    const description = ref('')
 
     /* Buttons */
     const handleCancel = () => {

--- a/src/data/report-service.js
+++ b/src/data/report-service.js
@@ -6,7 +6,7 @@ const ReportService = {
   sendReport(params) {
     const mediaType = params.mediaType ?? IMAGE
     return VersionedApiService.post(
-      `/${getResourceSlug(mediaType)}${params.identifier}/report/`,
+      `/${getResourceSlug(mediaType)}${params.identifier}/report`,
       params
     )
   },

--- a/src/pages/image/_id.vue
+++ b/src/pages/image/_id.vue
@@ -160,9 +160,17 @@ const VImageDetailsPage = {
       if (this.image.filetype) {
         this.imageType = this.image.filetype
       } else {
-        axios.head(event.target.src).then((res) => {
-          this.imageType = res.headers['content-type']
-        })
+        axios
+          .head(event.target.src)
+          .then((res) => {
+            this.imageType = res.headers['content-type']
+          })
+          .catch(() => {
+            /**
+             * Do nothing. This avoid the console warning "Uncaught (in promise) Error:
+             * Network Error" in Firefox in development mode.
+             */
+          })
       }
       this.isLoadingFullImage = false
     },

--- a/test/unit/specs/components/v-content-report-form.spec.js
+++ b/test/unit/specs/components/v-content-report-form.spec.js
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
-import { createLocalVue } from '@vue/test-utils'
 import VueI18n from 'vue-i18n'
 
 import VContentReportForm from '~/components/VContentReport/VContentReportForm.vue'
@@ -9,7 +8,7 @@ const messages = require('~/locales/en.json')
 const i18n = new VueI18n({
   locale: 'en',
   fallbackLocale: 'en',
-  messages,
+  messages: { en: messages },
 })
 
 const getDmcaInput = () =>
@@ -53,7 +52,7 @@ describe('VContentReportForm', () => {
   beforeEach(() => {
     props = {
       media: {
-        identifier: '0aff3595-8168-440b-83ff-7a80b65dea42',
+        id: '0aff3595-8168-440b-83ff-7a80b65dea42',
         foreign_landing_url: 'https://wordpress.org/openverse/',
         provider: 'provider',
       },
@@ -62,12 +61,10 @@ describe('VContentReportForm', () => {
       reportService: reportServiceProp,
     }
 
-    const localVue = createLocalVue()
-    localVue.use(VueI18n)
-
     options = {
       propsData: props,
       i18n,
+      stubs: ['VIcon'],
     }
   })
 
@@ -86,7 +83,7 @@ describe('VContentReportForm', () => {
     await fireEvent.click(getReportButton())
 
     // Submission successful message
-    getByText('media-details.content-report.success.note')
+    getByText(/Thank you for reporting this content/i)
   })
 
   it('should render error message if report sending fails', async () => {
@@ -105,7 +102,9 @@ describe('VContentReportForm', () => {
     await fireEvent.click(getDmcaInput())
 
     // Notice with link to provider
-    getByText('media-details.content-report.form.dmca.note')
+    getByText(
+      /No action will be taken until this form is filled out and submitted/i
+    )
     getReportLink()
   })
 
@@ -126,7 +125,7 @@ describe('VContentReportForm', () => {
     await fireEvent.click(getReportButton())
 
     expect(serviceMock.sendReport).toHaveBeenCalledWith({
-      identifier: props.media.identifier,
+      identifier: props.media.id,
       reason: 'mature',
       description: '',
     })
@@ -144,7 +143,7 @@ describe('VContentReportForm', () => {
 
     await fireEvent.click(getReportButton())
     expect(serviceMock.sendReport).toHaveBeenCalledWith({
-      identifier: props.media.identifier,
+      identifier: props.media.id,
       reason: 'other',
       description,
     })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1079 by @zackkrida 
Related to #1086 by @krysal 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR:
- fixes the mature content report submission by passing the id correctly and removing the extra `/` when building URL in the data service
- update Axios to the last version
- (no related to mentioned issues) adds a catch method to silence an annoying console error in Firefox when navigating by related images (in development mode). If you know a better way to handle this, please share it.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try to report any image, you should see the success message and the request must have been sent.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [-] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
