### PR TITLE
Stop fetching the media twice in the search page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
   playwright-test-failure-comment:
     name: Share Playwright test debugging instructions
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: always() && (needs.nuxt-playwright.result == 'failure' || needs.storybook-playwright.result == 'failure')
     needs:
       - nuxt-playwright
       - storybook-playwright

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -226,8 +226,6 @@ const HomePage = {
         query,
       })
       router.push(newPath)
-
-      await mediaStore.fetchMedia()
     }
 
     return {

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -113,6 +113,12 @@ export const useSearchStore = defineStore('search', {
           filterKey !== 'mature' && filterItems.some((filter) => filter.checked)
       )
     },
+    /**
+     * Returns whether the current `seartchType` is a supported media type for search.
+     */
+    searchTypeIsSupported(state) {
+      return supportedSearchTypes.includes(state.searchType)
+    },
   },
   actions: {
     setSearchType(type: SupportedSearchType) {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1225 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The actual fix is in the `src/pages/index.vue` file but I also refactored the search page to use the correct Nuxt hook for async data (SSR), and remove a duplicated computed property with the Vue Options API.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Follow the steps in the issue and observe no more double fetching for audio and images in the browser console.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
