### PR TITLE
Fix audio button rounding and global audio not closing

### DIFF
--- a/src/components/VAudioTrack/VGlobalAudioTrack.vue
+++ b/src/components/VAudioTrack/VGlobalAudioTrack.vue
@@ -1,10 +1,6 @@
 <template>
-  <div
-    class="audio-track"
-    :aria-label="$t('audio-track.aria-label').toString()"
-    role="region"
-  >
-    <VGlobalLayout :audio="audio" size="m">
+  <div class="audio-track" :aria-label="ariaLabel" role="region">
+    <VGlobalLayout :audio="audio">
       <template #controller="waveformProps">
         <VWaveform
           v-bind="waveformProps"
@@ -74,6 +70,10 @@ export default defineComponent({
     const i18n = useI18n()
     const activeMediaStore = useActiveMediaStore()
     const activeAudio = useActiveAudio()
+
+    const ariaLabel = computed(() =>
+      i18n.t('audio-track.aria-label', { title: props.audio.title }).toString()
+    )
 
     const status = ref<AudioStatus>('paused')
     const currentTime = ref(0)
@@ -209,6 +209,7 @@ export default defineComponent({
 
       currentTime,
       duration,
+      ariaLabel,
     }
   },
 })

--- a/src/components/VAudioTrack/VPlayPause.vue
+++ b/src/components/VAudioTrack/VPlayPause.vue
@@ -5,7 +5,7 @@
     class="play-pause flex-shrink-0 bg-dark-charcoal border-dark-charcoal text-white disabled:opacity-70 focus-visible:border-pink focus-visible:outline-none focus-visible:shadow-ring"
     :icon-props="{ iconPath: icon }"
     :aria-label="$t(label)"
-    :button-props="{ variant: 'plain-dangerous' }"
+    :button-props="buttonProps"
     @click.stop.prevent="handleClick"
   />
 </template>
@@ -16,6 +16,7 @@ import { computed, defineComponent, PropType } from '@nuxtjs/composition-api'
 import type { AudioLayout, AudioStatus } from '~/constants/audio'
 
 import VIconButton from '~/components/VIconButton/VIconButton.vue'
+import type { ButtonConnections, ButtonVariant } from '~/components/VButton.vue'
 
 import playIcon from '~/assets/icons/play.svg'
 import pauseIcon from '~/assets/icons/pause.svg'
@@ -69,12 +70,27 @@ export default defineComponent({
      * Get the button icon based on the current status of the player.
      */
     const icon = computed(() => statusIconMap[props.status])
+
+    const buttonProps = computed(() => {
+      const connections = (
+        props.layout === 'row'
+          ? 'end'
+          : props.layout === 'global'
+          ? 'all'
+          : 'none'
+      ) as ButtonConnections
+      const variant = 'plain-dangerous' as ButtonVariant
+
+      return { variant, connections }
+    })
+
     const handleClick = () => {
       emit('toggle', isPlaying.value ? 'paused' : 'playing')
     }
     return {
       label,
       icon,
+      buttonProps,
 
       handleClick,
     }

--- a/src/components/VAudioTrack/VPlayPause.vue
+++ b/src/components/VAudioTrack/VPlayPause.vue
@@ -26,12 +26,21 @@ const statusVerbMap = {
   playing: 'pause',
   paused: 'play',
   played: 'replay',
-}
+} as const
+
 const statusIconMap = {
   playing: pauseIcon,
   paused: playIcon,
   played: replayIcon,
-}
+} as const
+
+const layoutConnectionsMap: Record<AudioLayout, ButtonConnections> = {
+  row: 'end',
+  global: 'all',
+  box: 'none',
+  full: 'none',
+} as const
+
 /**
  * Displays the control for switching between the playing and paused states of
  * a media file.
@@ -71,17 +80,14 @@ export default defineComponent({
      */
     const icon = computed(() => statusIconMap[props.status])
 
+    /**
+     * Sets the button variant to `plain-dangerous` to manually handle focus states.
+     * Sets the connections (none-rounded corners) for the button based on the layout.
+     */
     const buttonProps = computed(() => {
-      const connections = (
-        props.layout === 'row'
-          ? 'end'
-          : props.layout === 'global'
-          ? 'all'
-          : 'none'
-      ) as ButtonConnections
       const variant = 'plain-dangerous' as ButtonVariant
 
-      return { variant, connections }
+      return { variant, connections: layoutConnectionsMap[props.layout] }
     })
 
     const handleClick = () => {

--- a/src/components/VAudioTrack/layouts/VGlobalLayout.vue
+++ b/src/components/VAudioTrack/layouts/VGlobalLayout.vue
@@ -2,7 +2,7 @@
   <div class="global-track flex flex-row w-full">
     <div class="flex-shrink-0">
       <VAudioThumbnail :audio="audio" />
-      <slot name="play-pause" size="medium" />
+      <slot name="play-pause" size="medium" layout="global" />
     </div>
 
     <div class="relative flex-grow">

--- a/src/components/VAudioTrack/layouts/VRowLayout.vue
+++ b/src/components/VAudioTrack/layouts/VRowLayout.vue
@@ -9,7 +9,7 @@
     >
       <VAudioThumbnail :audio="audio" />
       <div v-show="isSmall" class="absolute bottom-0 rtl:left-0 ltr:right-0">
-        <slot name="play-pause" size="tiny" />
+        <slot name="play-pause" size="tiny" layout="row" />
       </div>
     </div>
 
@@ -71,7 +71,11 @@
           'flex-grow': isMedium,
         }"
       >
