### PR TITLE
Remove usage of legacy classes

### DIFF
--- a/src/components/VMetaSearch/VMetaSearchForm.vue
+++ b/src/components/VMetaSearch/VMetaSearchForm.vue
@@ -13,7 +13,7 @@
             : 'meta-search.form.unsupported-title'
         "
         tag="h4"
-        class="b-header mb-2"
+        class="text-4xl mb-2"
       >
         <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
         <template #openverse>Openverse</template>
@@ -25,7 +25,7 @@
         v-else
         path="meta-search.form.no-results-title"
         tag="h4"
-        class="b-header mb-2"
+        class="text-4xl mb-2"
       >
         <template #type>{{ type }}</template>
         <template #query>{{ query.q }}</template>
@@ -45,7 +45,7 @@
       :query="query"
     />
 
-    <p class="caption font-semibold max-w-3xl my-0 mx-auto">
+    <p class="text-sm font-semibold max-w-3xl my-0 mx-auto">
       {{ $t('meta-search.caption', { openverse: 'Openverse' }) }}
     </p>
   </section>


### PR DESCRIPTION
Related to the legacy styles milestone, this PR removes some small instances (the only ones I'm aware of) of classes used from the global sass stylesheets.