### PR TITLE
Handle focus events that are fired  when the audio player is clicked

### DIFF
--- a/src/pages/search/audio.vue
+++ b/src/pages/search/audio.vue
@@ -26,6 +26,7 @@
       layout="row"
       @shift-tab="handleShiftTab($event, i)"
       @interacted="hideSnackbar"
+      @mousedown.native="handleMouseDown"
       @focus.native="showSnackbar"
     />
     <VLoadMore />
@@ -33,7 +34,12 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, useMeta } from '@nuxtjs/composition-api'
+import {
+  computed,
+  defineComponent,
+  useMeta,
+  ref,
+} from '@nuxtjs/composition-api'
 
 import { isMinScreen } from '~/composables/use-media-query'
 import { useBrowserIsMobile } from '~/composables/use-browser-detection'
@@ -82,10 +88,21 @@ export default defineComponent({
       }
     }
 
+    const isMouseDown = ref(false)
+    const handleMouseDown = () => {
+      isMouseDown.value = true
+    }
+
     const uiStore = useUiStore()
     const isSnackbarVisible = computed(() => uiStore.areInstructionsVisible)
     const showSnackbar = () => {
-      uiStore.showInstructionsSnackbar()
+      if (isMouseDown.value) {
+        // The audio player was clicked to open the single result view, not
+        // focused via keyboard.
+        isMouseDown.value = false
+      } else {
+        uiStore.showInstructionsSnackbar()
+      }
     }
     const hideSnackbar = () => {
       uiStore.hideInstructionsSnackbar()
@@ -96,6 +113,7 @@ export default defineComponent({
       audioTrackSize,
 
       handleShiftTab,
+      handleMouseDown,
 
       isSnackbarVisible,
       showSnackbar,


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1799 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
When the audio result in the search results view is clicked to navigate to the single result view, it fires the `mousedown` event, followed by a `focus` event, which activates the snackbar. This PR handles these scenarios by ignoring `focus` events immediately preceded by a `mousedown`.

I'm not sure if this is the most elegant solution, but it handles the case descried in the linked issue and needs to be fixed quickly as it's already been deployed to prod.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

0. Follow the steps to reproduce from #1799.
1. Fail to reproduce it on this branch.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
