### PR TITLE
Replace Search result page `h` element with a `p` element

### DIFF
--- a/src/components/VMetaSearch/VMetaSearchForm.vue
+++ b/src/components/VMetaSearch/VMetaSearchForm.vue
@@ -14,8 +14,8 @@
             ? 'meta-search.form.supported-title'
             : 'meta-search.form.unsupported-title'
         "
-        tag="h4"
-        class="mb-2 text-4xl"
+        tag="p"
+        class="mb-2 text-base"
       >
         <template #openverse>Openverse</template>
         <template #type>{{ $t(`meta-search.form.types.${type}`) }}</template>
@@ -23,8 +23,8 @@
       <i18n
         v-else
         path="meta-search.form.no-results-title"
-        tag="h4"
-        class="mb-2 text-4xl"
+        tag="p"
+        class="mb-2 text-base"
       >
         <template #type>{{ $t(`meta-search.form.types.${type}`) }}</template>
         <template #query>{{ query.q }}</template>

--- a/src/components/VMetaSearch/VMetaSearchForm.vue
+++ b/src/components/VMetaSearch/VMetaSearchForm.vue
@@ -2,50 +2,52 @@
   <section
     :key="type"
     ref="sectionRef"
-    class="meta-search mt-12 p-6 text-center"
+    class="meta-search p-6 text-center"
     data-testid="meta-search-form"
     @keydown.tab.exact="handleTab"
   >
-    <header class="mb-10">
-      <i18n
-        v-if="!hasNoResults"
-        :path="
-          isSupported
-            ? 'meta-search.form.supported-title'
-            : 'meta-search.form.unsupported-title'
-        "
-        tag="p"
-        class="mb-2 text-base"
-      >
-        <template #openverse>Openverse</template>
-        <template #type>{{ $t(`meta-search.form.types.${type}`) }}</template>
-      </i18n>
-      <i18n
-        v-else
-        path="meta-search.form.no-results-title"
-        tag="p"
-        class="mb-2 text-base"
-      >
-        <template #type>{{ $t(`meta-search.form.types.${type}`) }}</template>
-        <template #query>{{ query.q }}</template>
-      </i18n>
-      <i18n path="meta-search.form.caption" tag="p">
-        <template #type>{{
-          $t(`meta-search.form.types-plural.${type}`)
-        }}</template>
-        <template #break>
-          <br />
-        </template>
-      </i18n>
-    </header>
+    <i18n
+      v-if="!hasNoResults"
+      :path="
+        isSupported
+          ? 'meta-search.form.supported-title'
+          : 'meta-search.form.unsupported-title'
+      "
+      tag="p"
+      class="text-base font-normal leading-[130%]"
+    >
+      <template #openverse>Openverse</template>
+      <template #type>{{ $t(`meta-search.form.types.${type}`) }}</template>
+    </i18n>
+    <i18n
+      v-else
+      path="meta-search.form.no-results-title"
+      tag="p"
+      class="text-base font-normal leading-[130%]"
+    >
+      <template #type>{{ $t(`meta-search.form.types.${type}`) }}</template>
+      <template #query>{{ query.q }}</template>
+    </i18n>
+    <i18n
+      class="text-base font-normal leading-[130%]"
+      path="meta-search.form.caption"
+      tag="p"
+    >
+      <template #type>{{
+        $t(`meta-search.form.types-plural.${type}`)
+      }}</template>
+      <template #break>
+        <br />
+      </template>
+    </i18n>
 
     <VMetaSourceList
-      class="mt-6 mb-10 md:justify-center"
+      class="my-8 md:justify-center"
       :type="type"
       :query="query"
     />
 
-    <p class="my-0 mx-auto max-w-3xl text-sm font-semibold">
+    <p class="my-0 mx-auto max-w-3xl text-base font-normal leading-[130%]">
       {{ $t('meta-search.caption', { openverse: 'Openverse' }) }}
     </p>
   </section>


### PR DESCRIPTION
## Fixes
Changed from h tag to p tag, and also changed the text styling.
Fixes #1615 by @obulat 

## Description
The search results message did not match the figma at all. Addresses issue with ticket #1615, where the search results message is styled as a header and not as a paragraph. Changed from h tag to p tag, and also changed the text styling.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
