### PR TITLE
Make fetching related images on the client non-blocking

### DIFF
--- a/src/components/VImageDetails/VRelatedImages.vue
+++ b/src/components/VImageDetails/VRelatedImages.vue
@@ -3,6 +3,7 @@
     <h3 class="text-2xl md:text-3xl mb-6">
       {{ $t('image-details.related-images') }}
     </h3>
+    <VLoadingIcon v-if="fetchState.isFetching" />
     <VImageGrid
       :images="media"
       :show-load-more="false"
@@ -11,21 +12,27 @@
   </aside>
 </template>
 
-<script>
-import VImageGrid from '~/components/VImageGrid/VImageGrid.vue'
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
 
-export default {
+import type { ImageDetail } from '~/models/media'
+import type { FetchState } from '~/composables/use-fetch-state'
+
+import VImageGrid from '~/components/VImageGrid/VImageGrid.vue'
+import VLoadingIcon from '~/components/LoadingIcon.vue'
+
+export default defineComponent({
   name: 'VRelatedImages',
-  components: { VImageGrid },
+  components: { VImageGrid, VLoadingIcon },
   props: {
     media: {
-      type: Array,
+      type: Array as PropType<ImageDetail[]>,
       required: true,
     },
     fetchState: {
-      type: Object,
+      type: Object as PropType<FetchState>,
       required: true,
     },
   },
-}
+})
 </script>

--- a/src/stores/media/related-media.ts
+++ b/src/stores/media/related-media.ts
@@ -45,6 +45,7 @@ export const useRelatedMediaStore = defineStore('related-media', {
           'end',
           `Could not fetch related ${mediaType} for id ${id}`
         )
+        throw new Error(`Could not fetch related ${mediaType} for id ${id}`)
       }
     },
   },

--- a/src/stores/media/single-result.ts
+++ b/src/stores/media/single-result.ts
@@ -77,7 +77,18 @@ export const useSingleResultStore = defineStore('single-result', {
       } else {
         await this.fetchMediaItem(type, id)
       }
-      await useRelatedMediaStore().fetchMedia(type, id)
+      /**
+       * On the server, we await the related media to make sure it's rendered on the page.
+       * On the client, we don't await it to render the whole page while the related media are loading.
+       */
+      if (process.server) {
+        await useRelatedMediaStore().fetchMedia(type, id)
+      } else {
+        useRelatedMediaStore()
+          .fetchMedia(type, id)
+          .then(() => Promise.resolve())
+          .catch((error) => console.warn('Could not load related media', error))
+      }
     },
     /**
      * Fetches a media item from the API.

--- a/src/stores/media/single-result.ts
+++ b/src/stores/media/single-result.ts
@@ -82,12 +82,17 @@ export const useSingleResultStore = defineStore('single-result', {
        * On the client, we don't await it to render the whole page while the related media are loading.
        */
       if (process.server) {
-        await useRelatedMediaStore().fetchMedia(type, id)
+        try {
+          await useRelatedMediaStore().fetchMedia(type, id)
+        } catch (error) {
+          console.warn('Could not load related media: ', error)
+        }
       } else {
         useRelatedMediaStore()
           .fetchMedia(type, id)
-          .then(() => Promise.resolve())
-          .catch((error) => console.warn('Could not load related media', error))
+          .catch((error) =>
+            console.warn('Could not load related media: ', error)
+          )
       }
     },
     /**


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #1516 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The [comment from @sarayourfriend](https://github.com/WordPress/openverse-frontend/issues/1516#issuecomment-1152141457) in #1516 made me realize how to improve the loading of the single result pages so that they fully loa on SSR, but also do not block on the related media fetch call when being rendered client-side:

Awaiting the related media request on the server makes sure that the server-rendered page has the related media.
**Not** awaiting the related media request on the client makes the other parts of the page load quickly, and we can render a loading icon while fetching the related media.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try opening the single detail page for images directly, and from the search page. It should load the related items when opened directly, but on client-side, it should open the page and show a loading icon for the related images until they are fetched.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
