### PR TITLE
Add e2e test for localized back to search link

### DIFF
--- a/test/playwright/e2e/search-navigation.spec.ts
+++ b/test/playwright/e2e/search-navigation.spec.ts
@@ -46,3 +46,50 @@ test.describe('search history navigation', () => {
     expect(await page.locator('text=See all audio').isVisible()).toBe(true)
   })
 })
+
+test('navigates to the image detail page correctly', async ({ page }) => {
+  await page.goto('/search/image?q=honey')
+  const figure = page.locator('figure').first()
+  const imgTitle = await figure.locator('img').getAttribute('alt')
+
+  await page.locator('a[href^="/image"]').first().click()
+  // Until the image is loaded, the heading is 'Image' instead of the actual title
+  await page.locator('#main-image').waitFor()
+
+  const headingText = await page.locator('h1').textContent()
+  expect(headingText?.trim().toLowerCase()).toEqual(imgTitle?.toLowerCase())
+})
+
+test.describe('back to search results link', () => {
+  test('is visible in breadcrumb when navigating to image details page and returns to the search page', async ({
+    page,
+  }) => {
+    const url = '/search/?q=galah'
+    await page.goto(url)
+    await page.locator('a[href^="/image"]').first().click()
+    const link = page.locator('text="Back to search results"')
+    await expect(link).toBeVisible()
+    await link.click()
+    await expect(page).toHaveURL(url)
+  })
+
+  test('is visible in breadcrumb when navigating to localized image details page', async ({
+    page,
+  }) => {
+    await page.goto('/es/search/?q=galah')
+    await page.locator('a[href^="/es/image"]').first().click()
+    await expect(
+      page.locator('text="Volver a los resultados de búsqueda"')
+    ).toBeVisible()
+  })
+
+  test('is visible in breadcrumb when navigating to localized audio details page', async ({
+    page,
+  }) => {
+    await page.goto('/es/search/?q=galah')
+    await page.locator('a[href^="/es/audio"]').first().click()
+    await expect(
+      page.locator('text="Volver a los resultados de búsqueda"')
+    ).toBeVisible()
+  })
+})

--- a/test/playwright/e2e/search.spec.ts
+++ b/test/playwright/e2e/search.spec.ts
@@ -14,58 +14,7 @@ test.beforeEach(async ({ context }) => {
   await mockProviderApis(context)
 })
 
-test.skip('shows search result metadata', async ({ page }) => {
-  await page.goto('/search/image?q=cat&source=rijksmuseum')
-  await page.route('https://api.openverse.engineering/v1/images/**', (route) =>
-    route.fulfill({ path: 'test/e2e/resources/last_page.json' })
-  )
-
-  // Expect results meta
-  // Flaky test. Is there a way to mock the first api result when loading on the server?
-  await expect(page.locator('.results-meta span.pe-6')).toContainText(
-    /image results/
-  )
-  await expect(page.locator('text=Are these results relevant?')).toHaveCount(1)
-
-  // Click load more button
-  const loadMoreButton = page.locator('button:has-text("Load more results")')
-  await expect(loadMoreButton).toHaveCount(1)
-  await loadMoreButton.click()
-
-  // Click load more button
-  await expect(loadMoreButton).toHaveCount(1)
-  await loadMoreButton.click()
-  // All search results have been shown, cannot load more
-  await expect(loadMoreButton).toHaveCount(0, { timeout: 300 })
-})
-
 test('shows no results page when no results', async ({ page }) => {
   await page.goto('/search/image?q=243f6a8885a308d3')
   await expect(page.locator('.error-section')).toBeVisible()
-})
-
-test('navigates to the image detail page correctly', async ({ page }) => {
-  await page.goto('/search/image?q=honey')
-  const figure = page.locator('figure').first()
-  const imgTitle = await figure.locator('img').getAttribute('alt')
-
-  await page.locator('a[href^="/image"]').first().click()
-  // Until the image is loaded, the heading is 'Image' instead of the actual title
-  await page.locator('#main-image').waitFor()
-
-  const headingText = await page.locator('h1').textContent()
-  expect(headingText?.trim().toLowerCase()).toEqual(imgTitle?.toLowerCase())
-  // Renders the breadcrumb link
-  await expect(page.locator('text="Back to search results"')).toBeVisible()
-})
-
-test('the Back to search results link returns to the search page', async ({
-  page,
-}) => {
-  const url = '/search/image?q=honey'
-  await page.goto(url)
-
-  await page.locator('a[href^="/image"]').first().click()
-  await page.locator('text="Back to search results"').click()
-  await expect(page).toHaveURL(url)
 })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #1350

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Added tests in the `search-navigation.spec.ts` file. I also moved some test from the `search.spec.ts.` file to grouped them under the "back to search results link" description, and removed a skiped test.

Try these changes in **main** and observe tests fail, then here with @obulat fixes, they should pass.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
