### PR TITLE
Handle waveform with `peaks` prop as a blank array

### DIFF
--- a/src/components/VAudioTrack/VWaveform.vue
+++ b/src/components/VAudioTrack/VWaveform.vue
@@ -186,7 +186,6 @@ export default defineComponent({
     peaks: {
       type: Array,
       required: false,
-      default: () => Array.from({ length: 100 }, () => Math.random()),
       validator: (val) => val.every((item) => item >= 0 && item <= 1),
     },
     /**
@@ -332,8 +331,13 @@ export default defineComponent({
     const peakCount = computed(() =>
       getPeaksInWidth(waveformDimens.value.width)
     )
+    const peaks = computed(() =>
+      props.peaks?.length
+        ? props.peaks
+        : Array.from({ length: 1000 }, () => Math.random())
+    )
     const normalizedPeaks = computed(() => {
-      let samples = props.peaks
+      let samples = peaks.value
 
       const givenLength = samples.length
       const required = peakCount.value

--- a/src/components/VAudioTrack/VWaveform.vue
+++ b/src/components/VAudioTrack/VWaveform.vue
@@ -334,7 +334,7 @@ export default defineComponent({
     const peaks = computed(() =>
       props.peaks?.length
         ? props.peaks
-        : Array.from({ length: 1000 }, () => Math.random())
+        : Array.from({ length: 100 }, () => Math.random())
     )
     const normalizedPeaks = computed(() => {
       let samples = peaks.value

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-03-10T13:09:29+00:00\n"
+"POT-Creation-Date: 2022-03-11T08:08:25+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -272,7 +272,7 @@ msgid "Audio seek bar"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VWaveform.vue:573
+#: src/components/VAudioTrack/VWaveform.vue:577
 msgctxt "waveform.current-time"
 msgid "###time### second"
 msgid_plural "###time### seconds"

--- a/test/unit/specs/components/AudioTrack/waveform.spec.js
+++ b/test/unit/specs/components/AudioTrack/waveform.spec.js
@@ -1,0 +1,42 @@
+import { mount } from '@vue/test-utils'
+
+import VWaveform from '~/components/VAudioTrack/VWaveform.vue'
+
+jest.mock('~/utils/resampling', () => {
+  return {
+    downsampleArray: jest.fn((data) => data),
+    upsampleArray: jest.fn((data) => data),
+  }
+})
+
+describe('VWaveform', () => {
+  let options = null
+  let props = null
+
+  beforeEach(() => {
+    props = {
+      peaks: [],
+    }
+
+    options = {
+      propsData: props,
+    }
+  })
+
+  it('should use given peaks when peaks array is provided', () => {
+    props.peaks = Array.from({ length: 5 }, () => 0)
+    const wrapper = mount(VWaveform, options)
+    expect(wrapper.vm.normalizedPeaks.length).toBe(5)
+  })
+
+  it('should use random peaks when peaks not set', () => {
+    const wrapper = mount(VWaveform, options)
+    expect(wrapper.vm.normalizedPeaks.length).toBe(100)
+  })
+
+  it('should use random peaks when peaks array is blank', () => {
+    props.peaks = null
+    const wrapper = mount(VWaveform, options)
+    expect(wrapper.vm.normalizedPeaks.length).toBe(100)
+  })
+})


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1074 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates the `peaks` prop to use the default value even when given a truthy value of `[]`. This prevents the peaks from showing up as blank.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the PR and run the Storybook.
1. Visit a Waveform story and change the control for peaks to a blank array.
2. See the waveform become random.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
