### PR TITLE
 Correct heading order for single audio result pages

### DIFF
--- a/src/components/VAudioDetails/VAudioDetails.vue
+++ b/src/components/VAudioDetails/VAudioDetails.vue
@@ -1,9 +1,9 @@
 <template>
   <section class="audio-info">
     <header class="mb-6 flex flex-row items-center justify-between">
-      <h4 class="text-2xl lg:text-3xl">
+      <h2 class="text-2xl lg:text-3xl">
         {{ $t('audio-details.information') }}
-      </h4>
+      </h2>
       <VContentReportPopover :media="audio" />
     </header>
 

--- a/src/components/VAudioDetails/VRelatedAudio.vue
+++ b/src/components/VAudioDetails/VRelatedAudio.vue
@@ -1,8 +1,8 @@
 <template>
   <aside :aria-label="$t('audio-details.related-audios')">
-    <h4 class="mb-6 text-2xl lg:text-3xl">
+    <h3 class="mb-6 text-2xl lg:text-3xl">
       {{ $t('audio-details.related-audios') }}
-    </h4>
+    </h3>
     <div v-if="!fetchState.isError" class="mb-12 flex flex-col gap-8 lg:gap-12">
       <VAudioTrack
         v-for="audio in media"

--- a/src/components/VAudioDetails/VRelatedAudio.vue
+++ b/src/components/VAudioDetails/VRelatedAudio.vue
@@ -1,8 +1,8 @@
 <template>
   <aside :aria-label="$t('audio-details.related-audios')">
-    <h3 class="mb-6 text-2xl lg:text-3xl">
+    <h2 class="mb-6 text-2xl lg:text-3xl">
       {{ $t('audio-details.related-audios') }}
-    </h3>
+    </h2>
     <div v-if="!fetchState.isError" class="mb-12 flex flex-col gap-8 lg:gap-12">
       <VAudioTrack
         v-for="audio in media"

--- a/src/components/VMediaInfo/VCopyLicense.vue
+++ b/src/components/VMediaInfo/VCopyLicense.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <h5
+    <h3
       id="copy-license-title"
       class="mb-4 text-base font-semibold md:text-2xl"
     >
       {{ $t('media-details.reuse.copy-license.title') }}
-    </h5>
+    </h3>
 
     <VTabs label="#copy-license-title" :selected-id="tabs[0]">
       <template #tabs>

--- a/src/components/VMediaInfo/VMediaLicense.vue
+++ b/src/components/VMediaInfo/VMediaLicense.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="media-attribution">
-    <h5 class="mb-4 text-base font-semibold md:text-2xl">
+    <h3 class="mb-4 text-base font-semibold md:text-2xl">
       {{ headerText }}
-    </h5>
+    </h3>
 
     <template v-if="isLicense">
       <i18n

--- a/src/components/VMediaInfo/VMediaReuse.vue
+++ b/src/components/VMediaInfo/VMediaReuse.vue
@@ -3,9 +3,9 @@
     :aria-label="$t('media-details.reuse.title').toString()"
     class="media-reuse"
   >
-    <h1 class="mb-6 text-2xl md:text-3xl">
+    <h2 class="mb-6 text-2xl md:text-3xl">
       {{ $t('media-details.reuse.title') }}
-    </h1>
+    </h2>
     <div v-if="media.license_url" class="grid gap-6 md:grid-cols-2">
       <VMediaLicense
         :license="media.license"

--- a/src/components/VMediaInfo/VMediaReuse.vue
+++ b/src/components/VMediaInfo/VMediaReuse.vue
@@ -3,9 +3,9 @@
     :aria-label="$t('media-details.reuse.title').toString()"
     class="media-reuse"
   >
-    <h2 class="mb-6 text-2xl md:text-3xl">
+    <h1 class="mb-6 text-2xl md:text-3xl">
       {{ $t('media-details.reuse.title') }}
-    </h2>
+    </h1>
     <div v-if="media.license_url" class="grid gap-6 md:grid-cols-2">
       <VMediaLicense
         :license="media.license"

--- a/src/components/VMediaInfo/VMediaReuse.vue
+++ b/src/components/VMediaInfo/VMediaReuse.vue
@@ -3,9 +3,9 @@
     :aria-label="$t('media-details.reuse.title').toString()"
     class="media-reuse"
   >
-    <h3 class="mb-6 text-2xl md:text-3xl">
+    <h1 class="mb-6 text-2xl md:text-3xl">
       {{ $t('media-details.reuse.title') }}
-    </h3>
+    </h1>
     <div v-if="media.license_url" class="grid gap-6 md:grid-cols-2">
       <VMediaLicense
         :license="media.license"

--- a/test/playwright/visual-regression/components/media-reuse.spec.ts
+++ b/test/playwright/visual-regression/components/media-reuse.spec.ts
@@ -30,7 +30,7 @@ test.describe('media-reuse', () => {
           await page.locator(`#tab-${tab.id}`).click()
           // Make sure the tab is not focused and doesn't have a pink ring
           const reuseTitle = t('media-details.reuse.title', dir)
-          await page.locator(`h3:has-text("${reuseTitle}")`).click()
+          await page.locator(`h2:has-text("${reuseTitle}")`).click()
           await expectSnapshot(
             `media-reuse-${dir}-${tab.id}-tab`,
             page.locator('.media-reuse')

--- a/test/unit/specs/components/related-audios.spec.js
+++ b/test/unit/specs/components/related-audios.spec.js
@@ -32,7 +32,7 @@ describe('RelatedAudios', () => {
   it('should render content when finished loading related audios', async () => {
     const wrapper = await doRender()
 
-    const header = wrapper.find('h4').text()
+    const header = wrapper.find('h3').text()
     expect(header).toEqual('audio-details.related-audios')
 
     const audioTracks = wrapper.findAll('vaudiotrack-stub')

--- a/test/unit/specs/components/related-audios.spec.js
+++ b/test/unit/specs/components/related-audios.spec.js
@@ -32,7 +32,7 @@ describe('RelatedAudios', () => {
   it('should render content when finished loading related audios', async () => {
     const wrapper = await doRender()
 
-    const header = wrapper.find('h3').text()
+    const header = wrapper.find('h2').text()
     expect(header).toEqual('audio-details.related-audios')
 
     const audioTracks = wrapper.findAll('vaudiotrack-stub')


### PR DESCRIPTION
## Fixes
Fixes #1616 by @obulat 

## Description
- Pull Request changes the headers of the following components to be a in sequential order ( h1 - h3)
        (h1) * src/components/VMediaInfo/VMediaReuse.vue
        (h2) * src/components/VAudioDetails/VAudioDetails.vue
        (h3)  * src/components/VAudioDetails/VRelatedAudio.vue
- Pull Request changes testing file 'related-audios.spec.js' to pass 'RelatedAudios' test. 'h4' has been changed to 'h3'. Test now passes. 


##Add screenshot
![openverse issue#1616](https://user-images.githubusercontent.com/93889539/184450816-8f201de5-34b5-4c6c-96e4-25daa9ee9984.png)



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
