### PR TITLE
Allow setting feature flags using query params

### DIFF
--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -45,5 +45,6 @@ const middleware: Middleware = async ({ app, query, route, $pinia }) => {
 
   const featureFlagStore = useFeatureFlagStore($pinia)
   featureFlagStore.initFromCookies(app.$cookies.get('features') ?? {})
+  featureFlagStore.initFromQuery(query)
 }
 export default middleware

--- a/src/stores/feature-flag.ts
+++ b/src/stores/feature-flag.ts
@@ -16,6 +16,8 @@ import {
 } from '~/constants/feature-flag'
 import { LOCAL, DEPLOY_ENVS, DeployEnv } from '~/constants/deploy-env'
 
+import type { Dictionary } from 'vue-router/types/router'
+
 type FlagName = keyof typeof featureData['features']
 export interface FeatureFlagState {
   flags: Record<FlagName, FeatureFlag>
@@ -103,6 +105,9 @@ export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
      * Given a list of key value pairs of flags and their preferred states,
      * populate the store state to match the cookie.
      *
+     * Values stored in the cookie are stored across sessions and can be
+     * modified using the '/preferences' page.
+     *
      * @param cookies - mapping of feature flags and their preferred states
      */
     initFromCookies(cookies: Record<string, FeatureState>) {
@@ -110,6 +115,38 @@ export const useFeatureFlagStore = defineStore(FEATURE_FLAG, {
         if (getFlagStatus(flag) === SWITCHABLE)
           flag.preferredState = cookies[name]
       })
+    },
+    /**
+     * Set the value of flag entries from the query parameters. Only those
+     * query parameters that contain the 'ff_' prefix are considered.
+     *
+     * Values set using query params are per-session, and will not affect the
+     * value stored in the cookie.
+     *
+     * @param query - values for the feature flags
+     */
+    initFromQuery(query: Dictionary<string | (string | null)[]>) {
+      const isValidName = (name: string): name is `ff_${FlagName}` =>
+        name.startsWith('ff_') && name.replace('ff_', '') in this.flags
+      const isValidValue = (
+        value: string | (string | null)[]
+      ): value is FeatureState =>
+        typeof value === 'string' && ['on', 'off'].includes(value)
+      const isValidEntry = (
+        entry: [string, string | (string | null)[]]
+      ): entry is [`ff_${FlagName}`, FeatureState] =>
+        isValidName(entry[0]) && isValidValue(entry[1])
+
+      Object.entries(query)
+        .filter(isValidEntry)
+        .forEach(([name, state]) => {
+          // TODO: type `FlagName` should be inferred by TS
+          const flagName = name.substring(3) as FlagName
+          const flag = this.flags[flagName]
+          if (getFlagStatus(flag) === SWITCHABLE) {
+            flag.preferredState = state
+          }
+        })
     },
     /**
      * Toggle the feature flag of the given name to the given preferred state.

--- a/test/unit/specs/stores/feature-flag-store.spec.js
+++ b/test/unit/specs/stores/feature-flag-store.spec.js
@@ -103,6 +103,22 @@ describe('Feature flag store', () => {
   )
 
   it.each`
+    flagName           | queryState | finalState
+    ${'feat_disabled'} | ${'on'}    | ${'off'}
+    ${'feat_enabled'}  | ${'off'}   | ${'on'}
+  `(
+    'does not cascade non-switchable flags from query params',
+    ({ flagName, queryState, finalState }) => {
+      const featureFlagStore = useFeatureFlagStore()
+      featureFlagStore.initFromQuery({
+        [`ff_${flagName}`]: queryState,
+      })
+
+      expect(featureFlagStore.featureState(flagName)).toEqual(finalState)
+    }
+  )
+
+  it.each`
     environment     | featureState
     ${'local'}      | ${'on'}
     ${'staging'}    | ${'off'}

--- a/test/unit/specs/stores/feature-flag-store.spec.js
+++ b/test/unit/specs/stores/feature-flag-store.spec.js
@@ -83,6 +83,26 @@ describe('Feature flag store', () => {
   )
 
   it.each`
+    cookieState | queryState | finalState
+    ${'off'}    | ${'on'}    | ${'on'}
+    ${'on'}     | ${'off'}   | ${'off'}
+  `(
+    'cascades flag from cookies and query params',
+    ({ cookieState, queryState, finalState }) => {
+      const flagName = 'feat_switchable_optout'
+      const featureFlagStore = useFeatureFlagStore()
+      featureFlagStore.initFromCookies({
+        [flagName]: cookieState,
+      })
+      featureFlagStore.initFromQuery({
+        [`ff_${flagName}`]: queryState,
+      })
+
+      expect(featureFlagStore.featureState(flagName)).toEqual(finalState)
+    }
+  )
+
+  it.each`
     environment     | featureState
     ${'local'}      | ${'on'}
     ${'staging'}    | ${'off'}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1837 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR allows feature flags to be toggled (when set to switchable) using 'ff_' prefixed query params.

## Behaviour
The intended behaviour of the query param is to be be a one-time override to the value set in the cookie. After the query param is dropped and the page is refreshed, the flag will be reset to the value stored in the cookie.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the PR and run the dev server.
1. Visit the preferences page and set the 'new_header' flag to off.
2. Navigate around the site and see that the new header and footer are not shown.
3. Add the query param `?ff_new_header=on` to the URL. This time the footer will appear as will remain visible as long as you navigate the site.
4. On the next reload (<kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>R</kbd>) without the param, the header and footer will disappear.
5. Visit the preferences page and set the 'new_header' flag to on.
6. Navigate around the site and see that the new header and footer are shown.
7. Add the query param `?ff_new_header=off` to the URL. This time the footer will disappear and will remain hidden as long as you navigate the site.
8. On the next reload (<kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>R</kbd>) without the param, the header and footer will reappear.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
