### PR TITLE
Fix `use-media-query` composable

### DIFF
--- a/src/components/VHeaderOld/VHeaderOld.vue
+++ b/src/components/VHeaderOld/VHeaderOld.vue
@@ -52,14 +52,12 @@ import {
   computed,
   defineComponent,
   inject,
-  provide,
   ref,
   useContext,
   useRouter,
 } from '@nuxtjs/composition-api'
 
 import { ALL_MEDIA, searchPath } from '~/constants/media'
-import { isMinScreen } from '~/composables/use-media-query'
 import { useMatchSearchRoutes } from '~/composables/use-match-routes'
 import { useI18n } from '~/composables/use-i18n'
 import { useI18nResultsCount } from '~/composables/use-i18n-utilities'
@@ -97,9 +95,8 @@ export default defineComponent({
     const { matches: isSearchRoute } = useMatchSearchRoutes()
 
     const isHeaderScrolled = inject('isHeaderScrolled', false)
-    const isMinScreenMd = isMinScreen('md', { shouldPassInSSR: true })
+    const isMinScreenMd = inject('isMinScreenMd', { shouldPassInSSR: false })
     const headerHasTwoRows = inject('headerHasTwoRows')
-    provide('isMinScreenMd', isMinScreenMd)
 
     const menuModalRef = ref(null)
 

--- a/src/composables/use-media-query.ts
+++ b/src/composables/use-media-query.ts
@@ -46,11 +46,18 @@ export function useMediaQuery(
     }
     // This is already checked in `isSupported`, but TS doesn't know that
     if (!window) return
+
     cleanup()
-    if (!mediaQuery) {
-      mediaQuery = window.matchMedia(query)
+
+    mediaQuery = window.matchMedia(query)
+    matches.value = mediaQuery.matches
+
+    if ('addEventListener' in mediaQuery) {
+      mediaQuery.addEventListener('change', update)
+    } else {
+      // @ts-expect-error deprecated API
+      mediaQuery.addListener(update)
     }
-    matches.value = mediaQuery?.matches
   }
 
   watchEffect(update)

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -34,11 +34,7 @@ import { isMinScreen } from '~/composables/use-media-query'
 import { useFilterSidebarVisibility } from '~/composables/use-filter-sidebar-visibility'
 import { useFeatureFlagStore } from '~/stores/feature-flag'
 
-import {
-  IsHeaderScrolledKey,
-  IsMinScreenLgKey,
-  IsMinScreenMdKey,
-} from '~/types/provides'
+import { IsMinScreenLgKey, IsMinScreenMdKey } from '~/types/provides'
 
 import VMigrationNotice from '~/components/VMigrationNotice.vue'
 import VTranslationStatusBanner from '~/components/VTranslationStatusBanner.vue'
@@ -86,7 +82,7 @@ const embeddedPage = {
     })
     const showScrollButton = computed(() => scrollY.value > 70)
 
-    provide(IsHeaderScrolledKey, isHeaderScrolled)
+    provide('isHeaderScrolled', isHeaderScrolled)
     provide('showScrollButton', showScrollButton)
     // TODO: remove the untyped `isMinScreenMd` provide after the new header is enabled.
     provide('isMinScreenMd', isMinScreenMd)

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -9,7 +9,10 @@
     </div>
     <main
       class="main embedded w-screen md:w-full"
-      :class="{ 'has-sidebar': isSidebarVisible }"
+      :class="[
+        { 'has-sidebar': isSidebarVisible },
+        isNewHeaderEnabled ? 'new-layout' : 'old-layout',
+      ]"
     >
       <Nuxt class="main-page min-w-0" />
       <VSidebarTarget
@@ -30,6 +33,12 @@ import { useMatchSearchRoutes } from '~/composables/use-match-routes'
 import { isMinScreen } from '~/composables/use-media-query'
 import { useFilterSidebarVisibility } from '~/composables/use-filter-sidebar-visibility'
 import { useFeatureFlagStore } from '~/stores/feature-flag'
+
+import {
+  IsHeaderScrolledKey,
+  IsMinScreenLgKey,
+  IsMinScreenMdKey,
+} from '~/types/provides'
 
 import VMigrationNotice from '~/components/VMigrationNotice.vue'
 import VTranslationStatusBanner from '~/components/VTranslationStatusBanner.vue'
