### PR TITLE
Disable content link when result count is zero

### DIFF
--- a/src/components/VContentLink/VContentLink.vue
+++ b/src/components/VContentLink/VContentLink.vue
@@ -4,11 +4,11 @@
     :href="hasResults ? to : undefined"
     role="link"
     :aria-disabled="!hasResults"
-    class="flex w-full flex-col items-start overflow-hidden rounded-sm border border-dark-charcoal/20 bg-white py-4 text-dark-charcoal ps-4 pe-12 md:flex-row md:items-center md:justify-between md:p-6"
+    class="flex w-full flex-col items-start overflow-hidden rounded-sm border border-dark-charcoal/20 bg-white py-4 ps-4 pe-12 md:flex-row md:items-center md:justify-between md:p-6"
     :class="
       hasResults
-        ? 'hover:bg-dark-charcoal hover:text-white hover:no-underline focus:border-tx focus:outline-none focus-visible:ring focus-visible:ring-pink'
-        : 'opacity-50'
+        ? ' text-dark-charcoal hover:bg-dark-charcoal hover:text-white hover:no-underline focus:border-tx focus:outline-none focus-visible:ring focus-visible:ring-pink'
+        : 'text-dark-charcoal/40'
     "
     @keydown.native.shift.tab.exact="$emit('shift-tab', $event)"
   >

--- a/src/components/VContentLink/VContentLink.vue
+++ b/src/components/VContentLink/VContentLink.vue
@@ -8,7 +8,7 @@
     :class="
       hasResults
         ? ' text-dark-charcoal hover:bg-dark-charcoal hover:text-white hover:no-underline focus:border-tx focus:outline-none focus-visible:ring focus-visible:ring-pink'
-        : 'text-dark-charcoal/40'
+        : 'cursor-not-allowed text-dark-charcoal/40'
     "
     @keydown.native.shift.tab.exact="$emit('shift-tab', $event)"
   >

--- a/src/components/VContentLink/VContentLink.vue
+++ b/src/components/VContentLink/VContentLink.vue
@@ -1,14 +1,14 @@
 <template>
   <!-- We 'disable' the link when there are 0 results by removing the href and setting aria-disabled. -->
   <VLink
-    :href="noResults ? undefined : to"
+    :href="hasResults ? to : undefined"
     role="link"
-    :aria-disabled="noResults"
+    :aria-disabled="!hasResults"
     class="flex w-full flex-col items-start overflow-hidden rounded-sm border border-dark-charcoal/20 bg-white py-4 text-dark-charcoal ps-4 pe-12 md:flex-row md:items-center md:justify-between md:p-6"
     :class="
-      noResults
-        ? 'opacity-50'
-        : 'hover:bg-dark-charcoal hover:text-white hover:no-underline focus:border-tx focus:outline-none focus-visible:ring focus-visible:ring-pink'
+      hasResults
+        ? 'hover:bg-dark-charcoal hover:text-white hover:no-underline focus:border-tx focus:outline-none focus-visible:ring focus-visible:ring-pink'
+        : 'opacity-50'
     "
     @keydown.native.shift.tab.exact="$emit('shift-tab', $event)"
   >
@@ -76,14 +76,14 @@ export default defineComponent({
   setup(props) {
     const iconPath = computed(() => iconMapping[props.mediaType])
     const { getI18nCount } = useI18nResultsCount()
-    const noResults = computed(() => props.resultsCount === 0)
+    const hasResults = computed(() => props.resultsCount > 0)
     const resultsCountLabel = computed(() => getI18nCount(props.resultsCount))
 
     return {
       iconPath,
       imageIcon,
       resultsCountLabel,
-      noResults,
+      hasResults,
     }
   },
 })

--- a/src/components/VContentLink/VContentLink.vue
+++ b/src/components/VContentLink/VContentLink.vue
@@ -1,7 +1,15 @@
 <template>
+  <!-- We 'disable' the link when there are 0 results by removing the href and setting aria-disabled. -->
   <VLink
