### PR TITLE
Fix duplicated shell property in the staging build config; fix staging deploys

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -30,7 +30,6 @@ runs:
       id: pnpm-version
       run: |
         echo "::set-output name=val::$(cat .pnpm-version)"
-      shell: bash
 
     # setup docker buildx
     - name: setup docker buildx


### PR DESCRIPTION
This PR fixes staging deploys by removing a duplicated `shell` property on the pnpm version step.