### PR TITLE
Target slot container to copy just the text.

### DIFF
--- a/src/components/VMediaInfo/VLicenseTabPanel.vue
+++ b/src/components/VMediaInfo/VLicenseTabPanel.vue
@@ -3,10 +3,14 @@
     :id="tab"
     class="h-[190px] flex flex-col justify-between items-start text-sm md:text-base"
   >
-    <div class="overflow-y-auto">
+    <div :id="`panel-slot-${tab}`" class="overflow-y-auto">
       <slot />
     </div>
-    <VCopyButton :id="`copyattr-${tab}`" :el="`#panel-${tab}`" class="mt-6" />
+    <VCopyButton
+      :id="`copyattr-${tab}`"
+      :el="`#panel-slot-${tab}`"
+      class="mt-6"
+    />
   </VTabPanel>
 </template>
 


### PR DESCRIPTION

## Fixes
  On copy now copy just the text on the slot

## Description
 Targeting a container will copy all the text inside, including the text for the button, to prevent this we should target just the text container.

## Testing Instructions
  search for an image, click the selected image and go to credit the creator, select the type of credit and click "copy text" button.
  paste the text on any text editor.
  Expected: 
    the text is pasted without any extra line and without the button text.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