-    :href="to"
-    class="flex w-full flex-col items-start overflow-hidden rounded-sm border border-dark-charcoal/20 bg-white py-4 text-dark-charcoal ps-4 pe-12 hover:bg-dark-charcoal hover:text-white hover:no-underline focus:border-tx focus:outline-none focus-visible:ring focus-visible:ring-pink md:flex-row md:items-center md:justify-between md:p-6"
+    :href="noResults ? undefined : to"
+    role="link"
+    :aria-disabled="noResults"
+    class="flex w-full flex-col items-start overflow-hidden rounded-sm border border-dark-charcoal/20 bg-white py-4 text-dark-charcoal ps-4 pe-12 md:flex-row md:items-center md:justify-between md:p-6"
+    :class="
+      noResults
+        ? 'opacity-50'
+        : 'hover:bg-dark-charcoal hover:text-white hover:no-underline focus:border-tx focus:outline-none focus-visible:ring focus-visible:ring-pink'
+    "
     @keydown.native.shift.tab.exact="$emit('shift-tab', $event)"
   >
     <div class="flex flex-col items-start md:flex-row md:items-center">
@@ -48,7 +56,8 @@ export default defineComponent({
       required: true,
     },
     /**
-     * The number of results that the search returned.
+     * The number of results that the search returned. The link
+     * will be disabled if this value is zero.
      */
     resultsCount: {
       type: Number,
@@ -67,9 +76,15 @@ export default defineComponent({
   setup(props) {
     const iconPath = computed(() => iconMapping[props.mediaType])
     const { getI18nCount } = useI18nResultsCount()
+    const noResults = computed(() => props.resultsCount === 0)
     const resultsCountLabel = computed(() => getI18nCount(props.resultsCount))
 
-    return { iconPath, imageIcon, resultsCountLabel }
+    return {
+      iconPath,
+      imageIcon,
+      resultsCountLabel,
+      noResults,
+    }
   },
 })
 </script>

--- a/test/unit/specs/components/v-content-link.spec.js
+++ b/test/unit/specs/components/v-content-link.spec.js
@@ -16,7 +16,8 @@ describe('VContentLink', () => {
 
   beforeEach(() => {
     options = {
-      props: { mediaType: 'image', resultsCount: 123 },
+      props: { mediaType: 'image', resultsCount: 123, to: '/images' },
+      stubs: ['NuxtLink'],
       mocks: {
         $nuxt: {
           context: {
@@ -27,17 +28,23 @@ describe('VContentLink', () => {
     }
   })
 
-  xit('is not selected by default', () => {
+  it('is enabled when there are results', () => {
     render(VContentLink, options)
-    const btn = screen.getByRole('radio')
-    expect(btn).not.toHaveAttribute('aria-checked')
+    const btn = screen.getByRole('link')
+
+    /**  @todo: Mock NuxtLink and check for href instead.  **/
+    expect(btn).toHaveAttribute('to')
+    expect(btn).not.toHaveAttribute('aria-disabled')
   })
 
-  xit('is marked as selected when indicated with the isSelected prop', () => {
-    options.props.isSelected = true
+  it('is disabled when there are no results', () => {
+    options.props.resultsCount = 0
     render(VContentLink, options)
-    const btn = screen.getByRole('radio')
-    expect(btn).toHaveAttribute('aria-checked')
-    expect(btn.getAttribute('aria-checked')).toBeTruthy()
+    const btn = screen.getByRole('link')
+
+    /**  @todo: Mock NuxtLink and check for href instead.  **/
+    expect(btn).not.toHaveAttribute('to')
+    expect(btn).toHaveAttribute('aria-disabled')
+    expect(btn.getAttribute('aria-disabled')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1699 by @panchovm 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR disables the vcontent links when the result count is zero by:

- Removing their href
- Setting aria-disabled to true

This PR adds basic unit tests for this functionality and removes tests that no longer match the structure of the component. A previous version used radio buttons which was reflected in those tests.

The styling is a placeholder, waiting for design work from @panchovm. It currently sets the entire button's opacity to `.5`.

## Screenshot

![CleanShot 2022-09-07 at 12 38 17@2x](https://user-images.githubusercontent.com/6351754/188933247-db4ef85a-5bdf-4549-bd06-cb6beb63a216.png)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
