### PR TITLE
Fix hero search button layout error

### DIFF
--- a/src/components/VHeader/VSearchBar/VSearchButton.vue
+++ b/src/components/VHeader/VSearchBar/VSearchButton.vue
@@ -8,7 +8,7 @@
     :class="[
       isIcon
         ? 'search-button focus-visible:bg-pink focus-visible:text-white p-[0.5px] ps-[1.5px]'
-        : 'py-6 px-10 h-full',
+        : 'py-6 px-6 whitespace-nowrap h-full',
       sizeClasses,
       isHomeRoute
         ? 'bg-pink border-b border-b-pink text-white border-tx'
@@ -85,7 +85,7 @@ export default defineComponent({
             small: ['w-10', 'md:w-12', 'h-10', 'md:h-12'],
             medium: ['w-12', 'h-12'],
             large: ['w-14', 'h-14'],
-            standalone: ['w-14', 'md:w-[69px]', 'h-14', 'md:h-[69px]'],
+            standalone: ['w-14', 'md:w-auto', 'h-14', 'md:h-[69px]'],
           }[props.size]
         : undefined
     })

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -12,7 +12,7 @@
         :is-search-route="false"
       />
 
-      <div class="px-6 lg:ps-30 lg:pe-0 xl:px-40 mx-auto w-full lg:w-auto">
+      <div class="px-6 lg:ps-30 lg:pe-0 xl:px-40 mx-auto w-full lg:w-auto z-10">
         <VLink
           href="/"
           class="relative hidden lg:block -left-[6.25rem] rtl:-right-[6.25rem]"


### PR DESCRIPTION
## Fixes
Fixes #1136

## Description
This PR fixes two problems with the hero search button:

- Text protrudes from the button
- Gallery images are placed above the search box at certain browser width
- The letters on the buttons are vertically aligned

## Testing Instructions
When the search button text is displayed (screens larger than 768px), check the following:

- Text must not be wrapped.
- The width of the search button should be variable depending on the length of the text.
- The search button should be positioned above the gallery image.

## ScreenShot

I have tested with `ja`, `fr`, `fa` locale.

https://user-images.githubusercontent.com/54422211/159016913-5e573d5b-8354-4e4f-a2e7-ad523ed86dff.mp4



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
