### PR TITLE
Fix audio results not being keyboard accessible in all results view

### DIFF
--- a/src/components/VAllResultsGrid/VAudioCell.vue
+++ b/src/components/VAllResultsGrid/VAudioCell.vue
@@ -1,13 +1,8 @@
 <template>
-  <VAudioTrack
-    :audio="audio"
-    layout="box"
-    @boxedAudioClick="navigateToSinglePage"
-  />
+  <VAudioTrack :audio="audio" layout="box" />
 </template>
 
 <script>
-import { useContext, useRouter } from '@nuxtjs/composition-api'
 import { defineComponent } from '@vue/composition-api'
 
 import VAudioTrack from '~/components/VAudioTrack/VAudioTrack.vue'
@@ -15,16 +10,5 @@ import VAudioTrack from '~/components/VAudioTrack/VAudioTrack.vue'
 export default defineComponent({
   components: { VAudioTrack },
   props: ['audio'],
-  setup() {
-    const { app } = useContext()
-    const router = useRouter()
-    const navigateToSinglePage = (audio) => {
-      router.push(app.localePath({ path: `/audio/${audio.id}` }))
-    }
-
-    return {
-      navigateToSinglePage,
-    }
-  },
 })
 </script>

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -398,8 +398,10 @@ export default defineComponent({
     })
     const ariaLabel = computed(() =>
       isBoxed.value
-        ? i18n.t('audio-track.aria-label-interactive')
-        : i18n.t('audio-track.aria-label')
+        ? i18n.t('audio-track.aria-label-interactive', {
+            title: props.audio.title,
+          })
+        : i18n.t('audio-track.aria-label', { title: props.audio.title })
     )
     /**
      * @param {KeyboardEvent} event

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -1,6 +1,6 @@
 <template>
   <Component
-    :is="isBoxed ? 'VLink' : 'div'"
+    :is="isBoxed ? 'VLink' : 'VWarningSuppressor'"
     class="audio-track group"
     :aria-label="ariaLabel"
     role="region"
@@ -65,6 +65,7 @@ import VRowLayout from '~/components/VAudioTrack/layouts/VRowLayout.vue'
 import VBoxLayout from '~/components/VAudioTrack/layouts/VBoxLayout.vue'
 import VGlobalLayout from '~/components/VAudioTrack/layouts/VGlobalLayout.vue'
 import VLink from '~/components/VLink.vue'
+import VWarningSuppressor from '~/components/VWarningSuppressor.vue'
 
 const propTypes = {
   /**
@@ -116,6 +117,7 @@ export default defineComponent({
     VPlayPause,
     VWaveform,
     VLink,
+    VWarningSuppressor,
 
     // Layouts
     VFullLayout,

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -1,5 +1,6 @@
 <template>
-  <div
+  <Component
+    :is="isBoxed ? 'VLink' : 'div'"
     class="audio-track group"
     :aria-label="$t('audio-track.aria-label')"
     role="region"
@@ -34,7 +35,7 @@
         />
       </template>
     </Component>
-  </div>
+  </Component>
 </template>
 
 <script>
@@ -61,6 +62,7 @@ import VFullLayout from '~/components/VAudioTrack/layouts/VFullLayout.vue'
 import VRowLayout from '~/components/VAudioTrack/layouts/VRowLayout.vue'
 import VBoxLayout from '~/components/VAudioTrack/layouts/VBoxLayout.vue'
 import VGlobalLayout from '~/components/VAudioTrack/layouts/VGlobalLayout.vue'
+import VLink from '~/components/VLink.vue'
 
 const propTypes = {
   /**
@@ -111,6 +113,7 @@ export default defineComponent({
   components: {
     VPlayPause,
     VWaveform,
+    VLink,
 
     // Layouts
     VFullLayout,
@@ -385,7 +388,7 @@ export default defineComponent({
     const layoutBasedProps = computed(() => {
       if (!isBoxed.value) return {}
       return {
-        tabindex: isBoxed.value ? 0 : -1,
+        href: `/audio/${props.audio.id}`,
         class:
           'block focus:bg-white focus:border-tx focus:ring-[3px] focus:ring-pink focus:ring-offset-[3px] focus:outline-none rounded-sm overflow-hidden cursor-pointer',
       }
@@ -421,6 +424,7 @@ export default defineComponent({
       layoutComponent,
       _size,
 
+      isBoxed,
       layoutBasedProps,
       layoutBasedListeners,
 

--- a/src/components/VAudioTrack/VPlayPause.vue
+++ b/src/components/VAudioTrack/VPlayPause.vue
@@ -6,7 +6,7 @@
     :icon-props="{ iconPath: icon }"
     :aria-label="$t(label)"
     :button-props="{ variant: 'plain-dangerous' }"
-    @click="handleClick"
+    @click.stop.prevent="handleClick"
   />
 </template>
 

--- a/src/components/VAudioTrack/layouts/VBoxLayout.vue
+++ b/src/components/VAudioTrack/layouts/VBoxLayout.vue
@@ -2,7 +2,7 @@
   <div :style="{ width }">
     <!-- The width is determined by the parent element if the 'size' property is not specified. -->
     <div
-      class="box-track group relative bg-yellow h-0 w-full pt-full rounded-sm"
+      class="box-track group relative bg-yellow h-0 w-full pt-full rounded-sm text-dark-blue"
     >
       <div class="absolute inset-0 flex flex-col">
         <div class="info flex-grow flex flex-col justify-between p-4">

--- a/src/components/VWarningSuppressor.vue
+++ b/src/components/VWarningSuppressor.vue
@@ -1,0 +1,17 @@
+<template>
+  <div v-on="$listeners">
+    <slot />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+/**
+ * A `div` replacement component useful for suppressing warnings
+ * about `.native` modifiers on non-components.
+ */
+export default defineComponent({
+  name: 'VWarningSuppressor',
+})
+</script>

