### PR TITLE
Convert active media to options store

### DIFF
--- a/src/stores/active-media.ts
+++ b/src/stores/active-media.ts
@@ -1,10 +1,9 @@
 import { defineStore } from 'pinia'
-import { reactive, readonly, toRefs } from '@nuxtjs/composition-api'
 
 import type { SupportedMediaType } from '~/constants/media'
 import type { Media } from '~/models/media'
 
-type MediaStatus = 'ejected' | 'playing' | 'paused' // 'ejected' means player is closed
+export type MediaStatus = 'ejected' | 'playing' | 'paused' // 'ejected' means player is closed
 
 export interface ActiveMediaState {
   type: SupportedMediaType | null
@@ -18,69 +17,55 @@ const ACTIVE_MEDIA = 'active-media'
 /**
  * Store information about the active media item.
  */
-export const useActiveMediaStore = defineStore(ACTIVE_MEDIA, () => {
+export const useActiveMediaStore = defineStore(ACTIVE_MEDIA, {
   /* State */
 
-  const state: ActiveMediaState = reactive({
+  state: (): ActiveMediaState => ({
     type: null,
     id: null,
     status: 'ejected',
     message: null,
-  })
+  }),
   /**
    * Only the properties used by components are exported as refs.
    * `status` is not used anywhere in the components.
    */
-  const { type, id, message } = toRefs(state)
-
-  /* Actions */
-
-  /**
-   * Sets a new media item as the active one.
-   *
-   * @param type - the type of the active media
-   * @param id - the unique identifier of the active media
-   * @param status - the current status of the active media
-   */
-  function setActiveMediaItem({
-    type,
-    id,
-    status = 'playing',
-  }: {
-    type: SupportedMediaType
-    id: Media['id']
-    status?: MediaStatus
-  }) {
-    state.type = type
-    state.id = id
-    state.status = status
-  }
-  function pauseActiveMediaItem() {
-    state.status = 'paused'
-  }
-  function ejectActiveMediaItem() {
-    state.status = 'ejected'
-    state.id = null
-    state.type = null
-  }
-  /**
-   * Set the message associated with rendering/playback of the active media.
-   *
-   * @param message - the message to display to the user
-   */
-  function setMessage({ message }: { message: string }) {
-    state.message = message
-  }
-
-  return {
-    type: readonly(type),
-    id: readonly(id),
-    message: readonly(message),
-    state: readonly(state),
-
-    setActiveMediaItem,
-    pauseActiveMediaItem,
-    ejectActiveMediaItem,
-    setMessage,
-  }
+  actions: {
+    /**
+     * Sets a new media item as the active one.
+     *
+     * @param type - the type of the active media
+     * @param id - the unique identifier of the active media
+     * @param status - the current status of the active media
+     */
+    setActiveMediaItem({
+      type,
+      id,
+      status = 'playing',
+    }: {
+      type: SupportedMediaType
+      id: Media['id']
+      status?: MediaStatus
+    }) {
+      this.type = type
+      this.id = id
+      this.status = status
+    },
+    pauseActiveMediaItem() {
+      this.status = 'paused'
+    },
+    ejectActiveMediaItem() {
+      this.status = 'ejected'
+      this.id = null
+      this.type = null
+    },
+    /**
+     * Set the message associated with rendering/playback of the active media.
+     *
+     * @param message - the message to display to the user
+     */
+    setMessage({ message }: { message: string }) {
+      this.message = message
+    },
+  },
 })

--- a/src/stores/active-media.ts
+++ b/src/stores/active-media.ts
@@ -51,9 +51,11 @@ export const useActiveMediaStore = defineStore(ACTIVE_MEDIA, {
       this.id = id
       this.status = status
     },
+
     pauseActiveMediaItem() {
       this.status = 'paused'
     },
+
     ejectActiveMediaItem() {
       this.status = 'ejected'
       this.id = null

--- a/src/stores/active-media.ts
+++ b/src/stores/active-media.ts
@@ -26,10 +26,7 @@ export const useActiveMediaStore = defineStore(ACTIVE_MEDIA, {
     status: 'ejected',
     message: null,
   }),
-  /**
-   * Only the properties used by components are exported as refs.
-   * `status` is not used anywhere in the components.
-   */
+
   actions: {
     /**
      * Sets a new media item as the active one.

--- a/test/unit/specs/stores/active-media-store.spec.js
+++ b/test/unit/specs/stores/active-media-store.spec.js
@@ -14,17 +14,22 @@ describe('Active Media Store', () => {
   describe('state', () => {
     it('sets initial filters to filterData', () => {
       const activeMediaStore = useActiveMediaStore()
-      expect(activeMediaStore.state).toEqual(initialState)
+      expect(activeMediaStore.type).toEqual(initialState.type)
+      expect(activeMediaStore.id).toEqual(initialState.id)
+      expect(activeMediaStore.status).toEqual(initialState.status)
+      expect(activeMediaStore.message).toEqual(initialState.message)
     })
   })
   describe('actions', () => {
-    it.each(statuses)('can set active media with status $status', (status) => {
+    it.each(statuses)(`can set active media with status $status`, (status) => {
       const activeMediaStore = useActiveMediaStore()
       const mediaItem = { type: AUDIO, id: 'audio1' }
       activeMediaStore.setActiveMediaItem({ ...mediaItem, status })
       const expectedState = { ...initialState, ...mediaItem, status }
 
-      expect(activeMediaStore.state).toEqual(expectedState)
+      expect(activeMediaStore.id).toEqual(expectedState.id)
+      expect(activeMediaStore.type).toEqual(expectedState.type)
+      expect(activeMediaStore.status).toEqual(expectedState.status)
     })
 
     it.each(statuses)('can pause an item with any status', (status) => {
@@ -32,7 +37,7 @@ describe('Active Media Store', () => {
       activeMediaStore.setActiveMediaItem({ status })
       activeMediaStore.pauseActiveMediaItem()
 
-      expect(activeMediaStore.state.status).toEqual('paused')
+      expect(activeMediaStore.status).toEqual('paused')
     })
     it('can eject an item', () => {
       const activeMediaStore = useActiveMediaStore()
@@ -44,7 +49,9 @@ describe('Active Media Store', () => {
       })
       activeMediaStore.ejectActiveMediaItem()
 
-      expect(activeMediaStore.state).toEqual(initialState)
+      expect(activeMediaStore.id).toEqual(initialState.id)
+      expect(activeMediaStore.type).toEqual(initialState.type)
+      expect(activeMediaStore.status).toEqual(initialState.status)
     })
     it('can set a message', () => {
       const activeMediaStore = useActiveMediaStore()


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1627 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR converts the `active-media` store from a setup store to an options store. This makes all stores consistent and prevents `cannot assign to a readonly value` errors in updated versions of Pinia/Nuxt/Vue. You can see the warnings in the CI logs of #1635:
```
console.error
    [Vue warn]: Set operation on key "id" failed: target is readonly.

      33 |   const pinia = createPinia()
      34 |   const activeMediaStore = useActiveMediaStore(pinia)
    > 35 |   activeMediaStore.$patch({
         |                    ^
      36 |     state: {
      37 |       type: 'audio',
      38 |       id: 'e19345b8-6937-49f7-a0fd-03bf057efc28',

      at warn$2 (node_modules/.pnpm/vue@2.7.10/node_modules/vue/dist/vue.common.dev.js:5005:21)
      at Object.set (node_modules/.pnpm/vue@2.7.10/node_modules/vue/dist/vue.common.dev.js:1335:13)
      at Object.reactiveSetter [as id] (node_modules/.pnpm/vue@2.7.10/node_modules/vue/dist/vue.common.dev.js:958:24)
      at mergeReactiveObjects (node_modules/.pnpm/pinia@2.0.20_bwmvgbrvs54y3u2q642yxns4ge/node_modules/pinia/dist/pinia.cjs:1141:25)
      at mergeReactiveObjects (node_modules/.pnpm/pinia@2.0.20_bwmvgbrvs54y3u2q642yxns4ge/node_modules/pinia/dist/pinia.cjs:1137:27)
      at Object.$patch (node_modules/.pnpm/pinia@2.0.20_bwmvgbrvs54y3u2q642yxns4ge/node_modules/pinia/dist/pinia.cjs:1293:13)
      at useStore (test/unit/specs/components/AudioTrack/v-audio-track.spec.js:35:20)

```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The CI should pass. Also, try playing the audio on the pages. There should be no errors

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
