### PR TITLE
Open results in modal

### DIFF
--- a/src/components/SketchFabViewer.vue
+++ b/src/components/SketchFabViewer.vue
@@ -28,6 +28,7 @@ export default {
       required: true,
     },
   },
+  emits: ['failure'],
   data() {
     return {
       client: null,

--- a/src/components/VAllResultsGrid/VImageCellSquare.vue
+++ b/src/components/VAllResultsGrid/VImageCellSquare.vue
@@ -4,6 +4,7 @@
     :title="image.title"
     :href="'/image/' + image.id"
     class="group block focus:ring-[3px] focus:ring-pink focus:ring-offset-[3px] focus:outline-none rounded-sm"
+    :data-resultid="image.id"
   >
     <figure
       itemprop="image"

--- a/src/components/VImageGrid/VImageCell.vue
+++ b/src/components/VImageGrid/VImageCell.vue
@@ -6,6 +6,7 @@
     :style="`width: ${containerAspect * widthBasis}px;flex-grow: ${
       containerAspect * widthBasis
     }`"
+    :data-resultid="image.id"
     @click="onGotoDetailPage($event, image)"
   >
     <figure

--- a/src/components/VImageResult.vue
+++ b/src/components/VImageResult.vue
@@ -1,0 +1,151 @@
+<template>
+  <div>
+    <figure class="w-full mb-4 pt-8 md:pt-12 px-6 bg-dark-charcoal-06 relative">
+      <img
+        v-if="!sketchFabUid"
+        id="main-image"
+        :src="isLoadingFullImage ? image.thumbnail : image.url"
+        :alt="image.title"
+        class="h-full max-h-[500px] mx-auto rounded-t-sm"
+        @load="onImageLoaded"
+      />
+      <SketchFabViewer
+        v-else
+        :uid="sketchFabUid"
+        class="mx-auto rounded-t-sm"
+        @failure="sketchFabFailure = true"
+      />
+    </figure>
+
+    <section
+      id="title-button"
+      class="flex flex-row md:flex-row-reverse flex-wrap justify-between md:mt-6"
+    >
+      <VButton
+        as="VLink"
+        :href="image.foreign_landing_url"
+        class="btn-main flex-initial w-full md:w-max mb-4 md:mb-0"
+        size="large"
+        >{{ $t('image-details.weblink') }}</VButton
+      >
+      <span class="flex-1 flex flex-col justify-center">
+        <h1 class="text-base md:text-3xl font-semibold leading-[130%]">
+          {{ image.title }}
+        </h1>
+        <i18n
+          v-if="image.creator"
+          path="image-details.creator"
+          tag="span"
+          class="font-semibold leading-[130%]"
+        >
+          <template #name>
+            <VLink
+              v-if="image.creator_url"
+              :aria-label="
+                $t('media-details.aria.creator-url', {
+                  creator: image.creator,
+                })
+              "
+              :href="image.creator_url"
+              >{{ image.creator }}</VLink
+            >
+            <span v-else>{{ image.creator }}</span>
+          </template>
+        </i18n>
+      </span>
+    </section>
+
+    <VMediaReuse :media="image" />
+    <VImageDetails
+      :image="image"
+      :image-width="imageWidth"
+      :image-height="imageHeight"
+      :image-type="imageType"
+    />
+    <VRelatedImages :media="relatedMedia" :fetch-state="relatedFetchState" />
+  </div>
+</template>
+
+<script>
+import { ref, defineComponent, computed } from '@nuxtjs/composition-api'
+import axios from 'axios'
+
+import { useSingleResultStore } from '~/stores/media/single-result'
+import { useRelatedMediaStore } from '~/stores/media/related-media'
+
+import VButton from '~/components/VButton.vue'
+import VLink from '~/components/VLink.vue'
+import VImageDetails from '~/components/VImageDetails/VImageDetails.vue'
+import VMediaReuse from '~/components/VMediaInfo/VMediaReuse.vue'
+import VRelatedImages from '~/components/VImageDetails/VRelatedImages.vue'
+import SketchFabViewer from '~/components/SketchFabViewer.vue'
+
+export default defineComponent({
+  name: 'VImageResult',
+  components: {
+    VButton,
+    VLink,
+    VImageDetails,
+    VMediaReuse,
+    VRelatedImages,
+    SketchFabViewer,
+  },
+  setup() {
+    const singleResultStore = useSingleResultStore()
+    const image = computed(() => singleResultStore.mediaItem)
+    const imageWidth = ref(image.width)
+    const imageHeight = ref(image.height)
+    const imageType = ref(image.filetype)
+    const isLoadingFullImage = ref(true)
+    const sketchFabFailure = ref(false)
+    const sketchFabUid = computed(() => {
+      if (image?.source !== 'sketchfab' || sketchFabFailure.value) {
+        return null
+      }
+      return image.url
+        .split('https://media.sketchfab.com/models/')[1]
+        .split('/')[0]
+    })
+
+    const onImageLoaded = (event) => {
+      imageWidth.value = image.width || event.target.naturalWidth
+      imageHeight.value = image.height || event.target.naturalHeight
+      if (image.filetype) {
+        isLoadingFullImage.value = false
+      } else {
+        axios
+          .head(event.target.src)
+          .then((res) => {
+            imageType.value = res.headers['content-type']
+            isLoadingFullImage.value = false
+          })
+          .catch(() => {
+            /**
+             * Do nothing. This avoid the console warning "Uncaught (in promise) Error:
+             * Network Error" in Firefox in development mode.
+             */
+          })
+      }
+    }
+
+    const relatedMediaStore = useRelatedMediaStore()
+
+    const relatedMedia = computed(() => relatedMediaStore.media)
+    const relatedFetchState = computed(() => relatedMediaStore.fetchState)
+
+    return {
+      image,
+      onImageLoaded,
+      sketchFabUid,
+      sketchFabFailure,
+      relatedMedia,
+      relatedFetchState,
+
+      isLoadingFullImage,
+      imageWidth,
+      imageHeight,
+      imageType,
+    }
+  },
+})
+</script>

--- a/src/components/VModal/VModal.vue
+++ b/src/components/VModal/VModal.vue
@@ -104,6 +104,20 @@ export default defineComponent({
       ),
       default: undefined,
     },
+    visible: {
+      type: Boolean,
+      default: undefined,
+    },
+    /**
+     * Allow passing a specific disclosure element to focus when for some
+     * reason the modal can't have a populated `trigger` slot.
+     */
+    displacedDisclosure: {
+      type: /** @type {import('@nuxtjs/composition-api').PropType<HTMLElement>} */ (
+        process.server ? Object : HTMLElement
+      ),
+      default: undefined,
+    },
   },
   emits: [
     /**
@@ -115,8 +129,24 @@ export default defineComponent({
      */
     'close',
   ],
-  setup(_, { emit }) {
-    const visibleRef = ref(false)
+  setup(props, { emit }) {
+    const visibleRef = ref(props.visible || false)
+    watch(
+      () => props.visible,
+      (visible) => {
+        switch (visible) {
+          case true: {
+            return open()
+          }
+          case false: {
+            return close()
+          }
+          default: {
+            return undefined
+          }
+        }
+      }
+    )
     const nodeRef = ref()
 
     /** @type {import('@nuxtjs/composition-api').Ref<HTMLElement | undefined>} */
@@ -127,7 +157,9 @@ export default defineComponent({
       'aria-haspopup': 'dialog',
     })
 
-    const triggerRef = computed(() => triggerContainerRef.value?.firstChild)
+    const triggerRef = computed(
+      () => props.displacedDisclosure ?? triggerContainerRef.value?.firstChild
+    )
 
     watch([visibleRef], ([visible]) => {
       if (visible) {

--- a/src/pages/image/_id.vue
+++ b/src/pages/image/_id.vue
@@ -1,135 +1,17 @@
 <template>
-  <div>
-    <figure class="w-full mb-4 pt-8 md:pt-12 px-6 bg-dark-charcoal-06 relative">
-      <div
-        v-if="showBackToSearchLink"
-        class="absolute left-0 top-0 right-0 z-40 w-full px-2"
-      >
-        <VBackToSearchResultsLink />
-      </div>
-
-      <img
-        v-if="!sketchFabUid"
-        id="main-image"
-        :src="isLoadingFullImage ? image.thumbnail : image.url"
-        :alt="image.title"
-        class="h-full max-h-[500px] mx-auto rounded-t-sm"
-        @load="onImageLoaded"
-      />
-      <SketchFabViewer
-        v-if="sketchFabUid"
-        :uid="sketchFabUid"
-        class="mx-auto rounded-t-sm"
-        @failure="sketchFabfailure = true"
-      />
-    </figure>
-
-    <section
-      id="title-button"
-      class="flex flex-row md:flex-row-reverse flex-wrap justify-between md:mt-6"
-    >
-      <VButton
-        as="VLink"
-        :href="image.foreign_landing_url"
-        class="btn-main flex-initial w-full md:w-max mb-4 md:mb-0"
-        size="large"
-        >{{ $t('image-details.weblink') }}</VButton
-      >
-      <span class="flex-1 flex flex-col justify-center">
-        <h1 class="text-base md:text-3xl font-semibold leading-[130%]">
-          {{ image.title }}
-        </h1>
-        <i18n
-          v-if="image.creator"
-          path="image-details.creator"
-          tag="span"
-          class="font-semibold leading-[130%]"
-        >
-          <template #name>
-            <VLink
-              v-if="image.creator_url"
-              :aria-label="
-                $t('media-details.aria.creator-url', {
-                  creator: image.creator,
-                })
-              "
-              :href="image.creator_url"
-              >{{ image.creator }}</VLink
-            >
-            <span v-else>{{ image.creator }}</span>
-          </template>
-        </i18n>
-      </span>
-    </section>
-
-    <VMediaReuse :media="image" />
-    <VImageDetails
-      :image="image"
-      :image-width="imageWidth"
-      :image-height="imageHeight"
-      :image-type="imageType"
-    />
-    <VRelatedImages :media="relatedMedia" :fetch-state="relatedFetchState" />
-  </div>
+  <VImageResult />
 </template>
 
 <script>
-import axios from 'axios'
-
-import { computed } from '@nuxtjs/composition-api'
-
 import { IMAGE } from '~/constants/media'
 import { useSingleResultStore } from '~/stores/media/single-result'
-import { useRelatedMediaStore } from '~/stores/media/related-media'
 
-import VButton from '~/components/VButton.vue'
-import VIcon from '~/components/VIcon/VIcon.vue'
-import VLink from '~/components/VLink.vue'
-import VImageDetails from '~/components/VImageDetails/VImageDetails.vue'
-import VMediaReuse from '~/components/VMediaInfo/VMediaReuse.vue'
-import VRelatedImages from '~/components/VImageDetails/VRelatedImages.vue'
-import SketchFabViewer from '~/components/SketchFabViewer.vue'
-import VBackToSearchResultsLink from '~/components/VBackToSearchResultsLink.vue'
+import VImageResult from '~/components/VImageResult.vue'
 
 const VImageDetailsPage = {
   name: 'VImageDetailsPage',
   components: {
-    VButton,
-    VIcon,
-    VLink,
-    VImageDetails,
-    VMediaReuse,
-    VRelatedImages,
-    SketchFabViewer,
-    VBackToSearchResultsLink,
-  },
-  data() {
-    return {
-      imageWidth: 0,
-      imageHeight: 0,
-      imageType: 'Unknown',
-      isLoadingFullImage: true,
-      showBackToSearchLink: false,
-      sketchFabfailure: false,
-    }
-  },
-  setup() {
-    const relatedMediaStore = useRelatedMediaStore()
-
-    const relatedMedia = computed(() => relatedMediaStore.media)
-    const relatedFetchState = computed(() => relatedMediaStore.fetchState)
-
-    return { relatedMedia, relatedFetchState }
-  },
-  computed: {
-    sketchFabUid() {
-      if (this.image?.source !== 'sketchfab' || this.sketchFabfailure) {
-        return null
-      }
-      return this.image.url
-        .split('https://media.sketchfab.com/models/')[1]
-        .split('/')[0]
-    },
+    VImageResult,
   },
   async asyncData({ app, error, route, $pinia }) {
     const imageId = route.params.id
@@ -149,38 +31,6 @@ const VImageDetailsPage = {
         message: errorMessage,
       })
     }
-  },
-  beforeRouteEnter(to, from, nextPage) {
-    nextPage((_this) => {
-      if (
-        from.name === _this.localeRoute({ path: '/search/' }).name ||
-        from.name === _this.localeRoute({ path: '/search/image' }).name
-      ) {
-        _this.showBackToSearchLink = true
-      }
-    })
-  },
-  methods: {
-    onImageLoaded(event) {
-      this.imageWidth = this.image.width || event.target.naturalWidth
-      this.imageHeight = this.image.height || event.target.naturalHeight
-      if (this.image.filetype) {
-        this.imageType = this.image.filetype
-      } else {
-        axios
-          .head(event.target.src)
-          .then((res) => {
-            this.imageType = res.headers['content-type']
-          })
-          .catch(() => {
-            /**
-             * Do nothing. This avoid the console warning "Uncaught (in promise) Error:
-             * Network Error" in Firefox in development mode.
-             */
-          })
-      }
-      this.isLoadingFullImage = false
-    },
   },
   head() {
     const title = `${this.image.title} | Openverse`

--- a/src/stores/media/single-result.ts
+++ b/src/stores/media/single-result.ts
@@ -50,6 +50,8 @@ export const useSingleResultStore = defineStore('single-result', {
     },
 
     async fetchMediaItem(type: SupportedMediaType, id: string) {
+      if (this.mediaItem?.id === id) return
+
       const mediaStore = useMediaStore()
       const existingItem = mediaStore.getItemById(type, id)
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #601  by @panchovm 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Still very much a work in progress. More or less works in the happy path for images (all that's been set up yet, haven't touched audio at all but once images are sorted out it shouldn't be too bad to get audio, or any media type, working).

What works:

Open an image result from the all content results into a modal. Closing the modal works and even using the back button to navigate back to the results (i.e., close the modal with the back button). You can even _reopen_ the modal using the forward button (but then the back button stops working to go back to search).

Navigating related results works until you try to use the browser forward button, then they stop working. Otherwise you can visit several related results and use the back button to go all the way back to the search results. However, if you hit "back" again after closing the modal from a related result it will open the modal but with the first result you selected instead of the last result that was viewed.

What does not work:

As I mentioned above, if you open the modal then go "back - forward - back" in the browser it should close then reopen the modal, then on the second back, close the modal again. The closing the modal the second time does not work for some reason.

Basically a whole bunch of edge cases with the browser back/forward navigation don't work. It feels like history state is supposed to be useful for this but for some reason `popstate`'s Event.state property just has a `key: number` property in it no matter what I pass for the state in `pushState`. From what I read in the docs that's not the expected behavior. My only guess is that this is something to do with vue-router also writing to state (potentially using `replaceState` in a sneaky way?) and overwriting the state that I pass in myself.

I'm considering the idea that maybe a custom history stack needs to be maintained that can actually be inspected, as `history` doesn't allow you to do that. The idea here would be that we'd monitor `popstate` and check for back/forwards navigation and maintain our own separate routing path stack in a ref or something. Of course that would be difficult to do actually because the popstate event doesn't actually tell you if back or forwards was pressed, so we'd have to be guessing by maintaining a separate ref to know the previous location and compare the current, then try to guess which direction in the stack we're moving. The problem with that, of course, is that the if you have a stack that goes `A B A B`, if you're on the second A and then navigate to B, it's impossible to know whether it's a forward or back action. I don't think we actually have the possibility for that in the current application but it'd be a nasty bug to run into down the line if we did. Overall re-implementing history stack sounds like a real source for headaches.

I'm glad I've been able to get what's working so far actually working.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
