### PR TITLE
Add loading indication for audio

### DIFF
--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -132,13 +132,9 @@ export default defineComponent({
       // Preserve existing local audio if we plucked it from the global active audio
       if (!localAudio) localAudio = new Audio(props.audio.url)
 
-      localAudio.addEventListener('play', setPlaying)
-      localAudio.addEventListener('playing', setLoaded)
-      localAudio.addEventListener('waiting', setWaiting)
-      localAudio.addEventListener('pause', setPaused)
-      localAudio.addEventListener('ended', setPlayed)
-      localAudio.addEventListener('timeupdate', setTimeWhenPaused)
-      localAudio.addEventListener('durationchange', setDuration)
+      Object.entries(eventMap).forEach(([name, fn]) =>
+        localAudio?.addEventListener(name, fn)
+      )
 
       /**
        * Similar to the behavior in the global audio track,
@@ -201,8 +197,6 @@ export default defineComponent({
       }
     }
 
-    watch(status, console.log)
-
     let hasLoaded = false
     const setLoaded = () => {
       hasLoaded = true
@@ -250,6 +244,16 @@ export default defineComponent({
       if (localAudio) duration.value = localAudio.duration
     }
 
+    const eventMap = {
+      play: setPlaying,
+      pause: setPaused,
+      ended: setPlayed,
+      timeupdate: setTimeWhenPaused,
+      durationchange: setDuration,
+      waiting: setWaiting,
+      playing: setLoaded,
+    } as const
+
     /**
      * If we're transforming the globally active audio
      * into our local audio, then we need to initialize
@@ -267,13 +271,10 @@ export default defineComponent({
     onUnmounted(() => {
       if (!localAudio) return
 
-      localAudio.removeEventListener('play', setPlaying)
-      localAudio.removeEventListener('pause', setPaused)
-      localAudio.removeEventListener('ended', setPlayed)
-      localAudio.removeEventListener('timeupdate', setTimeWhenPaused)
-      localAudio.removeEventListener('durationchange', setDuration)
-      localAudio.removeEventListener('waiting', setWaiting)
-      localAudio.removeEventListener('playing', setLoaded)
+      Object.entries(eventMap).forEach(([name, fn]) =>
+        localAudio?.removeEventListener(name, fn)
+      )
+
       const mediaStore = useMediaStore()
       if (
         route.value.params.id === props.audio.id ||

--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -133,7 +133,11 @@ export default defineComponent({
       if (!localAudio) localAudio = new Audio(props.audio.url)
 
       Object.entries(eventMap).forEach(([name, fn]) =>
-        localAudio?.addEventListener(name, fn)
+        /**
+         * This cast is safe, it just filters `undefined` that is still present on the
+         * `localAudio`'s type despite the check above to create it if it doesn't exist.
+         */
+        (localAudio as HTMLAudioElement).addEventListener(name, fn)
       )
 
       /**

--- a/src/components/VAudioTrack/VPlayPause.vue
+++ b/src/components/VAudioTrack/VPlayPause.vue
@@ -3,17 +3,36 @@
     v-bind="$attrs"
     :tabindex="layout === 'box' ? -1 : 0"
     class="play-pause flex-shrink-0 bg-dark-charcoal border-dark-charcoal text-white disabled:opacity-70 focus-visible:border-pink focus-visible:outline-none focus-visible:shadow-ring"
-    :icon-props="{ iconPath: icon }"
+    :icon-props="icon === undefined ? undefined : { iconPath: icon }"
     :aria-label="$t(label)"
     :button-props="buttonProps"
     @click.stop.prevent="handleClick"
-  />
+  >
+    <template #default="{ iconSizeClasses }">
+      <svg
+        v-if="isLoading"
+        class="loading p-2"
+        :class="iconSizeClasses"
+        xmlns="http://www.w3.org/2000/svg"
+        overflow="visible"
+        viewBox="0 0 12 12"
+      >
+        <circle cx="6" cy="6" r="6" vector-effect="non-scaling-stroke" />
+        <path
+          d="m 6 0 a 6 6 0 0 1 6 6"
+          stroke="white"
+          vector-effect="non-scaling-stroke"
+        />
+      </svg>
+    </template>
+  </VIconButton>
 </template>
 
 <script lang="ts">
 import { computed, defineComponent, PropType } from '@nuxtjs/composition-api'
 
 import type { AudioLayout, AudioStatus } from '~/constants/audio'
+import { defineEvent } from '~/types/emits'
 
 import VIconButton from '~/components/VIconButton/VIconButton.vue'
 import type { ButtonConnections, ButtonVariant } from '~/components/VButton.vue'
@@ -26,12 +45,14 @@ const statusVerbMap = {
   playing: 'pause',
   paused: 'play',
   played: 'replay',
+  loading: 'loading',
 } as const
 
 const statusIconMap = {
   playing: pauseIcon,
   paused: playIcon,
   played: replayIcon,
+  loading: undefined,
 } as const
 
 const layoutConnectionsMap: Record<AudioLayout, ButtonConnections> = {
@@ -69,8 +90,12 @@ export default defineComponent({
       default: 'full',
     },
   },
+  emits: {
+    toggle: defineEvent<['paused' | 'playing']>(),
+  },
   setup(props, { emit }) {
     const isPlaying = computed(() => props.status === 'playing')
+    const isLoading = computed(() => props.status === 'loading')
     /**
      * Get the button label based on the current status of the player.
      */
@@ -91,15 +116,43 @@ export default defineComponent({
     })
 
     const handleClick = () => {
-      emit('toggle', isPlaying.value ? 'paused' : 'playing')
+      emit('toggle', isPlaying.value || isLoading.value ? 'paused' : 'playing')
     }
     return {
       label,
       icon,
       buttonProps,
+      isLoading,
 
       handleClick,
     }
   },
 })
 </script>
