### PR TITLE
 Text styles in no results page are incorrect #1588 

### DIFF
--- a/src/components/VErrorSection/VNoResults.vue
+++ b/src/components/VErrorSection/VNoResults.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="no-results text-center md:text-left">
-    <h5 class="break-words text-5xl">
+    <h4 class="break-words text-5xl">
       {{ $t('no-results.heading', { query: query.q }) }}
-    </h5>
-    <h6 class="mt-10 text-3xl font-normal md:mt-16 md:font-bold">
+    </h4>
+    <h6 class="mt-10 font-normal md:mt-16 md:font-bold">
       {{ $t('no-results.alternatives') }}
     </h6>
     <VMetaSourceList class="mt-4 md:mt-6" :type="type" :query="query" />

--- a/src/components/VErrorSection/VNoResults.vue
+++ b/src/components/VErrorSection/VNoResults.vue
@@ -3,7 +3,9 @@
     <h1 class="break-words text-4xl md:text-6xl">
       {{ $t('no-results.heading', { query: query.q }) }}
     </h1>
-    <h2 class="mt-10 text-base font-normal md:mt-16 md:text-3xl md:font-semibold">
+    <h2
+      class="mt-10 text-base font-normal md:mt-16 md:text-3xl md:font-semibold"
+    >
       {{ $t('no-results.alternatives') }}
     </h2>
     <VMetaSourceList class="mt-4 md:mt-6" :type="type" :query="query" />

--- a/src/components/VErrorSection/VNoResults.vue
+++ b/src/components/VErrorSection/VNoResults.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="no-results text-center md:text-left">
-    <h4 class="break-words text-5xl">
+    <h1 class="break-words text-6xl md:text-4xl">
       {{ $t('no-results.heading', { query: query.q }) }}
-    </h4>
-    <h6 class="mt-10 font-normal md:mt-16 md:font-bold">
+    </h1>
+    <h2 class="mt-10 text-base font-normal md:mt-16 md:text-3xl md:font-bold">
       {{ $t('no-results.alternatives') }}
-    </h6>
+    </h2>
     <VMetaSourceList class="mt-4 md:mt-6" :type="type" :query="query" />
   </div>
 </template>

--- a/src/components/VErrorSection/VNoResults.vue
+++ b/src/components/VErrorSection/VNoResults.vue
@@ -3,7 +3,7 @@
     <h1 class="break-words text-4xl md:text-6xl">
       {{ $t('no-results.heading', { query: query.q }) }}
     </h1>
-    <h2 class="mt-10 text-base font-normal md:mt-16 md:text-3xl md:font-bold">
+    <h2 class="mt-10 text-base font-normal md:mt-16 md:text-3xl md:font-semibold">
       {{ $t('no-results.alternatives') }}
     </h2>
     <VMetaSourceList class="mt-4 md:mt-6" :type="type" :query="query" />

--- a/src/components/VErrorSection/VNoResults.vue
+++ b/src/components/VErrorSection/VNoResults.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="no-results text-center md:text-left">
-    <h1 class="break-words text-6xl md:text-4xl">
+    <h1 class="break-words text-4xl md:text-6xl">
       {{ $t('no-results.heading', { query: query.q }) }}
     </h1>
     <h2 class="mt-10 text-base font-normal md:mt-16 md:text-3xl md:font-bold">


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1588 by @panchovm


## Description

On component VNoResults.vue
  - changed h5 to h4 below <div class="no-results text-center md:text-left">
  - deleted text-3xL -  on <h6 class="mt-10 text-3xl font-normal md:mt-16 md:font-bold">
  
![Screenshot from 2022-08-02 12-36-33](https://user-images.githubusercontent.com/93889539/182459125-9a1fcfa8-a50b-43cf-9222-a153e7547799.png)


## Testing Instructions
In live build
   - search "fjkdls;a;"
   - when you arrive at 'no results' page
        - inspect page, view on 'mobile view' to see text size changes

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
