### PR TITLE
Handle attribution when title is blank

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -421,7 +421,9 @@
         "link": "here"
       },
       "credit": {
-        "text": "\"{title}\"{creator}{marked-licensed}{license}. {view-legal}",
+        "generic-title": "This work",
+        "actual-title": "\"{title}\"",
+        "text": "{title}{creator}{marked-licensed}{license}. {view-legal}",
         "creator-text": " by {creator-name}",
         "marked": " is marked with ",
         "licensed": " is licensed under ",

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-05-03T05:46:51+00:00\n"
+"POT-Creation-Date: 2022-05-04T11:38:38+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -655,9 +655,18 @@ msgctxt "media-details.reuse.copy-license.copied"
 msgid "Copied!"
 msgstr ""
 
+msgctxt "media-details.reuse.credit.generic-title"
+msgid "This work"
+msgstr ""
+
+#. Do not translate words between ### ###.
+msgctxt "media-details.reuse.credit.actual-title"
+msgid "\"###title###\""
+msgstr ""
+
 #. Do not translate words between ### ###.
 msgctxt "media-details.reuse.credit.text"
-msgid "\"###title###\"###creator######marked-licensed######license###. ###view-legal###"
+msgid "###title######creator######marked-licensed######license###. ###view-legal###"
 msgstr ""
 
 #. Do not translate words between ### ###.

--- a/src/utils/attribution-html.ts
+++ b/src/utils/attribution-html.ts
@@ -105,7 +105,7 @@ export const getAttribution = (
   /* Title */
 
   let titleLink = mediaItem.title || ''
-  if (!isPlaintext && mediaItem.foreign_landing_url)
+  if (!isPlaintext && mediaItem.foreign_landing_url && titleLink)
     titleLink = extLink(mediaItem.foreign_landing_url, titleLink)
 
   /* Creator */
@@ -144,7 +144,9 @@ export const getAttribution = (
   let attribution: string
   if (i18n) {
     let fillers: Record<string, string> = {
-      title: titleLink,
+      title: titleLink
+        ? i18n.t(`${i18nBase}.actual-title`, { title: titleLink }).toString()
+        : i18n.t(`${i18nBase}.generic-title`).toString(),
       creator: creatorLink
         ? i18n
             .t(`${i18nBase}.creator-text`, {
@@ -172,7 +174,8 @@ export const getAttribution = (
     }
     attribution = i18n.t(`${i18nBase}.text`, fillers).toString()
   } else {
-    const attributionParts = [`"${titleLink}"`]
+    const attributionParts = []
+    attributionParts.push(titleLink ? `"${titleLink}"` : 'This work')
     if (creatorLink) attributionParts.push(' by ', creatorLink)
     attributionParts.push(
       isPd ? ' is marked with ' : ' is licensed under ',

--- a/test/unit/specs/utils/attribution-html.spec.ts
+++ b/test/unit/specs/utils/attribution-html.spec.ts
@@ -43,6 +43,16 @@ describe('getAttribution', () => {
     }
   )
 
+  it('uses generic title if not known', () => {
+    const mediaItemNoTitle = { ...mediaItem, title: '' }
+    const attrText = getAttribution(mediaItemNoTitle, i18n, {
+      isPlaintext: true,
+    })
+    const expectation =
+      'This work by Creator is marked with Public Domain Mark 1.0'
+    expect(attrText).toContain(expectation)
+  })
+
   it('omits creator if not known', () => {
     const mediaItemNoCreator = { ...mediaItem, creator: undefined }
     const attrText = getAttribution(mediaItemNoCreator, i18n, {


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR handles cases where a media item either has no name or a blank one. It uses "This work" (or it's equivalent translation) if the media name is not known.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
See added test case.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