-        <slot name="play-pause" :size="isLarge ? 'medium' : 'large'" />
+        <slot
+          name="play-pause"
+          :size="isLarge ? 'medium' : 'large'"
+          :layout="'row'"
+        />
         <slot
           name="controller"
           :features="features"

--- a/src/components/VButton.vue
+++ b/src/components/VButton.vue
@@ -6,6 +6,7 @@
     :class="[
       $style.button,
       $style[variant],
+      isConnected && $style[`connection-${connections}`],
       isActive && $style[`${variant}-pressed`],
       $style[`size-${size}`],
       isPlainDangerous ? '' : 'focus-visible:ring focus-visible:ring-pink',
@@ -55,16 +56,16 @@ export const buttonVariants = [
   'plain-dangerous',
   'full',
 ] as const
-
 export type ButtonVariant = typeof buttonVariants[number]
 
 export const buttonSizes = ['large', 'medium', 'small', 'disabled'] as const
-
 export type ButtonSize = typeof buttonSizes[number]
 
 export const buttonTypes = ['button', 'submit', 'reset'] as const
-
 export type ButtonType = typeof buttonTypes[number]
+
+export const buttonConnections = ['start', 'end', 'none', 'all'] as const
+export type ButtonConnections = typeof buttonConnections[number]
 
 export type ButtonProps = ProperlyExtractPropTypes<
   NonNullable<typeof VButton['props']>
@@ -169,6 +170,17 @@ const VButton = defineComponent({
       type: String as PropType<ButtonType>,
       default: 'button',
     },
+    /**
+     * Whether the button is connected to another control and needs to have no rounded
+     * borders at that edge.
+     * `all` means that the button is not rounded.
+     *
+     * @default 'none'
+     */
+    connections: {
+      type: String as PropType<ButtonConnections>,
+      default: 'none',
+    },
   },
   setup(props, { attrs }) {
     const propsRef = toRefs(props)
@@ -179,6 +191,8 @@ const VButton = defineComponent({
     const trulyDisabledRef = ref<boolean>()
     const typeRef = ref<ButtonType | undefined>(propsRef.type.value)
     const supportsDisabledAttributeRef = ref(true)
+
+    const isConnected = computed(() => props.connections !== 'none')
 
     const isActive = computed(() => {
       return (
@@ -237,6 +251,7 @@ const VButton = defineComponent({
       ariaDisabledRef,
       typeRef,
       isActive,
+      isConnected,
       isPlainDangerous,
     }
   },
@@ -321,5 +336,15 @@ a.button {
 
 .full-pressed {
   @apply w-full font-semibold bg-dark-charcoal-06 text-dark-charcoal;
+}
+
+.connection-start {
+  @apply rounded-s-none;
+}
+.connection-end {
+  @apply rounded-e-none;
+}
+.connection-all {
+  @apply rounded-none;
 }
 </style>

--- a/src/components/VGlobalAudioSection/VGlobalAudioSection.vue
+++ b/src/components/VGlobalAudioSection/VGlobalAudioSection.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="global-audio sticky sm:hidden bottom-0">
-    <VGlobalAudioTrack v-if="audio" layout="global" :audio="audio" />
+    <VGlobalAudioTrack v-if="audio" :audio="audio" />
     <VIconButton
       v-if="audio"
-      class="absolute top-0 rtl:left-0 ltr:right-0 border-none z-10"
+      class="absolute top-0 rtl:left-0 ltr:right-0 border-none z-20"
       :icon-props="{ iconPath: icons.closeIcon }"
       @click="handleClose"
     />

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-05-16T17:11:33+00:00\n"
+"POT-Creation-Date: 2022-05-17T14:42:04+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -252,7 +252,7 @@ msgctxt "audio-track.creator"
 msgid "by ###creator###"
 msgstr ""
 
-#: src/components/VAudioTrack/layouts/VRowLayout.vue:128
+#: src/components/VAudioTrack/layouts/VRowLayout.vue:132
 msgctxt "audio-track.messages.blink_seek_disabled"
 msgid "Seeking for Jamendo tracks is limited to Firefox and Safari."
 msgstr ""


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1427 by @panchovm
Fixes #1373 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds `connections` prop to `VButton` to enable setting non-rounded corners if the button is a part of a compound control and only needs rounded corners at start/end. So, for a row audio track, we can set `connections=end` and make the button non-rounded where it is connected to the waveform.

Other changes in this PR:
- Clean up some `GlobalAudioTrack` props/attrs that were not used before, or fell out of sync with the base `AudioTrack` component (e.g. `ariaLabel` wasn't computed).
- Set the `GlobalAudioTrack` `Close` button `z-index` to 20 to prevent the waveform from overlapping. This fixes #1373. It's a one-character change, so I added it in here instead of opening a separate PR.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
