### PR TITLE
CopyButton style and name change; remove unused locale strings 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,7 +47,7 @@ module.exports = {
     'vue/block-lang': [
       'error',
       {
-        // This confusing naming prevents the use of 'lang' directives 
+        // This confusing naming prevents the use of 'lang' directives
         // entirely on Vue SFC style blocks.
         style: { allowNoLang: true },
       },

--- a/src/components/VCopyButton.vue
+++ b/src/components/VCopyButton.vue
@@ -3,6 +3,8 @@
     :id="id"
     type="button"
     variant="secondary"
+    size="disabled"
+    class="py-2 px-3 text-sr"
     :data-clipboard-target="el"
   >
     <span v-if="!success">
@@ -20,7 +22,7 @@ import Clipboard from 'clipboard'
 import VButton from '~/components/VButton.vue'
 
 export default {
-  name: 'CopyButton',
+  name: 'VCopyButton',
   components: { VButton },
   props: {
     el: {
@@ -60,13 +62,3 @@ export default {
   },
 }
 </script>
-
-<style scoped>
-/**
-  * Styles are applied here to 'hack' and overrule specificity.
-  * @todo Find a better way to handle this in the template.
-**/
-button {
-  @apply py-2 px-3 text-sr;
-}
-</style>

--- a/src/components/VMediaInfo/VCopyLicense.vue
+++ b/src/components/VMediaInfo/VCopyLicense.vue
@@ -121,7 +121,7 @@
         </i18n>
       </div>
 
-      <CopyButton
+      <VCopyButton
         :id="`copyattr-${tab}`"
         :el="`#attribution-${tab}`"
         class="mt-6"
@@ -137,11 +137,11 @@ import getAttributionHtml from '~/utils/attribution-html'
 import { isPublicDomain } from '~/utils/license'
 
 import VLink from '~/components/VLink.vue'
-import CopyButton from '~/components/CopyButton.vue'
+import VCopyButton from '~/components/VCopyButton.vue'
 
 const VCopyLicense = defineComponent({
   name: 'VCopyLicense',
-  components: { CopyButton, VLink },
+  components: { VCopyButton, VLink },
   props: {
     media: {
       type: Object,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,10 +16,6 @@
     "license-filter": {
       "label": "I want something I can"
     },
-    "locale": {
-      "label": "Languages available",
-      "icon": "locale"
-    },
     "aria": {
       "search": "search",
       "search-type": "search type"

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-03-28T21:45:58+00:00\n"
+"POT-Creation-Date: 2022-03-29T03:57:50+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -596,12 +596,12 @@ msgctxt "media-details.reuse.copy-license.plain"
 msgid "Plain text"
 msgstr ""
 
-#: src/components/CopyButton.vue:9
+#: src/components/VCopyButton.vue:11
 msgctxt "media-details.reuse.copy-license.copy-text"
 msgid "Copy text"
 msgstr ""
 
-#: src/components/CopyButton.vue:12
+#: src/components/VCopyButton.vue:14
 msgctxt "media-details.reuse.copy-license.copied"
 msgid "Copied!"
 msgstr ""
@@ -1866,14 +1866,6 @@ msgstr ""
 
 msgctxt "hero.aria.search-type"
 msgid "search type"
-msgstr ""
-
-msgctxt "hero.locale.label"
-msgid "Languages available"
-msgstr ""
-
-msgctxt "hero.locale.icon"
-msgid "locale"
 msgstr ""
 
 msgctxt "hero.license-filter.label"

--- a/test/unit/specs/components/v-copy-button.spec.js
+++ b/test/unit/specs/components/v-copy-button.spec.js
@@ -1,8 +1,8 @@
-import CopyButton from '~/components/CopyButton.vue'
+import VCopyButton from '~/components/VCopyButton.vue'
 
 import render from '../../test-utils/render'
 
-describe('CopyButton', () => {
+describe('VCopyButton', () => {
   let options = null
   let props = null
 
@@ -20,28 +20,28 @@ describe('CopyButton', () => {
   })
 
   it('should render correct contents', () => {
-    const wrapper = render(CopyButton, options)
+    const wrapper = render(VCopyButton, options)
     expect(wrapper.find('button')).toBeDefined()
   })
 
   it('data.success should be false by default', () => {
-    const wrapper = render(CopyButton, options)
+    const wrapper = render(VCopyButton, options)
     expect(wrapper.vm.$data.success).toBe(false)
   })
 
   it('data.success should be false by default', () => {
-    const wrapper = render(CopyButton, options)
+    const wrapper = render(VCopyButton, options)
     expect(wrapper.vm.$data.success).toBe(false)
   })
 
   it('should set data.success to true', () => {
-    const wrapper = render(CopyButton, options)
+    const wrapper = render(VCopyButton, options)
     wrapper.vm.onCopySuccess(eventData)
     expect(wrapper.vm.$data.success).toBe(true)
   })
 
   it('should set data.success to back to false after 2s', (done) => {
-    const wrapper = render(CopyButton, options)
+    const wrapper = render(VCopyButton, options)
     wrapper.vm.onCopySuccess(eventData)
     setTimeout(() => {
       expect(wrapper.vm.$data.success).toBe(false)
@@ -50,19 +50,19 @@ describe('CopyButton', () => {
   })
 
   it('should call clearSelection', () => {
-    const wrapper = render(CopyButton, options)
+    const wrapper = render(VCopyButton, options)
     wrapper.vm.onCopySuccess(eventData)
     expect(eventData.clearSelection).toHaveBeenCalled()
   })
 
   it('should emit copied event', () => {
-    const wrapper = render(CopyButton, options)
+    const wrapper = render(VCopyButton, options)
     wrapper.vm.onCopySuccess(eventData)
     expect(wrapper.emitted().copied).toBeTruthy()
   })
 
   it('should emit copyFailed event', () => {
-    const wrapper = render(CopyButton, options)
+    const wrapper = render(VCopyButton, options)
     wrapper.vm.onCopyError(eventData)
     expect(wrapper.emitted().copyFailed).toBeTruthy()
   })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #1087 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR moves the CopyButton styles from `<style>` block to tailwind (class definitions), and renames the component to add `V` prefix.
