### PR TITLE
Parallelize snapshot tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: ./.github/actions/setup-node-env
 
       - name: Run Nuxt Playwright tests
-        run: pnpm test:playwright
+        run: pnpm test:playwright --workers=2
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/bin/playwright.sh
+++ b/bin/playwright.sh
@@ -12,3 +12,5 @@ export TEST_COMMAND=${TEST_COMMAND:-test:playwright:local}
 echo Running Playwright v$PLAYWRIGHT_VERSION as $USER_ID with Playwright arguments $PLAYWRIGHT_ARGS
 
 docker-compose -f docker-compose.playwright.yml up --build --force-recreate --abort-on-container-exit --exit-code-from playwright --remove-orphans
+
+docker-compose -f docker-compose.playwright.yml down

--- a/docker-compose.playwright.yml
+++ b/docker-compose.playwright.yml
@@ -15,3 +15,4 @@ services:
       # This makes the webserver that Playwright runs show the build
       - DEBUG=pw:webserver
       - UPDATE_TAPES=${UPDATE_TAPES:-false}
+    cpus: 0.000

--- a/docker-compose.playwright.yml
+++ b/docker-compose.playwright.yml
@@ -14,5 +14,6 @@ services:
     environment:
       # This makes the webserver that Playwright runs show the build
       - DEBUG=pw:webserver
+      - DISABLE_SENTRY=true
       - UPDATE_TAPES=${UPDATE_TAPES:-false}
     cpus: 0.000

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:unit": "jest",
     "test:unit:watch": "pnpm test:unit --collectCoverage=false --watch",
     "test:playwright": "./bin/playwright.sh",
-    "test:playwright:local": "playwright test -c test/playwright",
+    "test:playwright:local": "DISABLE_SENTRY=true playwright test -c test/playwright",
     "test:playwright:debug": "PWDEBUG=1 pnpm test:playwright:local",
     "test:playwright:recreate-tapes": "rimraf test/tapes && pnpm test:playwright:update-tapes",
     "test:playwright:update-tapes": "UPDATE_TAPES=true pnpm test:playwright",

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -8,6 +8,5 @@ const apiUrl = process.env.API_URL ?? 'https://api.openverse.engineering/'
 export const env = {
   apiUrl: apiUrl.endsWith('/') ? apiUrl : `${apiUrl}/`,
   filterStorageKey: 'openverse-filter-visibility',
-  enableInternalAnalytics: process.env.ENABLE_INTERNAL_ANALYTICS ?? 'false',
   providerUpdateFrequency: `${60 * 60 * 1000}`, // 1 hour
 } as const

