### PR TITLE
Remove ignore scripts (nuxt requires it)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,12 @@ RUN pnpm fetch
 # copy the rest of the content
 COPY --chown=node:node . /home/node/app
 
+# Prevent pre-commit from being installed, we don't need it here and it fails to install anyway
+ENV SKIP_PRE_COMMIT=true
+
 # `--ignore-scripts` prevents the `prepare` script from running. This avoids
 # installation of pre-commit inside the container.
-RUN pnpm install -r --offline --ignore-scripts
+RUN pnpm install -r --offline
 
 # disable telemetry when building the app
 ENV NUXT_TELEMETRY_DISABLED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ COPY --chown=node:node . /home/node/app
 # Prevent pre-commit from being installed, we don't need it here and it fails to install anyway
 ENV SKIP_PRE_COMMIT=true
 
-# `--ignore-scripts` prevents the `prepare` script from running. This avoids
-# installation of pre-commit inside the container.
 RUN pnpm install -r --offline
 
 # disable telemetry when building the app

--- a/bin/install-pre-commit.sh
+++ b/bin/install-pre-commit.sh
@@ -1,8 +1,8 @@
-#! /usr/bin/env bash
+#! /usr/bin/env sh
 
 set -e
 
-if [[ -z "$SKIP_PRE_COMMIT" ]]
+if [ -z "$SKIP_PRE_COMMIT" ]
 then
   echo "installing pre-commit"
   pnpm pc:download && pnpm pc:install

--- a/bin/install-pre-commit.sh
+++ b/bin/install-pre-commit.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+set -e
+
+if [[ -z "$SKIP_PRE_COMMIT" ]]
+then
+  echo "installing pre-commit"
+  pnpm pc:download && pnpm pc:install
+else
+  echo "skipping pre-commit installation"
+fi

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "sebworks",
   "private": true,
   "scripts": {
-    "prepare": "pnpm pc:download && pnpm pc:install",
+    "prepare": "./bin/install-pre-commit.sh",
     "predev": "pnpm install && pnpm i18n:no-get",
     "dev": "pnpm dev:only",
     "dev:only": "nuxt --hostname 0.0.0.0",


### PR DESCRIPTION
Add another facility to skip the pre-commit installation in environments that do not need it

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes the staging builds failing

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
We added `--ignore-scripts` so that `prepare` would be skipped inside Docker. Nuxt and some other dependencies need those scary post-installation, apparently, to make things work so we can't skip `prepare` in that way. I've added a different facility for skipping the pre-commit installation in Docker.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
```
docker build . --build-arg API_URL=https://api.openverse.engineering/ --build-arg RELEASE=v0-test -t openverse-frontend:latest

docker run -p 8443:8443/tcp  openverse-frontend:latest
```

And then make a request to the local server. Before this PR it will fail on an error about reading `use` of undefined. After this PR it will work.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