@@ -55,13 +64,20 @@ const embeddedPage = {
     return this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true })
   },
   setup() {
+    const featureFlagStore = useFeatureFlagStore()
+    const isNewHeaderEnabled = featureFlagStore.isOn('new_header')
+
     const { isVisible: isFilterVisible } = useFilterSidebarVisibility()
     const { matches: isSearchRoute } = useMatchSearchRoutes()
-    const isMinScreenMd = isMinScreen('md')
 
-    const isSidebarVisible = computed(
-      () => isSearchRoute.value && isMinScreenMd.value && isFilterVisible.value
-    )
+    const isMinScreenMd = isMinScreen('md')
+    const isMinScreenLg = isMinScreen('lg')
+
+    const isSidebarVisible = computed(() => {
+      return isNewHeaderEnabled
+        ? isSearchRoute.value && isMinScreenMd.value && isFilterVisible.value
+        : isSearchRoute.value && isMinScreenLg.value && isFilterVisible.value
+    })
 
     const isHeaderScrolled = ref(false)
     const { isScrolled: isMainContentScrolled, y: scrollY } = useWindowScroll()
@@ -70,17 +86,19 @@ const embeddedPage = {
     })
     const showScrollButton = computed(() => scrollY.value > 70)
 
-    provide('isHeaderScrolled', isHeaderScrolled)
+    provide(IsHeaderScrolledKey, isHeaderScrolled)
     provide('showScrollButton', showScrollButton)
+    // TODO: remove the untyped `isMinScreenMd` provide after the new header is enabled.
+    provide('isMinScreenMd', isMinScreenMd)
+    provide(IsMinScreenMdKey, isMinScreenMd)
+    provide(IsMinScreenLgKey, isMinScreenLg)
 
+    // TODO: remove `headerHasTwoRows` provide after the new header is enabled.
     const headerHasTwoRows = computed(
       () =>
         isSearchRoute.value && !isHeaderScrolled.value && !isMinScreenMd.value
     )
     provide('headerHasTwoRows', headerHasTwoRows)
-
-    const featureFlagStore = useFeatureFlagStore()
-    const isNewHeaderEnabled = featureFlagStore.isOn('new_header')
 
     return {
       isHeaderScrolled,
@@ -107,20 +125,37 @@ export default embeddedPage
 .app {
   grid-template-rows: auto 1fr;
 }
-
+/* TODO: remove these styles when new header is enabled */
 @screen md {
   /** Display the search filter sidebar and results as independently-scrolling. **/
-  .main {
+  .main.old-layout {
     height: 100%;
     display: grid;
     grid-template-columns: 1fr var(--filter-sidebar-width);
   }
   /** Make the main content area span both grid columns when the sidebar is closed... **/
-  .main > *:first-child {
+  .main.old-layout > *:first-child {
     grid-column: span 2;
   }
   /** ...and only one column when it is visible. **/
-  .main.has-sidebar > *:first-child {
+  .main.old-layout.has-sidebar > *:first-child {
+    grid-column: 1;
+  }
+}
+/* TODO: remove the new-layout class when new header is enabled */
+@screen lg {
+  /** Display the search filter sidebar and results as independently-scrolling. **/
+  .main.new-layout {
+    height: 100%;
+    display: grid;
+    grid-template-columns: 1fr var(--filter-sidebar-width);
+  }
+  /** Make the main content area span both grid columns when the sidebar is closed... **/
+  .main.new-layout > *:first-child {
+    grid-column: span 2;
+  }
+  /** ...and only one column when it is visible. **/
+  .main.new-layout.has-sidebar > *:first-child {
     grid-column: 1;
   }
 }

--- a/src/types/provides.ts
+++ b/src/types/provides.ts
@@ -1,0 +1,5 @@
+import type { InjectionKey, Ref } from '@nuxtjs/composition-api'
+
+export const IsMinScreenMdKey = Symbol() as InjectionKey<Ref<boolean>>
+export const IsMinScreenLgKey = Symbol() as InjectionKey<Ref<boolean>>
+export const IsHeaderScrolledKey = Symbol() as InjectionKey<Ref<boolean>>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1819 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR re-adds the `addEventListener` to `use-media-query` composable.

It also adds the typed `provide` keys for `isMinScreenMd` and `isMinScreenLg` that will be used in the new header, and updates the `default` layout classes to use `lg` breakpoint when the `new_header` flag is On.

## Testing instructions
There are several components that depend on `isMinScreenMd` value being updated. You can check that it is actually updated, for example, using the `RelatedAudios`:
If you go to https://search-staging.openverse.engineering/audio/2ecd5631-c48c-4a5f-89c4-83c44dbbd365 and narrow the screen, you will see that the related audios are not updated to use the `VAudioTrack` components used in smaller screens.
On this branch, the `VAudioTrack` should change (because the value of `isMinScreenMd` actually changes).

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
