### PR TITLE
Hotfix for negative values in peaks

### DIFF
--- a/src/components/VAudioTrack/VWaveform.vue
+++ b/src/components/VAudioTrack/VWaveform.vue
@@ -187,7 +187,7 @@ export default defineComponent({
     peaks: {
       type: Array,
       required: false,
-      validator: (val) => val.every((item) => item >= -0.3 && item <= 1),
+      validator: (val) => val.every((item) => typeof item === 'number'),
     },
     /**
      * the message to display instead of the waveform; This is useful when

--- a/src/components/VAudioTrack/VWaveform.vue
+++ b/src/components/VAudioTrack/VWaveform.vue
@@ -187,7 +187,7 @@ export default defineComponent({
     peaks: {
       type: Array,
       required: false,
-      validator: (val) => val.every((item) => item >= 0 && item <= 1),
+      validator: (val) => val.every((item) => item >= -0.3 && item <= 1),
     },
     /**
      * the message to display instead of the waveform; This is useful when
@@ -348,7 +348,9 @@ export default defineComponent({
         samples = downsampleArray(samples, required)
       }
 
-      return samples.map((peak) => peak * waveformDimens.value.height)
+      return samples.map(
+        (peak) => Math.max(peak, 0) * waveformDimens.value.height
+      )
     })
 
     /* SVG drawing */

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-03-18T03:49:09+00:00\n"
+"POT-Creation-Date: 2022-03-21T10:40:55+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -272,7 +272,7 @@ msgid "Audio seek bar"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VWaveform.vue:578
+#: src/components/VAudioTrack/VWaveform.vue:580
 msgctxt "waveform.current-time"
 msgid "###time### second"
 msgid_plural "###time### seconds"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to [`openverse-api` issue#575](https://github.com/WordPress/openverse-api/issues/575).

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The front end expects all audio peaks values to be non-negative integers in the range of [0..1]. However, [some of the peaks values](https://api.openverse.engineering/v1/audio/727b9979-98f1-4604-9097-0a8b6fa68f2e/) that API sends are negative.
This PR adjust the validator for peak values, and makes all the values at least zero.
To minimize the effect of this fix on performance, I added the `Math.max(0, value)` to the already existing `map` function that handles the peaks object.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
On the main branch, go to `http://localhost:8443/audio/727b9979-98f1-4604-9097-0a8b6fa68f2e/`. You should see a warning in the console saying "Invalid prop: custom validator check failed for prop "peaks".
When opening the same page on this branch, you should not see this warning. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
