### PR TITLE
Add defineEvent emit type helper

### DIFF
--- a/src/components/VHeader/VSearchBar/VSearchBar.vue
+++ b/src/components/VHeader/VSearchBar/VSearchBar.vue
@@ -29,6 +29,8 @@ import { computed, defineComponent, PropType } from '@nuxtjs/composition-api'
 
 import { useMatchHomeRoute } from '~/composables/use-match-routes'
 
+import { defineEvent } from '~/types/emits'
+
 import VInputField, {
   FIELD_SIZES,
 } from '~/components/VInputField/VInputField.vue'
@@ -61,7 +63,10 @@ const VSearchBar = defineComponent({
       required: false,
     },
   },
-  emits: ['input', 'submit'],
+  emits: {
+    input: defineEvent<[string]>(),
+    submit: defineEvent(),
+  },
   setup(props, { emit }) {
     const { matches: isHomeRoute } = useMatchHomeRoute()
 

--- a/src/components/VInputField/VInputField.vue
+++ b/src/components/VInputField/VInputField.vue
@@ -29,6 +29,8 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from '@nuxtjs/composition-api'
 
+import { defineEvent } from '~/types/emits'
+
 export const FIELD_SIZES = {
   small: 'h-10 text-md',
   medium: 'h-12',
@@ -92,7 +94,9 @@ export default defineComponent({
     },
   },
   // using non-native event name to ensure the two are not mixed
-  emits: ['update:modelValue'],
+  emits: {
+    'update:modelValue': defineEvent<[string]>(),
+  },
   setup(props, { emit, attrs }) {
     const type = typeof attrs['type'] === 'string' ? attrs['type'] : 'text'
 

--- a/src/components/VNotificationBanner.vue
+++ b/src/components/VNotificationBanner.vue
@@ -29,6 +29,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from '@nuxtjs/composition-api'
 
+import { defineEvent } from '~/types/emits'
 import { useI18n } from '~/composables/use-i18n'
 import { useStorage } from '~/composables/use-storage'
 
@@ -55,7 +56,9 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ['close'],
+  emits: {
+    close: defineEvent(),
+  },
   setup(props, { emit }) {
     const i18n = useI18n()
     const shouldShow = useStorage(`banner:show-${props.id}`, true)

--- a/src/types/emits.ts
+++ b/src/types/emits.ts
@@ -1,0 +1,47 @@
+/**
+ * Type utility function for defining `emits` values on components
+ * without needing to provide an actual validator function.
+ *
+ * This works by casting `null` (which acts as a "skip" validation
+ * signal) to a function type based on the array of parameters passed
+ * in to the function.
+ *
+ * This is also a way around TS and ESLint rules about unused parameters.
+ * The currently recommended way to document emits with Composition API,
+ * is to use a function that always returns `true`, so validation is effectively
+ * skipped as well. However, then TS and ESlint will complain about unused
+ * parameters depending on your configuration. We'd like to keep those rules
+ * and compiler flags on as they are useful for catching bugs, but needing to
+ * disable them for every emits is cumbersome! Casting null, therefore, is a
+ * clean and relatively straightforward solution, at least until we're able
+ * to move to the `script setup` syntax and can use `defineEmit`, which solves
+ * this problem.
+ *
+ * @example
+ * ```typescript
+ * export default defineComponent({
+ *  emits: {
+ *    click: defineEvent<[MouseEvent]>(), // (e: MouseEvent) => void
+ *    open: defineEvent(), // () => void
+ *    close: defineEvent<[{ reason: CloseReason }]>(), // (p: { reason: CloseReason }) => void
+ *  },
+ *  setup(_, { emit }) {
+ *    const state = ref('closed')
+ *    const handleClick = (e: MouseEvent) => {
+ *      // this will cause a TS error if you don't pass a `MouseEvent` payload
+ *      emit('click', e)
+ *      if (state.value === 'closed') {
+ *        emit('open', { reason: 'click' }) // this will cause an error because the `open` event takes no payload
+ *      } else {
+ *        emit('close') // this will cause an error because the `close` event requires a payload
+ *      }
+ *    }
+ *  }
+ * })
+ * ```
+ */
+export function defineEvent<Payload extends unknown[] | null = null>() {
+  return null as unknown as Payload extends [...infer A]
+    ? (...args: [...A]) => void
+    : () => void
+}


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The idea struck me earlier to go digging around the `defineComponent` types around the `emits` option and I remembered that there was a way to define emit payload types, just that it was cumbersome to do so because it required writing a validator function.

I wrote about this in the [WordPress Make slack](https://wordpress.slack.com/archives/C02012JB00N/p1650955199262509) (requires [a free account](https://make.wordpress.org/chat/) to view).

Hopefully the documentation on the `defineEvent` function is clear enough to explain the rationale and theory behind the function.

The code changes outside of that function are basically noops, `null` emit values are the same as just using the string array approach, so this shouldn't change the runtime behavior of the components, just the types.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch and try to break the types generated by `defineEvent` by passing it wacky stuff. If you find anything broken let me know!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
