### PR TITLE
Add license explanation to close button label

### DIFF
--- a/src/components/VFilters/VFilterChecklist.vue
+++ b/src/components/VFilters/VFilterChecklist.vue
@@ -122,7 +122,7 @@ export default {
       const descriptions = elements
         .map((element) => this.$t(`browse-page.license-description.${element}`))
         .join(' ')
-      const close = this.$t('modal.close', {
+      const close = this.$t('modal.close-named', {
         name: this.$t('browse-page.aria.license-explanation'),
       })
       return `${descriptions} - ${close}`

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -606,7 +606,8 @@
   },
   "interpunct": "•",
   "modal": {
-    "close": "Close {name}"
+    "close": "Close",
+    "close-named": "Close {name}"
   },
   "error-images": {
     "depressed-musician": "A depressed pianist rests their head in their hands.",

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-05-09T15:17:18+00:00\n"
+"POT-Creation-Date: 2022-05-10T15:31:18+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -136,9 +136,14 @@ msgctxt "error-images.waiting-for-a-bite"
 msgid "Three boys sit on a broken log while two of them fish."
 msgstr ""
 
-#. Do not translate words between ### ###.
 #: src/components/VContentReport/VContentReportPopover.vue:18
 msgctxt "modal.close"
+msgid "Close"
+msgstr ""
+
+#. Do not translate words between ### ###.
+#: src/components/VFilters/VFilterChecklist.vue:125
+msgctxt "modal.close-named"
 msgid "Close ###name###"
 msgstr ""
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #987 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I tried to fix this as best I can, but it needs to be tested in VO and JAWS. I'm working on JAWS, but someone with a Mac will have to help with VO.

This adds the license explanation to the close button. That way when the SR opens the popover and the close button is focused, it reads the explanation and then also declares that the close button is focused (so that the user knows they can close the popover).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch and go to the search results page, `/search?q=birds` then, navigating with a screen reader, open the filter sidebar and tab into it (note the experience here will improve with #1394). Focus the license explanation popover button. Open the popover and verify that the SR reads the license explanation and informs the user that they are on the close button for the popover and that you can close the popover successfully.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
