### PR TITLE
Stop opening `/search/video` from crashing the app

### DIFF
--- a/src/components/VContentSwitcher/VSearchTypeButton.vue
+++ b/src/components/VContentSwitcher/VSearchTypeButton.vue
@@ -23,14 +23,19 @@
     />
   </VButton>
 </template>
-<script>
-import { computed, defineComponent, inject } from '@nuxtjs/composition-api'
+<script lang="ts">
+import {
+  computed,
+  defineComponent,
+  inject,
+  PropType,
+  ref,
+} from '@nuxtjs/composition-api'
 
-import { ALL_MEDIA } from '~/constants/media'
+import { ALL_MEDIA, SearchType } from '~/constants/media'
 import useSearchType from '~/composables/use-search-type'
 import { useI18n } from '~/composables/use-i18n'
 import { isMinScreen } from '~/composables/use-media-query'
-import { isValidSearchType } from '~/utils/prop-validators'
 
 import VIcon from '~/components/VIcon/VIcon.vue'
 import VButton from '~/components/VButton.vue'
@@ -46,19 +51,17 @@ export default defineComponent({
       required: true,
     },
     activeItem: {
-      type: String,
+      type: String as PropType<SearchType>,
       default: ALL_MEDIA,
-      validator: isValidSearchType,
     },
     type: {
-      type: String,
+      type: String as PropType<'header' | 'searchbar'>,
       default: 'header',
-      validator: (v) => ['header', 'searchbar'].includes(v),
     },
   },
   setup(props) {
     const i18n = useI18n()
-    const isHeaderScrolled = inject('isHeaderScrolled', null)
+    const isHeaderScrolled = inject('isHeaderScrolled', ref(null))
     const isMinScreenMd = isMinScreen('md', { shouldPassInSSR: true })
 
     const { icons, activeType: activeItem } = useSearchType()

--- a/src/components/VContentSwitcher/VSearchTypePopover.vue
+++ b/src/components/VContentSwitcher/VSearchTypePopover.vue
@@ -2,7 +2,7 @@
   <VPopover
     ref="contentMenuPopover"
     class="flex items-stretch"
-    :label="$t('search-type.label')"
+    :label="$t('search-type.label').toString()"
     placement="bottom-end"
   >
     <template #trigger="{ a11yProps }">
@@ -28,10 +28,18 @@
   </VPopover>
 </template>
 
-<script>
-import { computed, defineComponent, ref } from '@nuxtjs/composition-api'
+<script lang="ts">
+import {
+  ComponentInstance,
+  computed,
+  defineComponent,
+  PropType,
+  ref,
+} from '@nuxtjs/composition-api'
 
 import useSearchType from '~/composables/use-search-type'
+import type { SearchType } from '~/constants/media'
+import { defineEvent } from '~/types/emits'
 
 import VPopover from '~/components/VPopover/VPopover.vue'
 import VSearchTypeButton from '~/components/VContentSwitcher/VSearchTypeButton.vue'
@@ -52,23 +60,25 @@ export default defineComponent({
   },
   props: {
     activeItem: {
-      type: String,
+      type: String as PropType<SearchType>,
       required: true,
     },
     placement: {
-      type: String,
+      type: String as PropType<'header' | 'searchbar'>,
       default: 'header',
     },
+  },
+  emits: {
+    select: defineEvent<SearchType>(),
   },
   setup(props, { emit }) {
     const content = useSearchType()
 
-    const contentMenuPopover = ref(null)
+    const contentMenuPopover = ref<ComponentInstance | null>(null)
 
     /**
      * When in the searchbar, content switcher button has a border when the
      * search bar group is hovered on.
-     * @type {ComputedRef<boolean>}
      */
     const isInSearchBar = computed(() => props.placement === 'searchbar')
 
@@ -81,7 +91,7 @@ export default defineComponent({
       }
     }
 
-    const selectItem = (item) => {
+    const selectItem = (item: SearchType) => {
       emit('select', item)
     }
 

--- a/src/components/VContentSwitcher/VSearchTypes.vue
+++ b/src/components/VContentSwitcher/VSearchTypes.vue
@@ -35,12 +35,12 @@
     </div>
   </VItemGroup>
 </template>
-<script>
-import { computed, defineComponent } from '@nuxtjs/composition-api'
+<script lang="ts">
+import { computed, defineComponent, PropType } from '@nuxtjs/composition-api'
 
 import { isDev } from '~/utils/node-env'
 
-import { supportedSearchTypes } from '~/constants/media'
+import type { SearchType } from '~/constants/media'
 import useSearchType from '~/composables/use-search-type'
 
 import VItemGroup from '~/components/VItemGroup/VItemGroup.vue'
@@ -55,14 +55,12 @@ export default defineComponent({
      * 'medium' size for larger screens.
      */
     size: {
-      type: String,
+      type: String as PropType<'small' | 'medium'>,
       default: 'small',
-      validator: (val) => ['small', 'medium'].includes(val),
     },
     activeItem: {
-      type: String,
+      type: String as PropType<SearchType>,
       required: true,
-      validator: (val) => supportedSearchTypes.includes(val),
     },
     useLinks: {
       type: Boolean,

--- a/src/components/VErrorSection/VNoResults.vue
+++ b/src/components/VErrorSection/VNoResults.vue
@@ -10,22 +10,24 @@
   </div>
 </template>
 
-<script>
-import { isValidSearchType } from '~/utils/prop-validators'
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+import type { MediaType } from '~/constants/media'
+import type { ApiQueryParams } from '~/utils/search-query-transform'
 
 import VMetaSourceList from '~/components/VMetaSearch/VMetaSourceList.vue'
 
-export default {
+export default defineComponent({
   name: 'VNoResults',
   components: { VMetaSourceList },
   props: {
     type: {
-      type: String,
-      validator: isValidSearchType,
+      type: String as PropType<MediaType>,
     },
     query: {
-      type: Object,
+      type: Object as PropType<ApiQueryParams>,
     },
   },
-}
+})
 </script>

--- a/src/components/VSearchGrid.vue
+++ b/src/components/VSearchGrid.vue
@@ -38,12 +38,12 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from '@nuxtjs/composition-api'
 
-import { ALL_MEDIA, IMAGE, SupportedSearchType } from '~/constants/media'
+import { ALL_MEDIA, IMAGE, VIDEO, SearchType } from '~/constants/media'
 import { NO_RESULT } from '~/constants/errors'
 import { defineEvent } from '~/types/emits'
-
 import type { ApiQueryParams } from '~/utils/search-query-transform'
 import type { FetchState } from '~/composables/use-fetch-state'
+import { isSearchTypeSupported } from '~/stores/search'
 
 import VMetaSearchForm from '~/components/VMetaSearch/VMetaSearchForm.vue'
 import VErrorSection from '~/components/VErrorSection/VErrorSection.vue'
@@ -70,7 +70,7 @@ export default defineComponent({
       required: true,
     },
     searchType: {
-      type: String as PropType<SupportedSearchType>,
+      type: String as PropType<SearchType>,
       required: true,
     },
     fetchState: {
@@ -93,9 +93,16 @@ export default defineComponent({
         ? props.query.q !== '' && props.resultsCount === 0
         : false
     })
+
+    /**
+     * Metasearch form shows the external sources for current search type, or for images if the search type is 'All Content'.
+     */
     const metaSearchFormType = computed(() => {
-      return props.searchType === ALL_MEDIA ? IMAGE : props.searchType
+      if (isSearchTypeSupported(props.searchType)) return props.searchType
+      if (props.searchType === VIDEO) return VIDEO
+      return IMAGE
     })
+
     const isAllView = computed(() => {
       return props.searchType === ALL_MEDIA
     })

--- a/src/components/VSearchGrid.vue
+++ b/src/components/VSearchGrid.vue
@@ -38,12 +38,11 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from '@nuxtjs/composition-api'
 
-import { ALL_MEDIA, IMAGE, VIDEO, SearchType } from '~/constants/media'
+import { ALL_MEDIA, IMAGE, SearchType, mediaTypes } from '~/constants/media'
 import { NO_RESULT } from '~/constants/errors'
 import { defineEvent } from '~/types/emits'
 import type { ApiQueryParams } from '~/utils/search-query-transform'
 import type { FetchState } from '~/composables/use-fetch-state'
-import { isSearchTypeSupported } from '~/stores/search'
 
 import VMetaSearchForm from '~/components/VMetaSearch/VMetaSearchForm.vue'
 import VErrorSection from '~/components/VErrorSection/VErrorSection.vue'
@@ -98,8 +97,9 @@ export default defineComponent({
      * Metasearch form shows the external sources for current search type, or for images if the search type is 'All Content'.
      */
     const metaSearchFormType = computed(() => {
-      if (isSearchTypeSupported(props.searchType)) return props.searchType
-      if (props.searchType === VIDEO) return VIDEO
+      if (mediaTypes.includes(props.searchType)) {
+        return props.searchType
+      }
       return IMAGE
     })
 

--- a/src/composables/use-search-type.js
+++ b/src/composables/use-search-type.js
@@ -6,6 +6,7 @@ import {
   AUDIO,
   IMAGE,
   MODEL_3D,
+  VIDEO,
 } from '~/constants/media'
 
 import { useSearchStore } from '~/stores/search'
@@ -13,19 +14,23 @@ import { useSearchStore } from '~/stores/search'
 import allIcon from '~/assets/icons/all-content.svg'
 import audioIcon from '~/assets/icons/audio-content.svg'
 import imageIcon from '~/assets/icons/image-content.svg'
+import videoIcon from '~/assets/icons/video-content.svg'
 import model3dIcon from '~/assets/icons/model-3d.svg'
 
 const icons = {
   [ALL_MEDIA]: allIcon,
   [AUDIO]: audioIcon,
   [IMAGE]: imageIcon,
+  [VIDEO]: videoIcon,
   [MODEL_3D]: model3dIcon,
 }
 const searchTypes = [...supportedSearchTypes]
 
 export default function useSearchType() {
   const activeType = computed(() => useSearchStore().searchType)
+
   const previousSearchType = ref(activeType.value)
+
   const setActiveType = (searchType) => {
     if (previousSearchType.value === searchType) return
     useSearchStore().setSearchType(searchType)

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -7,6 +7,7 @@ import {
   ALL_MEDIA,
   AUDIO,
   IMAGE,
+  SearchType,
   SupportedMediaType,
   SupportedSearchType,
   supportedSearchTypes,
@@ -28,8 +29,14 @@ import {
 
 import type { Dictionary } from 'vue-router/types/router'
 
+export const isSearchTypeSupported = (
+  st: SearchType
+): st is SupportedSearchType => {
+  return supportedSearchTypes.includes(st as SupportedSearchType)
+}
+
 export interface SearchState {
-  searchType: SupportedSearchType
+  searchType: SearchType
   searchTerm: string
   filters: Filters
 }
@@ -70,11 +77,15 @@ export const useSearchStore = defineStore('search', {
      * drops all parameters with blank values.
      */
     searchQueryParams(state) {
-      return computeQueryParams(
-        state.searchType,
-        state.filters,
-        state.searchTerm
-      )
+      if (isSearchTypeSupported(state.searchType)) {
+        return computeQueryParams(
+          state.searchType,
+          state.filters,
+          state.searchTerm
+        )
+      } else {
+        return { q: state.searchTerm }
+      }
     },
     /**
      * Returns the number of checked filters, excluding the `mature` filter.
@@ -114,10 +125,10 @@ export const useSearchStore = defineStore('search', {
       )
     },
     /**
-     * Returns whether the current `seartchType` is a supported media type for search.
+     * Returns whether the current `searchType` is a supported media type for search.
      */
     searchTypeIsSupported(state) {
-      return supportedSearchTypes.includes(state.searchType)
+      return isSearchTypeSupported(state.searchType)
     },
   },
   actions: {
@@ -259,6 +270,8 @@ export const useSearchStore = defineStore('search', {
         this.setSearchTerm(urlQuery.q.trim())
       }
       this.searchType = queryStringToSearchType(path)
+      console.log('search type set to', this.searchType)
+      if (!isSearchTypeSupported(this.searchType)) return
       // When setting filters from URL query, 'mature' has a value of 'true',
       // but we need the 'mature' code. Creating a local shallow copy to prevent mutation.
       const query = { ...urlQuery }

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -270,7 +270,6 @@ export const useSearchStore = defineStore('search', {
         this.setSearchTerm(urlQuery.q.trim())
       }
       this.searchType = queryStringToSearchType(path)
-      console.log('search type set to', this.searchType)
       if (!isSearchTypeSupported(this.searchType)) return
       // When setting filters from URL query, 'mature' has a value of 'true',
       // but we need the 'mature' code. Creating a local shallow copy to prevent mutation.


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1428 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR makes it possible to open a `/search/video` page without crashing the app (mostly for users that get redirected from CC Search). It doesn't add `Video` to the Content Switcher.
To make sure everything works, I had to make the types more flexible, and make some methods accept `SearchType` (i.e., All Content and all media types including `video` and `media_3d`) instead of `SupportedSearchType`.

This PR is probably a good precursor for #1410, which will add the ability to add more types to the Content Switcher, making it possible to open the `model-3d` and `video` pages through the UI and not only by using the URL with the type in path.

With this PR, you will not be able to open `model-3d` page because we still haven't added a page component (`pages/model-3d`). I think we should add it, no matter what the `AdditionalTypes` flag value is, so that opening a `/search/model-3d` page doesn't crash the app, and the `AdditionalTypes` flag should control whether we have the ability to change the search type via UI (the Content switcher in the header or homepage searchbar).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try opening `/search/video` or `search/video?q=cat` and make sure it doesn't crash anymore.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