--- a/src/constants/key-codes.ts
+++ b/src/constants/key-codes.ts
@@ -22,4 +22,5 @@ export const keycodes = Object.freeze({
   PageUp: 'PageUp',
   PageDown: 'PageDown',
   Tab: 'Tab',
+  Enter: 'Enter',
 } as const)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -551,6 +551,7 @@
   },
   "audio-track": {
     "aria-label": "Audio Player",
+    "aria-label-interactive": "Audio player - press the spacebar to play and pause a preview of the audio",
     "messages": {
       "blink_seek_disabled": "Seeking for Jamendo tracks is limited to Firefox and Safari.",
       "err_aborted": "You aborted playback.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -550,8 +550,8 @@
     "alt": "Cover art for \"{title}\" by {creator}"
   },
   "audio-track": {
-    "aria-label": "Audio Player",
-    "aria-label-interactive": "Audio player - press the spacebar to play and pause a preview of the audio",
+    "aria-label": "{title} - Audio Player",
+    "aria-label-interactive": "{title} - audio player - press the spacebar to play and pause a preview of the audio",
     "messages": {
       "blink_seek_disabled": "Seeking for Jamendo tracks is limited to Firefox and Safari.",
       "err_aborted": "You aborted playback.",

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-04-14T09:31:08+00:00\n"
+"POT-Creation-Date: 2022-04-14T15:48:23+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -188,13 +188,13 @@ msgid "Replay"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VAudioTrack.vue:404
+#: src/components/VAudioTrack/VAudioTrack.vue:406
 msgctxt "audio-track.aria-label"
 msgid "###title### - Audio Player"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VAudioTrack.vue:401
+#: src/components/VAudioTrack/VAudioTrack.vue:403
 msgctxt "audio-track.aria-label-interactive"
 msgid "###title### - audio player - press the spacebar to play and pause a preview of the audio"
 msgstr ""

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-04-14T06:58:09+00:00\n"
+"POT-Creation-Date: 2022-04-14T09:30:57+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -187,7 +187,7 @@ msgctxt "play-pause.replay"
 msgid "Replay"
 msgstr ""
 
-#: src/components/VAudioTrack/VAudioTrack.vue:4
+#: src/components/VAudioTrack/VAudioTrack.vue:5
 msgctxt "audio-track.aria-label"
 msgid "Audio Player"
 msgstr ""

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-04-14T09:31:04+00:00\n"
+"POT-Creation-Date: 2022-04-14T09:31:08+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -187,14 +187,16 @@ msgctxt "play-pause.replay"
 msgid "Replay"
 msgstr ""
 
-#: src/components/VAudioTrack/VAudioTrack.vue:402
+#. Do not translate words between ### ###.
+#: src/components/VAudioTrack/VAudioTrack.vue:404
 msgctxt "audio-track.aria-label"
-msgid "Audio Player"
+msgid "###title### - Audio Player"
 msgstr ""
 
+#. Do not translate words between ### ###.
 #: src/components/VAudioTrack/VAudioTrack.vue:401
 msgctxt "audio-track.aria-label-interactive"
-msgid "Audio player - press the spacebar to play and pause a preview of the audio"
+msgid "###title### - audio player - press the spacebar to play and pause a preview of the audio"
 msgstr ""
 
 #. Do not translate words between ### ###.

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-04-14T09:30:57+00:00\n"
+"POT-Creation-Date: 2022-04-14T09:31:04+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -187,9 +187,14 @@ msgctxt "play-pause.replay"
 msgid "Replay"
 msgstr ""
 
-#: src/components/VAudioTrack/VAudioTrack.vue:5
+#: src/components/VAudioTrack/VAudioTrack.vue:402
 msgctxt "audio-track.aria-label"
 msgid "Audio Player"
+msgstr ""
+
+#: src/components/VAudioTrack/VAudioTrack.vue:401
+msgctxt "audio-track.aria-label-interactive"
+msgid "Audio player - press the spacebar to play and pause a preview of the audio"
 msgstr ""
 
 #. Do not translate words between ### ###.

--- a/test/playwright/e2e/all-results-keyboard.spec.ts
+++ b/test/playwright/e2e/all-results-keyboard.spec.ts
@@ -1,0 +1,55 @@
+import { test, Page } from '@playwright/test'
+
+import { keycodes } from '~/constants/key-codes'
+
+const walkToType = async (type: 'image' | 'audio', page: Page) => {
+  // Go to skip to content button
+  await page.keyboard.press(keycodes.Tab)
+  // Skip to content
+  await page.keyboard.press(keycodes.Enter)
+
+  const isActiveElementOfType = () => {
+    return page.evaluate(
+      ([contextType]) =>
+        new RegExp(
+          `/${contextType}/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$`,
+          'i'
+        ).test(
+          (document.activeElement as HTMLAnchorElement | null)?.href ?? ''
+        ),
+      [type]
+    )
+  }
+
+  while (!(await isActiveElementOfType())) {
+    await page.keyboard.press(keycodes.Tab)
+  }
+}
+
+test.describe('all results grid keyboard accessibility test', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/search?q=birds')
+  })
+
+  test('should open image results as links', async ({ page }) => {
+    await walkToType('image', page)
+    await page.keyboard.press('Enter')
+    await page.waitForURL(
+      new RegExp(
+        `/image/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$`,
+        'i'
+      )
+    )
+  })
+
+  test('should open audio results as links', async ({ page }) => {
+    await walkToType('audio', page)
+    await page.keyboard.press('Enter')
+    await page.waitForURL(
+      new RegExp(
+        `/audio/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$`,
+        'i'
+      )
+    )
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
     "src/components/VContentPage.vue",
     "src/components/VMetaSearch/*.vue",
     "src/components/VLicenseElements.vue",
+    "src/components/VWarningSuppressor.vue",
     "src/components/VLink.vue",
     "src/components/VLoadMore.vue",
     "src/components/VIcon/VIcon.vue",


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1242   by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Makes the boxed audio result a VLink wrapped element so that when focused, it is keyboard accessibly openable and also reports the actual URL of the page that will be opened, unlike the existing solution which mimicked link behavior using JavaScript.

We will later continue to work on the audio result link by transforming it into a composite element (probably `role="grid"`) that has custom keyboard navigation to enter the link to be able to play and pause the audio.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check the new e2e tests pass. Also test it in your own browser and in particular check the focus styles.

I could add visual regression tests for the focus styles actually, I will do that tomorrow!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
