### PR TITLE
Revert "Avoid pausing audio when is loading"

### DIFF
--- a/src/components/VAudioTrack/VPlayPause.vue
+++ b/src/components/VAudioTrack/VPlayPause.vue
@@ -89,7 +89,6 @@ export default defineComponent({
   setup(props, { emit }) {
     const isPlaying = computed(() => props.status === 'playing')
     const isLoading = computed(() => props.status === 'loading')
-    const isPaused = computed(() => props.status === 'paused')
     /**
      * Get the button label based on the current status of the player.
      */
@@ -110,13 +109,8 @@ export default defineComponent({
     })
 
     const handleClick = () => {
-      if (isPlaying.value) {
-        emit('toggle', 'paused')
-      } else if (isPaused.value) {
-        emit('toggle', 'playing')
-      }
+      emit('toggle', isPlaying.value || isLoading.value ? 'paused' : 'playing')
     }
-
     return {
       label,
       icon,


### PR DESCRIPTION
Reverts WordPress/openverse-frontend#1643

Reverting due to the introduction of an uncaught Playwright failure: https://github.com/WordPress/openverse-frontend/actions/runs/2869167598

Playwright failures were not being surfaced in PRs due to #1637 