### PR TITLE
Fix mobile menu modals not opening for the second time

### DIFF
--- a/src/components/VContentSwitcher/VMobileMenuModal.vue
+++ b/src/components/VContentSwitcher/VMobileMenuModal.vue
@@ -12,7 +12,6 @@
       :visible="visibleRef"
       :trigger-element="triggerRef"
       :hide="close"
-      :hide-on-click-outside="false"
       :aria-label="$t('header.filter-button.simple')"
       :initial-focus-element="initialFocusElement"
     >

--- a/src/components/VContentSwitcher/VMobileMenuModal.vue
+++ b/src/components/VContentSwitcher/VMobileMenuModal.vue
@@ -12,6 +12,7 @@
       :visible="visibleRef"
       :trigger-element="triggerRef"
       :hide="close"
+      :hide-on-click-outside="false"
       :aria-label="$t('header.filter-button.simple')"
       :initial-focus-element="initialFocusElement"
     >

--- a/src/components/VHeader/VHeaderFilter.vue
+++ b/src/components/VHeader/VHeaderFilter.vue
@@ -105,8 +105,10 @@ export default {
         open()
       }
     }
+
     const mobileOptions = {
       visible: visibleRef,
+      hideOnClickOutside: false,
       'trigger-element': computed(() => nodeRef?.value?.firstChild),
       hide: close,
       'aria-label': i18n.t('header.filter-button.simple'),
@@ -121,7 +123,7 @@ export default {
      * @type { import('@nuxtjs/composition-api').Ref<{
      * 'trigger-element'?: import('@nuxtjs/composition-api').ComputedRef<HTMLElement|null>,
      * hide?: () => {}, visible: import('@nuxtjs/composition-api').Ref<boolean>,
-     * 'aria-label': [string], to?: string, mode?: string }> }
+     * 'aria-label': [string], to?: string, mode?: string, hideOnClickOutside?: boolean }> }
      */
     const options = ref(mobileOptions)
     onMounted(() => {

--- a/src/components/VHeader/VHeaderFilter.vue
+++ b/src/components/VHeader/VHeaderFilter.vue
@@ -108,10 +108,9 @@ export default {
 
     const mobileOptions = {
       visible: visibleRef,
-      hideOnClickOutside: false,
       'trigger-element': computed(() => nodeRef?.value?.firstChild),
       hide: close,
-      'aria-label': i18n.t('header.filter-button.simple'),
+      'aria-label': i18n.t('header.filter-button.simple').toString(),
       mode: 'mobile',
     }
 
@@ -120,10 +119,7 @@ export default {
       visible: visibleRef,
     }
     /**
-     * @type { import('@nuxtjs/composition-api').Ref<{
-     * 'trigger-element'?: import('@nuxtjs/composition-api').ComputedRef<HTMLElement|null>,
-     * hide?: () => {}, visible: import('@nuxtjs/composition-api').Ref<boolean>,
-     * 'aria-label': [string], to?: string, mode?: string, hideOnClickOutside?: boolean }> }
+     * @type { import('@nuxtjs/composition-api').Ref<{'trigger-element'?: import('@nuxtjs/composition-api').ComputedRef<HTMLElement|null>, hide?: () => void, visible: import('@nuxtjs/composition-api').Ref<boolean>, 'aria-label'?: string, to?: string, mode?: string, hideOnClickOutside?: boolean }> }
      */
     const options = ref(mobileOptions)
     onMounted(() => {

--- a/src/components/VModal/VModalContent.vue
+++ b/src/components/VModal/VModalContent.vue
@@ -92,7 +92,7 @@ const VModalContent = defineComponent({
     },
     hideOnClickOutside: {
       type: Boolean,
-      default: true,
+      default: false,
     },
     autoFocusOnShow: {
       type: Boolean,

--- a/src/composables/use-dialog-content.js
+++ b/src/composables/use-dialog-content.js
@@ -19,7 +19,7 @@ import { useFocusOnBlur } from '~/composables/use-focus-on-blur'
 /** @typedef {import('./types').ToRefs<InnerProps> & { emit: import('@nuxtjs/composition-api').SetupContext['emit']}} Props */
 
 /**
- * @param {Props} props
+ * @param {Props} params
  */
 export function useDialogContent({ emit, ...props }) {
   const focusOnBlur = useFocusOnBlur(props)

--- a/test/playwright/e2e/mobile-menu.spec.ts
+++ b/test/playwright/e2e/mobile-menu.spec.ts
@@ -14,10 +14,9 @@ const mobileFixture = {
   viewport: { width: 640, height: 700 },
   userAgent: mockUaString,
 }
+test.use(mobileFixture)
 
 test('Can open filters menu on mobile at least twice', async ({ page }) => {
-  test.use(mobileFixture)
-
   await page.goto('/search/?q=cat&license_type=commercial')
   const expectedFilter = 'commercial'
 
@@ -34,8 +33,6 @@ test('Can open filters menu on mobile at least twice', async ({ page }) => {
 })
 
 test('Can open mobile menu at least twice', async ({ page }) => {
-  test.use(mobileFixture)
-
   await page.goto('/search/?q=cat&license_type=commercial')
   await openMobileMenu(page)
   await expect(page.locator(`button:has-text('Close)`)).toBeVisible()

--- a/test/playwright/e2e/mobile-menu.spec.ts
+++ b/test/playwright/e2e/mobile-menu.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+
+import {
+  assertCheckboxStatus,
+  closeFilters,
+  closeMobileMenu,
+  openFilters,
+  openMobileMenu,
+} from '~~/test/playwright/utils/navigation'
+
+const mockUaString =
+  'Mozilla/5.0 (Android 7.0; Mobile; rv:54.0) Gecko/54.0 Firefox/54.0'
+const mobileFixture = {
+  viewport: { width: 640, height: 700 },
+  userAgent: mockUaString,
+}
+
+test('Can open filters menu on mobile at least twice', async ({ page }) => {
+  test.use(mobileFixture)
+
+  await page.goto('/search/?q=cat&license_type=commercial')
+  const expectedFilter = 'commercial'
+
+  await openFilters(page)
+  await assertCheckboxStatus(page, expectedFilter)
+
+  await closeFilters(page)
+  await expect(page.locator(`input[type="checkbox"]`)).toHaveCount(0, {
+    timeout: 100,
+  })
+
+  await openFilters(page)
+  await assertCheckboxStatus(page, expectedFilter)
+})
+
+test('Can open mobile menu at least twice', async ({ page }) => {
+  test.use(mobileFixture)
+
+  await page.goto('/search/?q=cat&license_type=commercial')
+  await openMobileMenu(page)
+  await expect(page.locator(`button:has-text('Close)`)).toBeVisible()
+  await closeMobileMenu(page)
+  await expect(page.locator(`button:has-text('Close)`)).not.toBeVisible()
+  await openMobileMenu(page)
+  await expect(page.locator(`button:has-text('Close)`)).toBeVisible()
+})

--- a/test/playwright/e2e/mobile-menu.spec.ts
+++ b/test/playwright/e2e/mobile-menu.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test'
 
 import {
-  assertCheckboxStatus,
-  closeFilters,
   closeMobileMenu,
   openFilters,
   openMobileMenu,
@@ -17,27 +15,29 @@ const mobileFixture = {
 test.use(mobileFixture)
 
 test('Can open filters menu on mobile at least twice', async ({ page }) => {
-  await page.goto('/search/?q=cat&license_type=commercial')
-  const expectedFilter = 'commercial'
+  await page.goto('/search/?q=cat')
 
   await openFilters(page)
-  await assertCheckboxStatus(page, expectedFilter)
-
-  await closeFilters(page)
+  await expect(page.locator(`input[type="checkbox"]`)).toHaveCount(11, {
+    timeout: 100,
+  })
+  await closeMobileMenu(page)
   await expect(page.locator(`input[type="checkbox"]`)).toHaveCount(0, {
     timeout: 100,
   })
 
   await openFilters(page)
-  await assertCheckboxStatus(page, expectedFilter)
+  await expect(page.locator(`input[type="checkbox"]`)).toHaveCount(11, {
+    timeout: 100,
+  })
 })
 
 test('Can open mobile menu at least twice', async ({ page }) => {
-  await page.goto('/search/?q=cat&license_type=commercial')
+  await page.goto('/search/?q=cat')
   await openMobileMenu(page)
-  await expect(page.locator(`button:has-text('Close)`)).toBeVisible()
+  await expect(page.locator('button', { hasText: 'Close' })).toBeVisible()
   await closeMobileMenu(page)
-  await expect(page.locator(`button:has-text('Close)`)).not.toBeVisible()
+  await expect(page.locator('button', { hasText: 'Close' })).not.toBeVisible()
   await openMobileMenu(page)
-  await expect(page.locator(`button:has-text('Close)`)).toBeVisible()
+  await expect(page.locator('button', { hasText: 'Close' })).toBeVisible()
 })

--- a/test/playwright/utils/navigation.ts
+++ b/test/playwright/utils/navigation.ts
@@ -1,13 +1,39 @@
 import { expect, Page } from '@playwright/test'
 
-export const openFilters = async (page: Page) => {
-  const filterButtonSelector = '[aria-controls="filters"]'
-  const isPressed = async () =>
-    await page.getAttribute(filterButtonSelector, 'aria-pressed')
-  if ((await isPressed()) !== 'true') {
-    await page.click(filterButtonSelector)
-    expect(await isPressed()).toEqual('true')
+const buttonSelectors = {
+  filter: '[aria-controls="filters"]',
+  mobileMenu: '[aria-controls="content-switcher-modal"]',
+}
+
+const isButtonPressed = async (page: Page, buttonSelector: string) =>
+  await page.getAttribute(buttonSelector, 'aria-pressed')
+
+const manipulateButton = async (
+  page: Page,
+  button: 'filter' | 'mobileMenu',
+  action: 'open' | 'close'
+) => {
+  const selector = buttonSelectors[button]
+  const expectedValue = action === 'open' ? 'true' : 'false'
+  if ((await isButtonPressed(page, selector)) !== expectedValue) {
+    await page.click(selector)
+    expect(await isButtonPressed(page, selector)).toEqual(expectedValue)
   }
+}
+
+export const openFilters = async (page: Page) => {
+  await manipulateButton(page, 'filter', 'open')
+}
+
+export const closeFilters = async (page: Page) => {
+  await manipulateButton(page, 'filter', 'close')
+}
+
+export const openMobileMenu = async (page: Page) => {
+  await manipulateButton(page, 'mobileMenu', 'open')
+}
+export const closeMobileMenu = async (page: Page) => {
+  await manipulateButton(page, 'mobileMenu', 'close')
 }
 
 export const assertCheckboxStatus = async (

--- a/test/playwright/utils/navigation.ts
+++ b/test/playwright/utils/navigation.ts
@@ -2,19 +2,29 @@ import { expect, Page } from '@playwright/test'
 
 const buttonSelectors = {
   filter: '[aria-controls="filters"]',
-  mobileMenu: '[aria-controls="content-switcher-modal"]',
+  contentSwitcher: '[aria-controls="content-switcher-modal"]',
 }
 
-const isButtonPressed = async (page: Page, buttonSelector: string) =>
-  await page.getAttribute(buttonSelector, 'aria-pressed')
+const isButtonPressed = async (page: Page, buttonSelector: string) => {
+  const viewportSize = page.viewportSize()
+  if (!viewportSize) {
+    return false
+  }
+  const pageWidth = viewportSize.width
+  if (pageWidth > 640) {
+    return await page.getAttribute(buttonSelector, 'aria-pressed')
+  } else {
+    console.log(
+      page.locator('button', { hasText: 'Close' }),
+      page.locator('button', { hasText: 'Close' }).isVisible()
+    )
+    return page.locator('button', { hasText: 'Close' }).isVisible()
+  }
+}
 
-const manipulateButton = async (
-  page: Page,
-  button: 'filter' | 'mobileMenu',
-  action: 'open' | 'close'
-) => {
+const openMenu = async (page: Page, button: 'filter' | 'contentSwitcher') => {
   const selector = buttonSelectors[button]
-  const expectedValue = action === 'open' ? 'true' : 'false'
+  const expectedValue = 'true'
   if ((await isButtonPressed(page, selector)) !== expectedValue) {
     await page.click(selector)
     expect(await isButtonPressed(page, selector)).toEqual(expectedValue)
@@ -22,18 +32,15 @@ const manipulateButton = async (
 }
 
 export const openFilters = async (page: Page) => {
-  await manipulateButton(page, 'filter', 'open')
-}
-
-export const closeFilters = async (page: Page) => {
-  await manipulateButton(page, 'filter', 'close')
+  await openMenu(page, 'filter')
 }
 
 export const openMobileMenu = async (page: Page) => {
-  await manipulateButton(page, 'mobileMenu', 'open')
+  await openMenu(page, 'contentSwitcher')
 }
+
 export const closeMobileMenu = async (page: Page) => {
-  await manipulateButton(page, 'mobileMenu', 'close')
+  await page.click('text=Close')
 }
 
 export const assertCheckboxStatus = async (

--- a/test/playwright/utils/navigation.ts
+++ b/test/playwright/utils/navigation.ts
@@ -14,11 +14,9 @@ const isButtonPressed = async (page: Page, buttonSelector: string) => {
   if (pageWidth > 640) {
     return await page.getAttribute(buttonSelector, 'aria-pressed')
   } else {
-    console.log(
-      page.locator('button', { hasText: 'Close' }),
-      page.locator('button', { hasText: 'Close' }).isVisible()
-    )
-    return page.locator('button', { hasText: 'Close' }).isVisible()
+    return (await page.locator('button', { hasText: 'Close' }).isVisible())
+      ? 'true'
+      : 'false'
   }
 }
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1308 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR sets the `useHideOutside` to false for mobile modals. This fixes the bug, but it doesn't fix the underlying problem. That, hopefully, will be fixed in PR that Typescriptifies the dialog composables: https://github.com/WordPress/openverse-frontend/pull/1279

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Open the app on mobile width, and try clicking Filter/ Page menu buttons in the header several times. The menus should open and close successfully. On main [search-staging.openverse.engineering/search](https://search-staging.openverse.engineering/search/?q=cat), you can only open them once.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
