### PR TITLE
Make Renovate bot ignore forks and remove the SENTR_DSN

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,5 +24,6 @@
     ".github/workflows/pr_label_check.yml",
     ".github/workflows/pr_ping.yml",
     "package.json"
-  ]
+  ],
+  "includeForks": false
 }

--- a/src/utils/sentry-config.ts
+++ b/src/utils/sentry-config.ts
@@ -8,10 +8,10 @@ import type { ModuleConfiguration } from '@nuxtjs/sentry'
  * @returns the Sentry configuration to use
  */
 export const sentryConfig: ModuleConfiguration = {
-  dsn:
-    process.env.SENTRY_DSN ||
-    'https://53da8fbcebeb48a6bf614a212629df6b@o787041.ingest.sentry.io/5799642',
-  disabled: process.env.DISABLE_SENTRY ? true : !isProd,
+  dsn: process.env.SENTRY_DSN,
+  disabled: process.env.DISABLE_SENTRY
+    ? true
+    : process.env.SENTRY_DSN === undefined || !isProd,
   lazy: true,
   clientConfig: {
     // Only allow errors that come from an actual openverse.engineering subdomain


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1625 by @sarayourfriend 
Fixes #1650 by @krysal 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR:

- makes Renovate bot ignore forks
- removes Openverse' Sentry DNS and disable it if it is not set

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
For Sentry, try running the project with different environment variables configurations.

1. Simulating production and without setting the SENTRY_DSN, confirm it's disabled
```sh
NODE_ENV=production pnpm dev:only
```
In your terminal you should see an output like this:
```sh
✔ Sentry reporting is disabled ("disabled" option has been set)                                                       nuxt:sentry 16:13:45

   ╭─────────────────────────────────────────────╮
   │                                             │
   │   Nuxt @ v2.15.8                            │
   │                                             │
   │   ▸ Environment: development (production)   │
   │   ▸ Rendering:   server-side                │
   │   ▸ Target:      server                     │
   │                                             │
   │   Listening: http://172.16.0.12:8443/       │
   │                                             │
   ╰─────────────────────────────────────────────╯
```

2. With production + a SENTRY_DSN string, it should be **enabled**
```sh
NODE_ENV=production SENTRY_DSN=<redacted> pnpm dev:only
```

3. For `development` it should remain **disabled**

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
