### PR TITLE
Make search.vue media fetching non-blocking

### DIFF
--- a/src/components/VHeader/VHeader.vue
+++ b/src/components/VHeader/VHeader.vue
@@ -166,12 +166,14 @@ export default defineComponent({
      * - search term hasn't changed:
      *   - on a search route, do nothing.
      *   - on other routes: set searchType to 'All content', reset the media,
-     *     change the path to `/search/` (All content) and fetch media.
+     *     change the path to `/search/` (All content).
      * - search term changed:
      *   - on a search route: Update the store searchTerm value, update query `q` param, reset media,
      *     fetch new media.
      *   - on other routes: Update the store searchTerm value, set searchType to 'All content', reset media,
-     *     update query `q` param, fetch new media.
+     *     update query `q` param.
+     * Updating the path causes the `search.vue` page's route watcher
+     * to run and fetch new media.
      */
     const handleSearch = async () => {
       window.scrollTo({ top: 0, left: 0, behavior: 'auto' })
@@ -198,7 +200,6 @@ export default defineComponent({
           query: searchStore.searchQueryParams,
         })
         router.push(newPath)
-        await mediaStore.fetchMedia()
       }
     }
     const areFiltersDisabled = computed(


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1516 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR moves the call to fetch media from `asyncData` to `fetch`. If we fetch data in `asyncData`, the page transitions only after the media are loaded from the API, and this makes the transition feel slower. With this PR, the page is being loaded concurrently with the media items, the search page opens as soon as the user clicks on the homepage 'Search' button, so it seems more responsive.
The Nuxt docs describe the difference between the `asyncData` and `fetch` hooks here: https://nuxtjs.org/docs/features/data-fetching#async-data

Since the `search` page fetches media on each route change, we only need to set the route in the header, and the media fetching should be handled by the `search` page. So, I removed the calls to `fetchMedia` from the header.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Search for something from the homepage, from the search page, and from content pages. The search page should not show the black progress bar at the top when loading. The navigation to the Search page should also feel faster than on main currently.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