+
+<style scoped>
+@keyframes spinAnimation {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading circle,
+.loading path {
+  fill: transparent;
+  stroke-width: 2px;
+}
+
+.loading circle {
+  stroke: #595258;
+}
+
+.loading path {
+  stroke-linecap: round;
+  transform-origin: 50% 50%;
+  animation: spinAnimation 1.4s linear infinite both;
+}
+</style>

--- a/src/components/VAudioTrack/layouts/VGlobalLayout.vue
+++ b/src/components/VAudioTrack/layouts/VGlobalLayout.vue
@@ -2,7 +2,7 @@
   <div class="global-track flex flex-row w-full">
     <div class="flex-shrink-0">
       <VAudioThumbnail :audio="audio" />
-      <slot name="play-pause" size="medium" layout="global" />
+      <slot name="play-pause" :size="size" :layout="layout" />
     </div>
 
     <div class="relative flex-grow">
@@ -37,6 +37,12 @@ export default defineComponent({
       type: Object as PropType<AudioDetail>,
       required: true,
     },
+  },
+  setup() {
+    const size = 'medium' as const
+    const layout = 'global' as const
+
+    return { size, layout }
   },
 })
 </script>

--- a/src/components/VIconButton/VIconButton.vue
+++ b/src/components/VIconButton/VIconButton.vue
@@ -7,9 +7,11 @@
     :type="type"
     v-on="$listeners"
   >
+    <slot name="default" :icon-size-classes="iconSizeClasses" />
     <VIcon
+      v-if="iconProps"
       class="pointer-events-none"
-      :class="[...iconSizeClasses]"
+      :class="iconSizeClasses"
       v-bind="iconProps"
     />
   </VButton>
