### PR TITLE
Add some a11y properties to VSearchGridFilter

### DIFF
--- a/src/components/VFilters/VSearchGridFilter.vue
+++ b/src/components/VFilters/VSearchGridFilter.vue
@@ -1,10 +1,11 @@
 <template>
-  <div
+  <section
     id="filters"
+    aria-labelledby="filters-heading"
     class="filters py-8 px-10 min-h-full md:bg-dark-charcoal-06"
   >
     <div class="flex items-center justify-between mt-2 mb-6">
-      <h4 class="text-sr font-semibold py-2 uppercase">
+      <h4 id="filters-heading" class="text-sr font-semibold py-2 uppercase">
         {{ $t('filter-list.filter-by') }}
       </h4>
       <button
@@ -36,7 +37,7 @@
         {{ $t('filter-list.show') }}
       </button>
     </footer>
-  </div>
+  </section>
 </template>
 
 <script>

--- a/src/components/VFilters/VSearchGridFilter.vue
+++ b/src/components/VFilters/VSearchGridFilter.vue
@@ -1,7 +1,7 @@
 <template>
   <div
+    id="filters"
     class="filters py-8 px-10 min-h-full md:bg-dark-charcoal-06"
-    data-testid="filters-list"
   >
     <div class="flex items-center justify-between mt-2 mb-6">
       <h4 class="text-sr font-semibold py-2 uppercase">

--- a/src/components/VHeader/VFilterButton.vue
+++ b/src/components/VHeader/VFilterButton.vue
@@ -4,10 +4,12 @@
     size="disabled"
     class="self-center gap-2 align-center font-semibold py-2 flex-shrink-0 focus-visible:border-tx focus-visible:ring focus-visible:ring-pink"
     :class="
-      filtersAreApplied ? 'px-3' : 'w-10 md:w-auto h-10 md:h-auto px-0 md:px-3'
+      filtersAreApplied
+        ? 'px-3 flex-shrink-0'
+        : 'w-10 md:w-auto h-10 md:h-auto px-0 md:px-3'
     "
     :pressed="pressed"
-    aria-controls="filter-sidebar"
+    aria-controls="filters"
     :aria-label="mdMinLabel"
     @click="$emit('toggle')"
   >

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-04-27T09:18:56+00:00\n"
+"POT-Creation-Date: 2022-04-27T11:03:45+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -806,7 +806,7 @@ msgctxt "browse-page.search-rating.feedback-thanks"
 msgid "Thank you for the feedback!"
 msgstr ""
 
-#: src/components/VFilters/VSearchGridFilter.vue:8
+#: src/components/VFilters/VSearchGridFilter.vue:9
 msgctxt "filter-list.filter-by"
 msgid "Filter by"
 msgstr ""
@@ -815,12 +815,12 @@ msgctxt "filter-list.hide"
 msgid "Hide filters"
 msgstr ""
 
-#: src/components/VFilters/VSearchGridFilter.vue:17
+#: src/components/VFilters/VSearchGridFilter.vue:18
 msgctxt "filter-list.clear"
 msgid "Clear filters"
 msgstr ""
 
-#: src/components/VFilters/VSearchGridFilter.vue:36
+#: src/components/VFilters/VSearchGridFilter.vue:37
 msgctxt "filter-list.show"
 msgid "Show results"
 msgstr ""

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-04-24T18:53:29+00:00\n"
+"POT-Creation-Date: 2022-04-27T09:18:56+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1817,7 +1817,7 @@ msgid "Filters"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VHeader/VFilterButton.vue:86
+#: src/components/VHeader/VFilterButton.vue:95
 msgctxt "header.filter-button.with-count"
 msgid "###count### Filter"
 msgid_plural "###count### Filters"

--- a/test/playwright/e2e/filters.spec.ts
+++ b/test/playwright/e2e/filters.spec.ts
@@ -153,7 +153,7 @@ test('filters are updated when media type changes', async ({ page }) => {
   // Only CC0 checkbox is checked, and the filter button label is '1 Filter'
   await assertCheckboxStatus(page, 'cc0')
   await expect(
-    page.locator('[aria-controls="filter-sidebar"] span:visible')
+    page.locator('[aria-controls="filters"] span:visible')
   ).toHaveText('1 Filter')
 
   await expect(page).toHaveURL('/search/audio?q=cat&license=cc0')

--- a/test/playwright/utils/navigation.ts
+++ b/test/playwright/utils/navigation.ts
@@ -1,7 +1,7 @@
 import { expect, Page } from '@playwright/test'
 
 export const openFilters = async (page: Page) => {
-  const filterButtonSelector = '[aria-controls="filter-sidebar"]'
+  const filterButtonSelector = '[aria-controls="filters"]'
   const isPressed = async () =>
     await page.getAttribute(filterButtonSelector, 'aria-pressed')
   if ((await isPressed()) !== 'true') {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Addresses the point in a [comment](https://github.com/WordPress/openverse-frontend/pull/1275#pullrequestreview-951750164) to #1275

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR sets updates `VSearchGridFilter` to add the id of `filters`, and adds `aria-controls = "filters"` attribute to `VFilterButton`.
Unfortunately, `aria-controls` isn't implemented by most of the screen-readers, so we will **have** to add our own solution to shift focus to the sidebar after `VFilterButton` is clicked. This PR also implements one piece of advice from an article about `aria-controls`: https://heydonworks.com/article/aria-controls-is-poop/: it makes `VSearchGridFilter` a `section`, so adds a landmark role to it. These other two pieces will have to be implemented separately
-  Same-page links to move users from one part of the interface to another
- Expandable areas that come immediately after their aria-expanded controllers in the source (and in focus order).

Even though the browser and screen reader support is patchy, it is nice to use `aria-controls` to select the filter button in the tests, considering that the filter button has different labels depending on the number of filters selected. Although now after I've written this, I thought that we should make sure to have a more consistent accessible name for this button for the screen readers.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the tests, open the app to see that VFilterButton still opens the Filters sidebar/ modal.

@sarayourfriend , please feel free to merge or not merge this as you see fit :)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
