### PR TITLE
Use the `route.meta` parameter to pass the path to search page

### DIFF
--- a/src/composables/use-match-routes.ts
+++ b/src/composables/use-match-routes.ts
@@ -20,14 +20,17 @@ export const useMatchRoute = (
   const { app } = useContext()
   const route = useRoute()
   const router = useRouter()
+
   const localizedRoutes = routes.map(
     (route) => app.localeRoute({ name: route })?.name
   )
   const matches = ref(localizedRoutes.includes(route.value.name))
+
   router.beforeEach((to, _from, next) => {
     matches.value = localizedRoutes.includes(to.name)
     next()
   })
+
   return { matches }
 }
 

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-05-12T05:53:51+00:00\n"
+"POT-Creation-Date: 2022-05-16T16:09:21+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1140,13 +1140,13 @@ msgid "An error occurred"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/pages/image/_id.vue:197
+#: src/pages/image/_id.vue:195
 msgctxt "error.image-not-found"
 msgid "Couldn't find image with id ###id###"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/pages/audio/_id.vue:84
+#: src/pages/audio/_id.vue:75
 msgctxt "error.media-not-found"
 msgid "Couldn't find ###mediaType### with id ###id###"
 msgstr ""

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-05-16T16:09:21+00:00\n"
+"POT-Creation-Date: 2022-05-16T17:11:33+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1882,7 +1882,7 @@ msgid "Filters"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VHeader/VFilterButton.vue:101
+#: src/components/VHeader/VFilterButton.vue:103
 msgctxt "header.filter-button.with-count"
 msgid "###count### Filter"
 msgid_plural "###count### Filters"

--- a/src/pages/image/_id.vue
+++ b/src/pages/image/_id.vue
@@ -78,7 +78,12 @@
 <script lang="ts">
 import axios from 'axios'
 
-import { computed, defineComponent, ref } from '@nuxtjs/composition-api'
+import {
+  computed,
+  defineComponent,
+  ref,
+  useRoute,
+} from '@nuxtjs/composition-api'
 
 import { IMAGE } from '~/constants/media'
 import { useSingleResultStore } from '~/stores/media/single-result'
@@ -93,8 +98,6 @@ import VRelatedImages from '~/components/VImageDetails/VRelatedImages.vue'
 import VSketchFabViewer from '~/components/VSketchFabViewer.vue'
 import VBackToSearchResultsLink from '~/components/VBackToSearchResultsLink.vue'
 
-import type { NuxtApp } from '@nuxt/types/app'
-
 export default defineComponent({
   name: 'VImageDetailsPage',
   components: {
@@ -106,22 +109,15 @@ export default defineComponent({
     VSketchFabViewer,
     VBackToSearchResultsLink,
   },
-  beforeRouteEnter(_to, from, nextPage) {
-    nextPage((_this) => {
-      // `_this` is the component instance that also has nuxt app properties injected
-      const localeRoute = (_this as NuxtApp).localeRoute
-      if (
-        from.name === localeRoute({ path: '/search/' })?.name ||
-        from.name === localeRoute({ path: '/search/image' })?.name
-      ) {
-        // I don't know how to type `this` here
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        _this.backToSearchPath = from.fullPath
-      }
-    })
+  beforeRouteEnter(to, from, next) {
+    if (from.path.includes('/search/')) {
+      to.meta.backToSearchPath = from.fullPath
+    }
+    next()
   },
   setup() {
+    const route = useRoute()
+
     const singleResultStore = useSingleResultStore()
     const relatedMediaStore = useRelatedMediaStore()
     const image = computed(() =>
@@ -130,6 +126,7 @@ export default defineComponent({
         : null
     )
 
+    const backToSearchPath = computed(() => route.value.meta?.backToSearchPath)
     const relatedMedia = computed(() => relatedMediaStore.media)
     const relatedFetchState = computed(() => relatedMediaStore.fetchState)
 
@@ -165,7 +162,7 @@ export default defineComponent({
             })
             .catch(() => {
               /**
-               * Do nothing. This avoid the console warning "Uncaught (in promise) Error:
+               * Do nothing. This avoids the console warning "Uncaught (in promise) Error:
                * Network Error" in Firefox in development mode.
                */
             })
@@ -185,6 +182,7 @@ export default defineComponent({
       sketchFabfailure,
       sketchFabUid,
       onImageLoaded,
+      backToSearchPath,
     }
   },
   async asyncData({ app, error, route, $pinia }) {
@@ -204,9 +202,6 @@ export default defineComponent({
       })
     }
   },
-  data: () => ({
-    backToSearchPath: '',
-  }),
   head() {
     const title = `${this.image.title} | Openverse`
 

--- a/typings/vue-router/index.d.ts
+++ b/typings/vue-router/index.d.ts
@@ -1,0 +1,7 @@
+import 'vue-router'
+
+declare module 'vue-router' {
+  export interface RouteMeta {
+    backToSearchPath?: string
+  }
+}


### PR DESCRIPTION
Simplify setting `backToSearchPath` in `beforeRouteEnter` in single media page and improve typing

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to Typescriptification milestone

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR uses `vue-router` `meta` parameter to pass the _Back to search path_ to the media detail page instead of adding it to the `next` component's `vm`. This makes typing the parameter easier, and the code cleaner. Now we don't need to use `this` parameter and can remove `data` from media detail page.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Search for something and open single result pages from the "All content", "Images" and "Audio" views. The "Back to search" path at the top should correctly return the user to the previous page.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
