### PR TITLE
Fix lint staged to match pnpm:fix order and settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
   rules: {
     semi: [2, 'never'],
     'no-console': 'off',
+    'prettier/prettier': 'off',
     'vue/max-attributes-per-line': 'off',
     'vue/require-prop-types': 'off',
     'vue/require-default-prop': 'off',

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,8 +1,5 @@
 {
-  "*.{ts,js,vue}": [
-    "eslint --fix --max-warnings=0"
-  ],
   "*.{ts,js,vue,json,yml,yaml,mdx,md}": [
-    "prettier --write"
+    "pnpm lint:fix"
   ]
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,8 @@
 {
   "*.{ts,js,vue,json,yml,yaml,mdx,md}": [
-    "pnpm lint:fix"
+    "prettier --write"
+  ],
+  "*.{ts,js,vue}": [
+    "eslint --ignore-path .gitignore --ignore-path .eslintignore --max-warnings=0 ."
   ]
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,8 +1,7 @@
 {
-  "*.{ts,js,vue,json,yml,yaml,mdx,md}": [
-    "prettier --write"
-  ],
+  "*.{json,yml,yaml,mdx,md}": "prettier --write",
   "*.{ts,js,vue}": [
-    "eslint --ignore-path .gitignore --ignore-path .eslintignore --max-warnings=0 ."
+    "prettier --write",
+    "eslint --ext .js,.vue,.ts --ignore-path .gitignore --ignore-path .eslintignore --max-warnings=0 ."
   ]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="https://github.com/orgs/WordPress/projects/3">Project Board</a> | <a href="https://make.wordpress.org/openverse/">Community Site</a> | <a href="https://make.wordpress.org/chat/">#openverse @ Slack</a> | <a href="https://make.wordpress.org/openverse/handbook/">Handbook</a> | <a href="https://www.figma.com/file/w60dl1XPUvSaRncv1Utmnb/Openverse-Releases">Figma Mockups</a>  | <a href="https://www.figma.com/file/GIIQ4sDbaToCfFQyKMvzr8/Openverse-Design-Library">Figma Design Library</a>
 </p>
 
-# Openverse Frontend
+     # Openverse Frontend
 
 ![openverse-frontend-ci](https://github.com/wordpress/openverse-frontend/workflows/openverse-frontend-ci/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="https://github.com/orgs/WordPress/projects/3">Project Board</a> | <a href="https://make.wordpress.org/openverse/">Community Site</a> | <a href="https://make.wordpress.org/chat/">#openverse @ Slack</a> | <a href="https://make.wordpress.org/openverse/handbook/">Handbook</a> | <a href="https://www.figma.com/file/w60dl1XPUvSaRncv1Utmnb/Openverse-Releases">Figma Mockups</a>  | <a href="https://www.figma.com/file/GIIQ4sDbaToCfFQyKMvzr8/Openverse-Design-Library">Figma Design Library</a>
 </p>
 
-     # Openverse Frontend
+# Openverse Frontend
 
 ![openverse-frontend-ci](https://github.com/wordpress/openverse-frontend/workflows/openverse-frontend-ci/badge.svg)
 


### PR DESCRIPTION
## Fixes

Fixes #1658 by @dhruvkb 

## Description

Fixes a discrepancy between `pnpm lint:fix` and our precommit linting script. Now they run eslint and prettier formatting in the same order with the same settings.