### PR TITLE
Break long searched words if necessary

### DIFF
--- a/src/components/VErrorSection/VNoResults.vue
+++ b/src/components/VErrorSection/VNoResults.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="no-results text-center md:text-left">
-    <h5 class="text-5xl">
+    <h5 class="text-5xl break-words">
       {{ $t('no-results.heading', { query: query.q }) }}
     </h5>
     <h6 class="text-3xl font-normal md:font-bold mt-10 md:mt-16">

--- a/src/components/VSearchResultsTitle.vue
+++ b/src/components/VSearchResultsTitle.vue
@@ -1,6 +1,6 @@
 <template>
   <h1
-    class="leading-tight sr-only md:not-sr-only"
+    class="leading-tight sr-only md:not-sr-only break-words"
     :class="[size === 'large' ? 'text-[90px]' : 'text-6xl']"
   >
     <slot default />


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1293 by @obulat 

## Description
If the user tried searching for a long word, for example `dog -dskaodkadokaosdadadasdadadasdsadadsad`, the long word would generate a horizontal overflow. The same thing happened on the 'no results' page.

## Testing Instructions
Try searching for something with a long word in it. I recommend using something like `dog -dskaodkadokaosdadadasdadadasdsadadsad` because it's easier to write whatever as a long excluding word, and check if there is a horizontal overflow on the page. (check issue for sample screenshot)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
