### PR TITLE
Fix audio track null duration and add defaultRef

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,8 +11,8 @@ module.exports = {
     parser: '@typescript-eslint/parser',
   },
   extends: [
-    'plugin:@typescript-eslint/recommended',
     'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:vue/recommended',
     'plugin:prettier/recommended',
     'plugin:vuejs-accessibility/recommended',
@@ -143,9 +143,6 @@ module.exports = {
         ],
       },
     ],
-    // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unused-vars.md
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error'],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -143,6 +143,9 @@ module.exports = {
         ],
       },
     ],
+    // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unused-vars.md
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error'],
   },
   overrides: [
     {

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -49,6 +49,7 @@ import {
 } from '@nuxtjs/composition-api'
 
 import { useActiveAudio } from '~/composables/use-active-audio'
+import { defaultRef } from '~/composables/default-ref'
 
 import { MEDIA } from '~/constants/store-modules'
 import { useActiveMediaStore } from '~/stores/active-media'
@@ -126,7 +127,6 @@ export default defineComponent({
 
     const status = ref('paused')
     const currentTime = ref(0)
-    const audioDuration = ref(null)
 
     const initLocalAudio = () => {
       // Preserve existing local audio if we plucked it from the global active audio
@@ -220,8 +220,16 @@ export default defineComponent({
         }
       }
     }
+    const duration = defaultRef(() => {
+      if (localAudio) {
+        return localAudio.duration
+      }
+      if (typeof props.audio?.duration === 'number')
+        return props.audio.duration / 1e3
+      return 0
+    })
     const setDuration = () => {
-      audioDuration.value = localAudio?.duration
+      if (localAudio) duration.value = localAudio.duration
     }
 
     /**
@@ -292,10 +300,6 @@ export default defineComponent({
     )
 
     /* Timekeeping */
-
-    const duration = computed(
-      () => audioDuration.value ?? props.audio?.duration / 1e3 ?? 0 // seconds
-    )
 
     const message = computed(() => activeMediaStore.message)
 

--- a/src/components/VAudioTrack/VGlobalAudioTrack.vue
+++ b/src/components/VAudioTrack/VGlobalAudioTrack.vue
@@ -32,6 +32,7 @@
 import { computed, defineComponent, ref, watch } from '@nuxtjs/composition-api'
 
 import { useActiveAudio } from '~/composables/use-active-audio'
+import { defaultRef } from '~/composables/default-ref'
 
 import { useActiveMediaStore } from '~/stores/active-media'
 
@@ -107,7 +108,11 @@ export default defineComponent({
 
     const status = ref('paused')
     const currentTime = ref(0)
-    const audioDuration = ref(null)
+    const duration = defaultRef(() => {
+      if (typeof props.audio?.duration === 'number')
+        return props.audio.duration / 1e3
+      return 0
+    })
 
     const setPlaying = () => {
       status.value = 'playing'
@@ -129,7 +134,7 @@ export default defineComponent({
       }
     }
     const setDuration = () => {
-      audioDuration.value = activeAudio.obj.value?.duration
+      if (activeAudio.obj.value) duration.value = activeAudio.obj.value.duration
     }
 
     const updateTimeLoop = () => {
@@ -149,7 +154,7 @@ export default defineComponent({
         audio.addEventListener('timeupdate', setTimeWhenPaused)
         audio.addEventListener('durationchange', setDuration)
         currentTime.value = audio.currentTime
-        audioDuration.value = audio.duration
+        duration.value = audio.duration
 
         /**
          * By the time the `activeAudio` is updated and a rerender
@@ -189,11 +194,6 @@ export default defineComponent({
     const pause = () => activeAudio.obj.value?.pause()
 
     /* Timekeeping */
-
-    const duration = computed(
-      () => audioDuration.value ?? props.audio?.duration / 1e3 ?? 0
-    ) // seconds
-
     const message = computed(() => activeMediaStore.message)
 
     /* Interface with VPlayPause */

--- a/src/composables/default-ref.ts
+++ b/src/composables/default-ref.ts
@@ -12,8 +12,8 @@ export const defaultRef = <T>(getDefault: () => T) => {
   const explicitlySet = ref<T | typeof NotSet>(NotSet)
   return computed<T>({
     get() {
-      if (explicitlySet.value !== NotSet) return explicitlySet.value as T
-      return getDefault()
+      if (explicitlySet.value === NotSet) return getDefault()
+      return explicitlySet.value as T
     },
     set(v) {
       explicitlySet.value = v as UnwrapRef<T>

--- a/src/composables/default-ref.ts
+++ b/src/composables/default-ref.ts
@@ -1,0 +1,22 @@
+import { computed, ref, UnwrapRef } from '@nuxtjs/composition-api'
+
+const NotSet = Symbol('NotSet')
+
+/**
+ * Produces a `computed` that returns a default value until
+ * an explicit value is set.
+ *
+ * @param getDefault - A function returning the default value
+ */
+export const defaultRef = <T>(getDefault: () => T) => {
+  const explicitlySet = ref<T | typeof NotSet>(NotSet)
+  return computed<T>({
+    get() {
+      if (explicitlySet.value !== NotSet) return explicitlySet.value as T
+      return getDefault()
+    },
+    set(v) {
+      explicitlySet.value = v as UnwrapRef<T>
+    },
+  })
+}

--- a/test/unit/specs/composables/default-ref.spec.ts
+++ b/test/unit/specs/composables/default-ref.spec.ts
@@ -1,0 +1,24 @@
+import { defaultRef } from '~/composables/default-ref'
+
+describe('defaultRef', () => {
+  it('should use the default value', () => {
+    const getDefault = () => 100
+    const value = defaultRef(getDefault)
+    expect(value.value).toBe(100)
+  })
+
+  it('should use the set value', () => {
+    const value = defaultRef(() => 'a')
+    value.value = 'b'
+    expect(value.value).toBe('b')
+  })
+
+  it.each([0, '', false, undefined, null] as const)(
+    'should use the set value even if it is falsy as `%s`',
+    (v) => {
+      const value = defaultRef(() => 'non-null default' as typeof v)
+      value.value = v
+      expect(value.value).toBe(v)
+    }
+  )
+})


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1076 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
`defaultRef` is just a computed that uses some default computed value until another value is explicitly set.

This allows us to get rid of the confusing `duration` and `audioDuration` ref duplication that was happening in the audio track components by hiding what was the effective "default" in the original computed.

It also fixes the `null / 0` error.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check the unit tests to make sure I didn't miss any edge case.

Test the audio track, global, search results, related audio, and single result tracks, specifically from Jamendo to make sure there isn't a regression on #692.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
