### PR TITLE
Improve filter sidebar rendering performance

### DIFF
--- a/src/components/VHeader/VHeaderDesktop.vue
+++ b/src/components/VHeader/VHeaderDesktop.vue
@@ -44,9 +44,6 @@
       @toggle="toggleSidebar"
       @tab="onTab"
     />
-    <VTeleport v-if="sidebarVisibleRef" to="sidebar">
-      <VSearchGridFilter class="px-10 pt-8 pb-10" @close="toggleSidebar" />
-    </VTeleport>
   </header>
 </template>
 <script lang="ts">
@@ -60,8 +57,6 @@ import {
   useRouter,
   watch,
 } from '@nuxtjs/composition-api'
-
-import { Portal as VTeleport } from 'portal-vue'
 
 import { useMediaStore } from '~/stores/media'
 import { isSearchTypeSupported, useSearchStore } from '~/stores/search'
@@ -85,7 +80,6 @@ import VFilterButton from '~/components/VHeader/VFilterButton.vue'
 import VSearchBar from '~/components/VHeader/VSearchBar/VSearchBar.vue'
 import VLogoButton from '~/components/VHeader/VLogoButton.vue'
 import VSearchBarButton from '~/components/VHeader/VHeaderMobile/VSearchBarButton.vue'
-import VSearchGridFilter from '~/components/VFilters/VSearchGridFilter.vue'
 import VSearchTypePopover from '~/components/VContentSwitcher/VSearchTypePopover.vue'
 
 import closeIcon from '~/assets/icons/close-small.svg'
@@ -99,10 +93,8 @@ export default defineComponent({
     VFilterButton,
     VLogoButton,
     VSearchBarButton,
-    VSearchGridFilter,
     VSearchTypePopover,
     VSearchBar,
-    VTeleport,
   },
   setup(_, { emit }) {
     const filterButtonRef = ref<InstanceType<typeof VFilterButton> | null>(null)

--- a/src/components/VHeaderOld/VHeaderFilter.vue
+++ b/src/components/VHeaderOld/VHeaderFilter.vue
@@ -14,23 +14,15 @@
       @toggle="onTriggerClick"
       @tab="onTab"
     />
-    <template v-if="visibleRef">
-      <VTeleport v-if="isMinScreenMd" to="sidebar">
-        <VSearchGridFilter class="px-10 pt-8 pb-10" @close="onTriggerClick" />
-      </VTeleport>
-      <VModalContent
-        v-else
-        :hide="close"
-        :visible="true"
-        :trigger-element="triggerElement"
-        :aria-label="$t('header.filter-button.simple')"
-      >
-        <VSearchGridFilter
-          class="px-6 pt-[7px] pb-10"
-          @close="onTriggerClick"
-        />
-      </VModalContent>
-    </template>
+    <VModalContent
+      v-if="visibleRef && !isMinScreenMd"
+      :hide="close"
+      :visible="true"
+      :trigger-element="triggerElement"
+      :aria-label="$t('header.filter-button.simple')"
+    >
+      <VSearchGridFilter class="px-6 pt-[7px] pb-10" @close="onTriggerClick" />
+    </VModalContent>
   </div>
 </template>
 
@@ -44,8 +36,6 @@ import {
   toRef,
   onBeforeUnmount,
 } from '@nuxtjs/composition-api'
-
-import { Portal as VTeleport } from 'portal-vue'
 
 import { useBodyScrollLock } from '~/composables/use-body-scroll-lock'
 import { useFilterSidebarVisibility } from '~/composables/use-filter-sidebar-visibility'
@@ -68,7 +58,6 @@ export default defineComponent({
     VFilterButtonOld,
     VModalContent,
     VSearchGridFilter,
-    VTeleport,
   },
   props: {
     disabled: {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -30,17 +30,20 @@
       </div>
       <Nuxt v-else class="main-page min-w-0" />
 
-      <VSidebarTarget
+      <aside
+        v-if="isSidebarVisible"
         class="sidebar fixed z-10 overflow-y-auto bg-dark-charcoal-06 end-0"
         :class="{ 'border-dark-charcoal-20 border-s': isSidebarVisible }"
-      />
+      >
+        <VSearchGridFilter class="px-10 pt-1" @close="closeSidebar" />
+      </aside>
     </main>
 
     <VModalTarget class="modal" />
     <VGlobalAudioSection />
   </div>
 </template>
-<script>
+<script lang="ts">
 import {
   computed,
   onMounted,
@@ -69,9 +72,9 @@ import VMigrationNotice from '~/components/VMigrationNotice.vue'
 import VTranslationStatusBanner from '~/components/VTranslationStatusBanner.vue'
 import VHeaderOld from '~/components/VHeaderOld/VHeaderOld.vue'
 import VModalTarget from '~/components/VModal/VModalTarget.vue'
-import VSidebarTarget from '~/components/VModal/VSidebarTarget.vue'
 import VGlobalAudioSection from '~/components/VGlobalAudioSection/VGlobalAudioSection.vue'
 import VFooter from '~/components/VFooter/VFooter.vue'
+import VSearchGridFilter from '~/components/VFilters/VSearchGridFilter.vue'
 
 const embeddedPage = {
   name: 'embedded',
@@ -86,8 +89,8 @@ const embeddedPage = {
     VFooter,
     VModalTarget,
     VTeleportTarget,
-    VSidebarTarget,
     VGlobalAudioSection,
+    VSearchGridFilter,
   },
   layout: 'embedded',
   head() {
@@ -99,7 +102,8 @@ const embeddedPage = {
       featureFlagStore.isOn('new_header')
     )
 
-    const { isVisible: isFilterVisible } = useFilterSidebarVisibility()
+    const { isVisible: isFilterVisible, setVisibility } =
+      useFilterSidebarVisibility()
     const { matches: isSearchRoute } = useMatchSearchRoutes()
     const { matches: isSingleResultRoute } = useMatchSingleResultRoutes()
     const isSearchHeader = computed(
@@ -134,6 +138,10 @@ const embeddedPage = {
         : isSearchRoute.value && isMinScreenMd.value && isFilterVisible.value
     })
 
+    const closeSidebar = () => {
+      setVisibility(false)
+    }
+
     const isHeaderScrolled = ref(false)
     const { isScrolled: isMainContentScrolled, y: scrollY } = useWindowScroll()
     watch([isMainContentScrolled], ([isMainContentScrolled]) => {
@@ -165,6 +173,7 @@ const embeddedPage = {
       isSearchHeader,
       headerHasTwoRows,
       isNewHeaderEnabled,
+      closeSidebar,
     }
   },
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #1958 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR removes the sidebar `Teleport` to improve the rendering of the desktop filters. Instead, the `VSearchGridFilter` used for the desktop filters sidebar is rendered in `default.vue` layout.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
