### PR TITLE
Workflow improvements to fix CI pipline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,20 +129,7 @@ jobs:
       - storybook-playwright
 
     steps:
-      - uses: actions/download-artifact@v2
-        with:
-          path: test-results
-
-      - name: Check if test results exist
-        id: check-results
-        run: |
-          has_results=$(stat test-results/nuxt-test-results || stat test-results/storybook-test-results) || false
-          if [[ $has_results ]]; then
-            echo "::set-output name=has-failure::true"
-          fi
-
       - uses: peter-evans/create-or-update-comment@v2
-        if: steps.check-results.outputs.has-failure
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
   nuxt-playwright:
     name: Nuxt Playwright tests
     runs-on: ubuntu-latest
+    needs:
+      - build
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
   clean-playwright-failure-comment:
     name: Remove previous Playwright test failure comments
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
 
     steps:
       - uses: peter-evans/find-comment@v2
@@ -123,7 +124,7 @@ jobs:
   playwright-test-failure-comment:
     name: Share Playwright test debugging instructions
     runs-on: ubuntu-latest
-    if: always() && (needs.nuxt-playwright.result == 'failure' || needs.storybook-playwright.result == 'failure')
+    if: always() && github.ref != 'refs/heads/main' && (needs.nuxt-playwright.result == 'failure' || needs.storybook-playwright.result == 'failure')
     needs:
       - nuxt-playwright
       - storybook-playwright


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request.
Fixes #[issue number] by @[issue author]
 -->

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR should fix the pipeline in `main` by doing the following:
- Skip jobs trying to comment instructions on the `main` branch
- Removes checking steps from the `playwright-test-failure-comment` job as they were interfering when we really want it to run
- Add dependency on `build` in the `nuxt-playwright` job, tests would fail if nuxt can't be built anyway

<!--
## Checklist

- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines
 -->

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
