### PR TITLE
Fix focus style of buttons in page menu

### DIFF
--- a/src/components/VItemGroup/VItem.vue
+++ b/src/components/VItemGroup/VItem.vue
@@ -20,11 +20,7 @@
         selected && 'bg-dark-charcoal-10 ring-offset-dark-charcoal-10',
         as === 'VLink' && 'text-dark-charcoal',
       ]"
-      :variant="
-        contextProps.size === 'small' && !contextProps.bordered
-          ? 'plain-dangerous'
-          : 'plain'
-      "
+      variant="plain"
       size="disabled"
       :pressed="selected"
       :role="contextProps.type === 'radiogroup' ? 'radio' : 'menuitemcheckbox'"


### PR DESCRIPTION
Following up #1191 that left out the items in the pages menu, as @obulat noticed.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR makes the `VItem` component use always the variant `plain` of the `VButton` to keep focus-visible styles. I don't know in which cases the "plain-dangerous" version would be used, please point it out or describe it if you find it. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Navigate the pages menu in a version of Safari < `15.4` with the keyboard, you should see the focus ring in each page entry.

<img width="273" alt="CleanShot 2022-04-05 at 14 38 27@2x" src="https://user-images.githubusercontent.com/9145885/161826564-7cc5132c-6dd4-4a4d-a24e-af4a3db3d7f4.png">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
