### PR TITLE
Add a click handler to VLink if it uses NuxtLink

### DIFF
--- a/src/components/VLink.vue
+++ b/src/components/VLink.vue
@@ -1,7 +1,27 @@
+<!-- eslint-disable vue/no-restricted-syntax -->
 <template>
-  <Component
-    :is="linkComponent"
-    v-bind="linkProperties"
+  <NuxtLink
+    v-if="linkComponent === 'NuxtLink'"
+    v-bind="$attrs"
+    :class="{ 'inline-flex flex-row items-center gap-2': showExternalIcon }"
+    :to="linkTo"
+    v-on="$listeners"
+    @click.native="$emit('click', $event)"
+  >
+    <slot /><VIcon
+      v-if="showExternalIcon && !isInternal"
+      :icon-path="externalLinkIcon"
+      class="inline-block"
+      :size="4"
+      rtl-flip
+    />
+  </NuxtLink>
+  <a
+    v-else-if="linkComponent === 'a'"
+    v-bind="$attrs"
+    :href="href"
+    target="_blank"
+    rel="noopener noreferrer"
     :class="{ 'inline-flex flex-row items-center gap-2': showExternalIcon }"
     v-on="$listeners"
   >
@@ -12,7 +32,20 @@
       :size="4"
       rtl-flip
     />
-  </Component>
+  </a>
+  <span
+    v-else
+    v-bind="$attrs"
+    :class="{ 'inline-flex flex-row items-center gap-2': showExternalIcon }"
+  >
+    <slot /><VIcon
+      v-if="showExternalIcon && !isInternal"
+      :icon-path="externalLinkIcon"
+      class="inline-block"
+      :size="4"
+      rtl-flip
+    />
+  </span>
 </template>
 
 <script lang="ts">
@@ -31,14 +64,10 @@ import VIcon from '~/components/VIcon/VIcon.vue'
 
 import externalLinkIcon from '~/assets/icons/external-link.svg'
 