--- a/src/utils/sentry-config.ts
+++ b/src/utils/sentry-config.ts
@@ -11,7 +11,7 @@ export const sentryConfig: ModuleConfiguration = {
   dsn:
     process.env.SENTRY_DSN ||
     'https://53da8fbcebeb48a6bf614a212629df6b@o787041.ingest.sentry.io/5799642',
-  disabled: !isProd,
+  disabled: process.env.DISABLE_SENTRY ? true : !isProd,
   lazy: true,
   clientConfig: {
     // Only allow errors that come from an actual openverse.engineering subdomain

--- a/test/playwright/e2e/filters.spec.ts
+++ b/test/playwright/e2e/filters.spec.ts
@@ -16,6 +16,8 @@ import {
   AUDIO,
 } from '~/constants/media'
 
+test.describe.configure({ mode: 'parallel' })
+
 test.beforeEach(async ({ context }) => {
   await mockProviderApis(context)
 })

--- a/test/playwright/e2e/report-media.spec.ts
+++ b/test/playwright/e2e/report-media.spec.ts
@@ -8,6 +8,8 @@ import {
 
 import { supportedMediaTypes } from '~/constants/media'
 
+test.describe.configure({ mode: 'parallel' })
+
 /**
  * Some helpers for repeated actions.
  */

--- a/test/playwright/playwright.config.ts
+++ b/test/playwright/playwright.config.ts
@@ -9,6 +9,8 @@ addAliases({
   '~~': process.cwd(),
 })
 
+const UPDATE_TAPES = process.env.UPDATE_TAPES || 'false'
+
 const config: PlaywrightTestConfig = {
   webServer: {
     /**
@@ -32,7 +34,7 @@ const config: PlaywrightTestConfig = {
     reuseExistingServer: !process.env.CI || process.env.PWDEBUG === '1',
     env: {
       API_URL: 'http://localhost:49153/',
-      UPDATE_TAPES: process.env.UPDATE_TAPES || '',
+      UPDATE_TAPES: UPDATE_TAPES,
     },
   },
   use: {
@@ -49,7 +51,7 @@ const config: PlaywrightTestConfig = {
    * tapes then we can avoid this problem. Defaulting to `undefined` means the
    * Playwright default of using 1/2 of the number of CPU cores continues to work otherwise.
    */
-  workers: process.env.UPDATE_TAPES ? 1 : undefined,
+  workers: UPDATE_TAPES === 'true' ? 1 : undefined,
 }
 
 export default config

--- a/test/playwright/visual-regression/components/audio-results.spec.ts
+++ b/test/playwright/visual-regression/components/audio-results.spec.ts
@@ -2,6 +2,8 @@ import { test } from '@playwright/test'
 
 import breakpoints from '~~/test/playwright/utils/breakpoints'
 
+test.describe.configure({ mode: 'parallel' })
+
 test.describe('audio results', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/search/audio?q=birds')

--- a/test/playwright/visual-regression/components/header.spec.ts
+++ b/test/playwright/visual-regression/components/header.spec.ts
@@ -9,6 +9,8 @@ import {
   sleep,
 } from '~~/test/playwright/utils/navigation'
 
+test.describe.configure({ mode: 'parallel' })
+
 const headerSelector = '.main-header'
 const loadMoreSelector = 'button:has-text("Load more")'
 

--- a/test/playwright/visual-regression/components/media-reuse.spec.ts
+++ b/test/playwright/visual-regression/components/media-reuse.spec.ts
@@ -7,6 +7,8 @@ import {
   languageDirections,
 } from '~~/test/playwright/utils/navigation'
 
+test.describe.configure({ mode: 'parallel' })
+
 const tabs = [
   { id: 'rich', name: 'Rich Text' },
   { id: 'html', name: 'HTML' },

--- a/test/playwright/visual-regression/pages/homepage.spec.ts
+++ b/test/playwright/visual-regression/pages/homepage.spec.ts
@@ -8,8 +8,10 @@ import {
   languageDirections,
 } from '~~/test/playwright/utils/navigation'
 
+test.describe.configure({ mode: 'parallel' })
+
 /**
- * Remove the randomly-selected images from the homepage .
+ * Remove the randomly-selected images from the homepage.
  */
 const deleteImageCarousel = async (page: Page) => {
   const element = await page.$('[data-testid="image-carousel"]')

--- a/test/playwright/visual-regression/pages/pages.spec.ts
+++ b/test/playwright/visual-regression/pages/pages.spec.ts
@@ -8,6 +8,8 @@ import {
   languageDirections,
 } from '~~/test/playwright/utils/navigation'
 
+test.describe.configure({ mode: 'parallel' })
+
 const contentPages = [
   'extension',
   'about',

--- a/test/playwright/visual-regression/pages/sources.spec.ts
+++ b/test/playwright/visual-regression/pages/sources.spec.ts
@@ -7,6 +7,8 @@ import {
   languageDirections,
 } from '~~/test/playwright/utils/navigation'
 
+test.describe.configure({ mode: 'parallel' })
+
 test.describe('sources page snapshots', () => {
   for (const dir of languageDirections) {
     test.describe(dir, () => {

--- a/test/unit/specs/stores/provider.spec.js
+++ b/test/unit/specs/stores/provider.spec.js
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 
+import { warn } from '~/utils/console'
 import { AUDIO, IMAGE, supportedMediaTypes } from '~/constants/media'
 import { useSearchStore } from '~/stores/search'
 import { useProviderStore } from '~/stores/provider'
@@ -14,6 +15,8 @@ jest.mock('@nuxtjs/composition-api', () => ({
   ...jest.requireActual('@nuxtjs/composition-api'),
   ssrRef: (v) => jest.fn(v),
 }))
+jest.mock('~/utils/console', () => ({ warn: jest.fn(), log: jest.fn() }))
+
 process.env.providerUpdateFrequency = '0'
 
 const mockData = [
@@ -68,6 +71,10 @@ describe('Provider Store', () => {
     providerServices.audio.getProviderStats.mockClear()
     providerServices.image.getProviderStats.mockClear()
   })
+  afterAll(() => {
+    warn.mockReset()
+  })
+
   it('sets the default state', () => {
     expect(providerStore.providers).toEqual({
       [AUDIO]: [],


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1491 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR:
- instruct playwright to run said tests in parallel workers
- fixes the condition for when updating tapes
- **sets the playwright service container to use the maximum number of CPUs available**[^1]. GitHub action runners only have 2-cores[^2], as Sara commented below, that is why it
- **sets the tests in CI to run with 2 workers** instead of one as it has been running so far
- turn down the docker container for testing after tests are finished, currently it keeps running 
- silence warnings in the `provider.spec.js` unit test

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the following command for more workers (to me it defaults to only 2):
```sh
pnpm test:playwright visual-regression --workers=4
```

In the main branch you'd see these lines when it finishes:

```
playwright_1  |   Slow test file: visual-regression/components/header.spec.ts (2m)
playwright_1  |   Slow test file: visual-regression/pages/pages.spec.ts (2m)
playwright_1  |   Slow test file: visual-regression/components/media-reuse.spec.ts (2m)
playwright_1  |   Slow test file: visual-regression/pages/homepage.spec.ts (59s)
playwright_1  |   Slow test file: e2e/filters.spec.ts (52s)
playwright_1  |   Consider splitting slow test files to speed up parallel execution
```

Here it should no longer be the case.

[^1]: https://docs.docker.com/compose/compose-file/#cpus
[^2]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
