### PR TITLE
Fix modal not hiding on escape

### DIFF
--- a/src/components/VModal/VModalContent.vue
+++ b/src/components/VModal/VModalContent.vue
@@ -1,7 +1,7 @@
 <template>
   <VTeleport v-if="visible" to="modal">
     <!-- Prevent FocusTrap from trying to focus the first element. We already do that in a more flexible, adaptive way in our Dialog composables. -->
-    <FocusTrap :initial-focus="() => false">
+    <FocusTrap :initial-focus="() => false" :escape-deactivates="!hideOnEsc">
       <div
         class="fixed inset-0 z-40 flex min-h-screen justify-center overflow-y-auto bg-dark-charcoal bg-opacity-75"
       >

--- a/test/unit/specs/components/v-modal.spec.js
+++ b/test/unit/specs/components/v-modal.spec.js
@@ -115,7 +115,7 @@ describe('VModal', () => {
     expect(screen.getByText(/custom initial focus/i))
   })
 
-  xit('should hide the modal on escape', async () => {
+  it('should hide the modal on escape', async () => {
     render(TestWrapper, options)
     await doOpen()
 

--- a/test/unit/specs/components/v-modal.spec.js
+++ b/test/unit/specs/components/v-modal.spec.js
@@ -114,4 +114,16 @@ describe('VModal', () => {
     expect(getDialog()).toBeVisible()
     expect(screen.getByText(/custom initial focus/i))
   })
+
+  xit('should hide the modal on escape', async () => {
+    render(TestWrapper, options)
+    await doOpen()
+
+    expect(getDialog()).toBeVisible()
+
+    await userEvent.keyboard('{Escape}')
+    await nextTick()
+
+    expect(queryDialog()).toBe(null)
+  })
 })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1280 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds ` :escape-deactivates="!hideOnEsc"` to `FocusTrap` so that the `Escape` key is handled by the `use-dialog-content` composable instead of the `focus-trap`.
The PR also updates the testing libraries. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
On mobile screen, open a menu modal or a filters modal, and press <kbd>Escape</kbd>. The modal should close. Try the same on the production site - Escape does not close the modal.
You can also check out Modal in the storybook.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
