### PR TITLE
Close the recent searches on Shift+Tab

### DIFF
--- a/src/components/VHeader/VSearchBar/VSearchBar.vue
+++ b/src/components/VHeader/VSearchBar/VSearchBar.vue
@@ -211,6 +211,11 @@ export default defineComponent({
         // If a recent search is selected, populate its value into the input.
         modelMedium.value = entries.value[selectedIdx.value]
 
+      // Hide the recent searches popover when the user presses shift+tab on the input.
+      if (key === keycodes.Tab && event.shiftKey) {
+        handleBlur()
+      }
+
       if (([keycodes.Escape, keycodes.Enter] as string[]).includes(key))
         // Hide the recent searches.
         isRecentVisible.value = false

--- a/src/components/VHeader/VSearchBar/VSearchBar.vue
+++ b/src/components/VHeader/VSearchBar/VSearchBar.vue
@@ -32,7 +32,7 @@
         :aria-activedescendant="
           selectedIdx !== undefined ? `option-${selectedIdx}` : undefined
         "
-        @focus="handleFocus"
+        @focus="showRecentSearches"
         @keydown="handleKeydown"
       >
         <!-- @slot Extra information such as loading message or result count goes here. -->
@@ -54,7 +54,7 @@
         :class="recentClasses"
         @select="handleSelect"
         @clear="handleClear"
-        @keydown.tab.native="handleBlur"
+        @keydown.tab.native="hideRecentSearches"
       />
     </ClientOnly>
   </div>
@@ -141,18 +141,6 @@ export default defineComponent({
       emit('submit')
     }
 
-    /* Focus */
-    const handleFocus = () => {
-      isRecentVisible.value = true
-    }
-    const handleBlur = () => {
-      isRecentVisible.value = false
-    }
-    const handleSearchBlur = () => {
-      if (!entries.value.length) handleBlur()
-    }
-    onClickOutside(searchBarEl, handleBlur)
-
     /* Recent searches */
     const featureFlagStore = useFeatureFlagStore()
     const isNewHeaderEnabled = featureFlagStore.isOn('new_header')
@@ -170,6 +158,24 @@ export default defineComponent({
       } as const
       return FIELD_OFFSETS[props.size]
     })
+
+    /**
+     * Show and hide recent searches.
+     */
+    const showRecentSearches = () => {
+      isRecentVisible.value = true
+    }
+    const hideRecentSearches = () => {
+      isRecentVisible.value = false
+    }
+    /**
+     * Hide recent searches on blur and click outside.
+     */
+    const handleSearchBlur = () => {
+      if (!entries.value.length) hideRecentSearches()
+    }
+    onClickOutside(searchBarEl, hideRecentSearches)
+
     /**
      * Refers to the current suggestion that has visual focus (not DOM focus)
      * and is the active descendant. This should be set to `undefined` when the
@@ -213,12 +219,12 @@ export default defineComponent({
 
       // Hide the recent searches popover when the user presses shift+tab on the input.
       if (key === keycodes.Tab && event.shiftKey) {
-        handleBlur()
+        hideRecentSearches()
       }
 
       if (([keycodes.Escape, keycodes.Enter] as string[]).includes(key))
         // Hide the recent searches.
-        isRecentVisible.value = false
+        hideRecentSearches()
 
       selectedIdx.value = undefined // Lose visual focus from entries.
     }
@@ -252,8 +258,8 @@ export default defineComponent({
       route,
       modelMedium,
 
-      handleFocus,
-      handleBlur,
+      showRecentSearches,
+      hideRecentSearches,
       handleSearchBlur,
 
       isNewHeaderEnabled,

--- a/src/components/VHeader/VSearchBar/VSearchBar.vue
+++ b/src/components/VHeader/VSearchBar/VSearchBar.vue
@@ -188,8 +188,7 @@ export default defineComponent({
       event.preventDefault() // Prevent the cursor from moving horizontally.
       const { key, altKey } = event
 
-      // Show the recent searches.
-      isRecentVisible.value = true
+      showRecentSearches()
       if (altKey) return
 
       // Shift selection (if Alt was not pressed with arrow keys)
@@ -217,14 +216,13 @@ export default defineComponent({
         // If a recent search is selected, populate its value into the input.
         modelMedium.value = entries.value[selectedIdx.value]
 
-      // Hide the recent searches popover when the user presses shift+tab on the input.
-      if (key === keycodes.Tab && event.shiftKey) {
+      // Hide the recent searches popover when the user presses Enter, Escape or Shift+Tab on the input.
+      if (
+        (key === keycodes.Tab && event.shiftKey) ||
+        ([keycodes.Escape, keycodes.Enter] as string[]).includes(key)
+      ) {
         hideRecentSearches()
       }
-
-      if (([keycodes.Escape, keycodes.Enter] as string[]).includes(key))
-        // Hide the recent searches.
-        hideRecentSearches()
 
       selectedIdx.value = undefined // Lose visual focus from entries.
     }
@@ -240,7 +238,7 @@ export default defineComponent({
     const handleSelect = (idx: number) => {
       modelMedium.value = entries.value[idx]
 
-      isRecentVisible.value = false
+      hideRecentSearches()
       selectedIdx.value = undefined // Lose visual focus from entries.
       handleSearch() // Immediately execute the search manually.
     }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1886 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This is a follow up for [1889](https://github.com/WordPress/openverse-frontend/pull/1889) to close the Recent searches popover when pressing <kbd>Shift</kbd>+<kbd>Tab</kbd> while inside the input (when you get to the Openverse logo).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
On main, when you press <kbd>Shift</kbd>+<kbd>Tab</kbd> while inside the search input, you focus the Openverse logo, but the Recent searches popover stays open. Here, it should close.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
