### PR TITLE
Allow running prod ECS deployment action from ref

### DIFF
--- a/.github/workflows/push_production.yaml
+++ b/.github/workflows/push_production.yaml
@@ -7,6 +7,11 @@ on:
   release:
     types:
       - 'released'
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Git commit from which to build the new stable image.
+        required: true
 
 jobs:
   push:
@@ -20,6 +25,8 @@ jobs:
       # download the source code into the runner
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.sha || 'main' }}
 
       # build a new docker image and push it into the repository
       - name: docker build


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds the ability to rollback the `stable` image tag to a specific commit.

Note: the action should always be run from the `main` branch, this just changes the ref that is used to checkout the code that the docker build is run on.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Not sure how to test this without merging it and then seeing how it goes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [N/A] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