@@ -59,7 +61,7 @@ export default defineComponent({
      */
     iconProps: {
       type: Object as PropType<IconProps>,
-      required: true,
+      required: false,
     },
     /**
      * props to pass down to the `VButton` component nested inside the button;

--- a/src/constants/audio.ts
+++ b/src/constants/audio.ts
@@ -1,6 +1,6 @@
 export const audioLayouts = ['full', 'box', 'row', 'global'] as const
 export const audioSizes = ['s', 'm', 'l'] as const
-export const audioStatuses = ['playing', 'paused', 'played'] as const
+export const audioStatuses = ['playing', 'paused', 'played', 'loading'] as const
 export const audioFeatures = ['timestamps', 'duration', 'seek'] as const
 
 export type AudioLayout = typeof audioLayouts[number]

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -583,7 +583,8 @@
   "play-pause": {
     "play": "Play",
     "pause": "Pause",
-    "replay": "Replay"
+    "replay": "Replay",
+    "loading": "Loading"
   },
   "search": {
     "search": "Search",

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-06-09T12:59:13+00:00\n"
+"POT-Creation-Date: 2022-06-15T20:45:00+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -253,14 +253,18 @@ msgctxt "play-pause.replay"
 msgid "Replay"
 msgstr ""
 
+msgctxt "play-pause.loading"
+msgid "Loading"
+msgstr ""
+
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VAudioTrack.vue:389
+#: src/components/VAudioTrack/VAudioTrack.vue:411
 msgctxt "audio-track.aria-label"
 msgid "###title### - Audio Player"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VAudioTrack.vue:386
+#: src/components/VAudioTrack/VAudioTrack.vue:408
 msgctxt "audio-track.aria-label-interactive"
 msgid "###title### - audio player - press the spacebar to play and pause a preview of the audio"
 msgstr ""

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-06-15T20:45:08+00:00\n"
+"POT-Creation-Date: 2022-06-15T20:45:14+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -258,13 +258,13 @@ msgid "Loading"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VAudioTrack.vue:412
+#: src/components/VAudioTrack/VAudioTrack.vue:416
 msgctxt "audio-track.aria-label"
 msgid "###title### - Audio Player"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VAudioTrack.vue:409
+#: src/components/VAudioTrack/VAudioTrack.vue:413
 msgctxt "audio-track.aria-label-interactive"
 msgid "###title### - audio player - press the spacebar to play and pause a preview of the audio"
 msgstr ""

--- a/src/locales/po-files/openverse.pot
+++ b/src/locales/po-files/openverse.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Openverse \n"
 "Report-Msgid-Bugs-To: https://github.com/wordpress/openverse/issues \n"
-"POT-Creation-Date: 2022-06-15T20:45:00+00:00\n"
+"POT-Creation-Date: 2022-06-15T20:45:08+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -258,13 +258,13 @@ msgid "Loading"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VAudioTrack.vue:411
+#: src/components/VAudioTrack/VAudioTrack.vue:412
 msgctxt "audio-track.aria-label"
 msgid "###title### - Audio Player"
 msgstr ""
 
 #. Do not translate words between ### ###.
-#: src/components/VAudioTrack/VAudioTrack.vue:408
+#: src/components/VAudioTrack/VAudioTrack.vue:409
 msgctxt "audio-track.aria-label-interactive"
 msgid "###title### - audio player - press the spacebar to play and pause a preview of the audio"
 msgstr ""

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,7 @@
     "src/components/VContentLink/VContentLink.vue",
     "src/components/VContentReport/VReportDescForm.vue",
     "src/components/VErrorSection/VErrorImage.vue",
-    "src/components/VAudioTrack/**.vue",
+    "src/components/VAudioTrack/**/*.vue",
     "src/components/VAudioThumbnail/VAudioThumbnail.vue",
     "src/components/VGlobalAudioSection/VGlobalAudioSection.vue",
     "src/components/VInputField/VInputField.vue",


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1001 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a loading indication to the button when audio is being loaded.

https://user-images.githubusercontent.com/24264157/172460095-b69a35eb-18f6-4784-869e-64c45b65ed0b.mp4

## Testing instructions
Do what I do in the video above, click around the audio results page, single results, mobile results, etc and make sure that the loading indicator appears and disappears when it's meant to. Be sure to test edge cases like multiple audios loading at once. Only the "about to be played" audio should ever indicate loading status.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
