### PR TITLE
Add better concurrency settings for workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - main
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/bundle_size.yml
+++ b/.github/workflows/bundle_size.yml
@@ -26,7 +26,7 @@ on:
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
   # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/generate_pot.yml
+++ b/.github/workflows/generate_pot.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -10,12 +10,13 @@ on:
   release:
     types: [published]
 
-# Cancels all previous workflow runs for pull requests that have not completed.
+# Prevents multiple deployments/builds from running at the same time
 concurrency:
-  # The concurrency group contains the workflow name and the branch name for pull requests
-  # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'release' && 'production' || github.event_name == 'push' && 'staging' || github.event.pull_request.number }}_release
+  # Don't continue building images for a PR if the PR is updated quickly
+  # For other workflows, allow them to complete and just block on them. This
+  # ensures deployments in particular happen in series rather than parallel.
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   push-to-ghcr:

--- a/.github/workflows/label_new_pr.yml
+++ b/.github/workflows/label_new_pr.yml
@@ -8,6 +8,10 @@ on:
       # events that will trigger the checks defined in `pr_label_check.yml`.
       - opened
 
+# Prevent API rate limiting by only allowing a single PR
+# to dispatch workflows at a time
+concurrency: ${{ github.workflow }}
+
 jobs:
   set_label:
     name: Set labels

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -10,6 +10,11 @@ on:
         required: true
         description: The GHCR image tag to which the environment should be rolled back
 
+# Only allow a single rollback to happen at a time
+# If you need to stop an in-progress rollback to force
+# another for the same environment, you'll need to manually cancel it
+concurrency: ${{ github.workflow }}-${{ inputs.environment }}
+
 jobs:
   rollback:
     name: Perform Rollback


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to https://github.com/WordPress/openverse/issues/290 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Workflows by default run in parallel and will finish running even if the
results of them don't matter by the time they're done. CI for example,
does not matter on a PR if the PR is updated. That's why we already had
concurrency on the ci.yml workflow that cancels in progress workflow
runs. This helps prevent our worker allowance from being eaten up by
long CI runs.

We can also use this to prevent certain workflows from running in
parallel and instead waiting for the previous run to finish. For
example, deployments. Auto-deployments should never happen in parallel
and should wait for any currently active deployments to the same
environment, whether to staging or production, to finish before starting.

Similarly, rollbacks should not happen in parallel and will block and
wait for previous rollbacks to the same environment to finish.

Lastly, there are workflows that don't need to run in parallel, but can
also cancel in progress flows. Examples of this are artifact generation
like GitHub pages updates from `main` and PO file generation also from
`main`. Both of these only need the latest invocation of them to run
because any given run will necessarily include any changes that a
previous cancelled run would have made. If we merge two PRs one after
another, we don't need to generate PO files twice. We can just generate
them for the second PR that was merged.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Review the configurations and confirm that they make sense for the given workflow they're referencing. Then we merge and see if it works.

If there ends up being any issue with them, revert the PR so that it doesn't block ongoing work.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [N/A] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