-const defaultProps = Object.freeze({
-  target: '_blank',
-  rel: 'noopener noreferrer',
-})
-
 export default defineComponent({
   name: 'VLink',
   components: { VIcon },
+  inheritAttrs: false,
   props: {
     href: {
       type: String,
@@ -71,15 +100,18 @@ export default defineComponent({
       hasHref.value ? (isInternal.value ? 'NuxtLink' : 'a') : 'span'
     )
 
-    let linkProperties = computed(() =>
-      checkHref(props)
-        ? isInternal.value
-          ? { to: app?.localePath(props.href) ?? props.href }
-          : { ...defaultProps, href: props.href }
+    let linkTo = computed(() =>
+      checkHref(props) && isInternal.value
+        ? app?.localePath(props.href) ?? props.href
         : null
     )
 
-    return { linkProperties, linkComponent, isInternal, externalLinkIcon }
+    return {
+      linkTo,
+      linkComponent,
+      isInternal,
+      externalLinkIcon,
+    }
   },
 })
 </script>

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -13,6 +13,14 @@ Vue.config.productionTip = false
 Vue.config.devtools = false
 Vue.use(VueI18n)
 
+/**
+ * Simplified mock of a NuxtLink component.
+ */
+config.stubs['nuxt-link'] = Vue.component('NuxtLink', {
+  props: ['to'],
+  template: '<a :href="to" v-on="$listeners"><slot /></a>',
+})
+
 config.mocks.$t = (key) => key
 config.mocks.localePath = (i) => i
 global.matchMedia =

--- a/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -74,7 +74,6 @@ const configureVue = (vue) => {
 
 const stubs = {
   VPlayPause: true,
-  NuxtLink: true,
   VLicense: true,
   VWaveform: true,
 }

--- a/test/unit/specs/components/image-grid.spec.js
+++ b/test/unit/specs/components/image-grid.spec.js
@@ -39,7 +39,7 @@ describe('VImageGrid', () => {
       localVue,
       pinia,
       props: propsData,
-      stubs: ['NuxtLink', 'VLicense'],
+      stubs: ['VLicense'],
       mocks: { $nuxt: { context: { i18n } } },
     }
   })

--- a/test/unit/specs/components/related-images.spec.js
+++ b/test/unit/specs/components/related-images.spec.js
@@ -31,7 +31,7 @@ describe('RelatedImage', () => {
       localVue,
       pinia,
       propsData: props,
-      stubs: ['VLicense', 'NuxtLink'],
+      stubs: ['VLicense'],
       mocks: { $nuxt: { context: { i18n } } },
     }
   })

--- a/test/unit/specs/components/v-content-link.spec.js
+++ b/test/unit/specs/components/v-content-link.spec.js
@@ -17,7 +17,6 @@ describe('VContentLink', () => {
   beforeEach(() => {
     options = {
       props: { mediaType: 'image', resultsCount: 123, to: '/images' },
-      stubs: ['NuxtLink'],
       mocks: {
         $nuxt: {
           context: {
@@ -32,8 +31,7 @@ describe('VContentLink', () => {
     render(VContentLink, options)
     const btn = screen.getByRole('link')
 
-    /**  @todo: Mock NuxtLink and check for href instead.  **/
-    expect(btn).toHaveAttribute('to')
+    expect(btn).toHaveAttribute('href')
     expect(btn).not.toHaveAttribute('aria-disabled')
   })
 
@@ -42,8 +40,7 @@ describe('VContentLink', () => {
     render(VContentLink, options)
     const btn = screen.getByRole('link')
 
-    /**  @todo: Mock NuxtLink and check for href instead.  **/
-    expect(btn).not.toHaveAttribute('to')
+    expect(btn).not.toHaveAttribute('href')
     expect(btn).toHaveAttribute('aria-disabled')
     expect(btn.getAttribute('aria-disabled')).toBeTruthy()
   })

--- a/test/unit/specs/components/v-link.spec.js
+++ b/test/unit/specs/components/v-link.spec.js
@@ -6,14 +6,6 @@ import VLink from '~/components/VLink.vue'
 const nuxtContextMock = {
   $nuxt: { context: { app: { localePath: jest.fn((v) => v) } } },
 }
-/**
- * Simplified mock of a NuxtLink component.
- */
-// eslint-disable-next-line vue/one-component-per-file
-const NuxtLink = Vue.component('NuxtLink', {
-  props: ['to'],
-  template: '<a :href="to" v-on="$listeners"><slot /></a>',
-})
 
 describe('VLink', () => {
   it.each`
@@ -23,17 +15,11 @@ describe('VLink', () => {
   `(
     'Creates a correct link component based on href',
     ({ href, target, rel }) => {
-      render(
-        VLink,
-        {
-          props: { href },
-          slots: { default: 'Code is Poetry' },
-          mocks: nuxtContextMock,
-        },
-        (localVue) => {
-          localVue.component('NuxtLink', NuxtLink)
-        }
-      )
+      render(VLink, {
+        props: { href },
+        slots: { default: 'Code is Poetry' },
+        mocks: nuxtContextMock,
+      })
       const link = screen.getByRole('link')
       const expectedHref = href.startsWith('/')
         ? `http://localhost${href}`
@@ -62,7 +48,6 @@ describe('VLink', () => {
       })
     const WrapperComponent = createVLinkWrapper(href)
     render(WrapperComponent, { mocks: nuxtContextMock }, (localVue) => {
-      localVue.component('NuxtLink', NuxtLink)
       localVue.component('VLink', VLink)
     })
     const linkBefore = await screen.getByRole('link')

--- a/test/unit/specs/components/v-modal.spec.js
+++ b/test/unit/specs/components/v-modal.spec.js
@@ -64,7 +64,6 @@ describe('VModal', () => {
   beforeEach(() => {
     options = {
       props: { useCustomInitialFocus: false },
-      stubs: ['NuxtLink'],
     }
     jest.resetAllMocks()
   })


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1828 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR replaces the conditional component (`component :is="<>"`) in `VLink` with one of three components with `v-if`/`v-else-if`/`v-else` to make it possible to use `@click.native` with `NuxtLink`. The component looks much more verbose now, but the functionality is improved. 
This PR also adds a common mocking for `NuxtLink` in unit tests.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
All the links in the app should work as normal. You can also see these changes in #1825: the click handler for an internal link in the mobile modal closes the modal using a `click` handler. It wouldn't work without these changes: the click event is not passed to the parent component from a `VLink` that is a `NuxtLink` (internal link).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
