### PR TITLE
Prevent obstruction of audio player controls

### DIFF
--- a/src/components/VGlobalAudioSection/VGlobalAudioSection.vue
+++ b/src/components/VGlobalAudioSection/VGlobalAudioSection.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="global-audio sticky bottom-0 sm:hidden">
+  <div class="global-audio sticky bottom-0 z-global-audio sm:hidden">
     <VGlobalAudioTrack v-if="audio" :audio="audio" />
     <VIconButton
       v-if="audio"
-      class="absolute top-0 z-20 border-none ltr:right-0 rtl:left-0"
+      class="absolute top-0 z-10 border-none ltr:right-0 rtl:left-0"
       size="large"
       :icon-props="{ iconPath: icons.closeIcon }"
       @click="handleClose"

--- a/src/components/VSnackbar.vue
+++ b/src/components/VSnackbar.vue
@@ -38,7 +38,7 @@ export default defineComponent({
 <style module>
 .snackbar {
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.3);
-  @apply fixed bottom-4 z-10 rounded-sm bg-black text-white transition-[opacity,transform] duration-500 ltr:left-4 rtl:right-4 motion-reduce:transition-opacity;
+  @apply fixed bottom-4 z-snackbar rounded-sm bg-black text-white transition-[opacity,transform] duration-500 ltr:left-4 rtl:right-4 motion-reduce:transition-opacity;
 }
 
 .large {

--- a/src/constants/z-indices.js
+++ b/src/constants/z-indices.js
@@ -17,6 +17,8 @@ const Z_INDICES = Object.freeze(
     50: 50,
     // Named indices
     popover: 50,
+    snackbar: 10,
+    'global-audio': 20,
   })
 )
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #2018 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR
- puts the z-index of the global audio player at 20 (starting a new stacking context, so we can reduce the z-index of the &times; to 10)
- reduces the z-index of the snackbar to 10

This prevents the visible/invisible snackbar from overlapping with player controls. The use of clearer z-index names should prevent such issues in the future.

In the long term, adoption of an official system for z-indices (such as Material design's) could be immensely useful.

![image](https://user-images.githubusercontent.com/16580576/204804239-307513c6-2a36-40c0-b0ec-d149dbd1c648.png)
^ https://m2.material.io/design/environment/elevation.html#default-elevations

![image](https://user-images.githubusercontent.com/16580576/204804359-e9763483-7465-4bf6-98eb-8eb5560dfdc6.png)
^ https://m1.material.io/material-design/elevation-shadows.html#elevation-shadows-elevation-android

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Try reproducing the linked bug with the PR checked out. You should fail.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
