### PR TITLE
Set same site to None when `new_header` is off

### DIFF
--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -61,7 +61,11 @@ const middleware: Middleware = async ({
 
   const uiStore = useUiStore($pinia)
   const isMobileUa = $ua ? $ua.isMobile : false
-  $cookies.set('uiIsMobileUa', isMobileUa, cookieOptions)
+  const sameSite = featureFlagStore.isOn('new_header')
+    ? cookieOptions.sameSite
+    : 'none'
+
+  $cookies.set('uiIsMobileUa', isMobileUa, { ...cookieOptions, sameSite })
   uiStore.initFromCookies($cookies.getAll() ?? {})
 }
 export default middleware

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -159,7 +159,7 @@ export const useUiStore = defineStore('ui', {
     },
 
     updateCookies() {
-      const opts = cookieOptions
+      const opts = { ...cookieOptions }
       if (useFeatureFlagStore().isOn('new_header')) {
         opts.sameSite = 'none'
       }

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -64,6 +64,7 @@ export const useUiStore = defineStore('ui', {
     areInstructionsVisible(state): boolean {
       return state.instructionsSnackbarState === 'visible'
     },
+
     desktopBreakpoints(): Breakpoint[] {
       const featureFlagStore = useFeatureFlagStore()
       const isNewHeaderEnabled = computed(() =>
@@ -159,6 +160,10 @@ export const useUiStore = defineStore('ui', {
 
     updateCookies() {
       const opts = cookieOptions
+      if (useFeatureFlagStore().isOn('new_header')) {
+        opts.sameSite = 'none'
+      }
+
       this.$nuxt.$cookies.setAll([
         {
           name: 'uiInstructionsSnackbarState',
@@ -183,7 +188,14 @@ export const useUiStore = defineStore('ui', {
       }
 
       this.breakpoint = breakpoint
-      this.$nuxt.$cookies.set('uiBreakpoint', this.breakpoint, cookieOptions)
+      const sameSite = useFeatureFlagStore().isOn('new_header')
+        ? cookieOptions.sameSite
+        : 'none'
+
+      this.$nuxt.$cookies.set('uiBreakpoint', this.breakpoint, {
+        ...cookieOptions,
+        sameSite,
+      })
       this.isDesktopLayout = this.desktopBreakpoints.includes(breakpoint)
     },
 
@@ -198,11 +210,14 @@ export const useUiStore = defineStore('ui', {
       this.innerFilterVisible = visible
       if (this.isDesktopLayout) {
         this.isFilterDismissed = !visible
-        this.$nuxt.$cookies.set(
-          'uiIsFilterDismissed',
-          this.isFilterDismissed,
-          cookieOptions
-        )
+        const sameSite = useFeatureFlagStore().isOn('new_header')
+          ? cookieOptions.sameSite
+          : 'none'
+
+        this.$nuxt.$cookies.set('uiIsFilterDismissed', this.isFilterDismissed, {
+          ...cookieOptions,
+          sameSite,
+        })
       }
     },
 
@@ -222,11 +237,14 @@ export const useUiStore = defineStore('ui', {
       }
 
       this.dismissedBanners.push(bannerId)
-      this.$nuxt.$cookies.set(
-        'uiDismissedBanners',
-        this.dismissedBanners,
-        cookieOptions
-      )
+      const sameSite = useFeatureFlagStore().isOn('new_header')
+        ? cookieOptions.sameSite
+        : 'none'
+
+      this.$nuxt.$cookies.set('uiDismissedBanners', this.dismissedBanners, {
+        ...cookieOptions,
+        sameSite,
+      })
     },
     isBannerDismissed(bannerId: BannerId) {
       return this.dismissedBanners.includes(bannerId)

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -160,7 +160,7 @@ export const useUiStore = defineStore('ui', {
 
     updateCookies() {
       const opts = { ...cookieOptions }
-      if (useFeatureFlagStore().isOn('new_header')) {
+      if (!useFeatureFlagStore().isOn('new_header')) {
         opts.sameSite = 'none'
       }
 

--- a/test/unit/specs/stores/ui-store.spec.js
+++ b/test/unit/specs/stores/ui-store.spec.js
@@ -31,7 +31,7 @@ const NOT_VISIBLE_AND_NOT_DISMISSED = {
 const cookieOptions = {
   maxAge: 5184000,
   path: '/',
-  sameSite: 'strict',
+  sameSite: 'none',
   secure: false,
 }
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #2029 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR sets the UI cookies' `sameSite` to `None` if the new_header is Off to stop them from being rejected when Openverse is inside the iframe.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
