### PR TITLE
Fix popover not closing on Escape or click outside

### DIFF
--- a/src/components/VModal/VInputModal.vue
+++ b/src/components/VModal/VInputModal.vue
@@ -115,6 +115,7 @@ export default defineComponent({
       autoFocusOnHideRef: ref(false),
       triggerElementRef: ref(null),
       hideOnClickOutsideRef: ref(false),
+      trapFocusRef: ref(true),
       hideRef: ref(close),
       hideOnEscRef: ref(true),
       emit: emit as SetupContext['emit'],

--- a/src/components/VModal/VModalContent.vue
+++ b/src/components/VModal/VModalContent.vue
@@ -117,6 +117,10 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    trapFocus: {
+      type: Boolean,
+      default: true,
+    },
     triggerElement: {
       type: (process.server ? Object : HTMLElement) as PropType<HTMLElement>,
       default: null,
@@ -158,6 +162,7 @@ export default defineComponent({
       visibleRef: propsRefs.visible,
       autoFocusOnShowRef: propsRefs.autoFocusOnShow,
       autoFocusOnHideRef: propsRefs.autoFocusOnHide,
+      trapFocusRef: propsRefs.trapFocus,
       triggerElementRef: propsRefs.triggerElement,
       hideOnClickOutsideRef: propsRefs.hideOnClickOutside,
       hideRef: propsRefs.hide,

--- a/src/composables/use-dialog-content.ts
+++ b/src/composables/use-dialog-content.ts
@@ -11,6 +11,7 @@ type Props = {
   visibleRef: Ref<boolean>
   autoFocusOnShowRef: Ref<boolean>
   autoFocusOnHideRef: Ref<boolean>
+  trapFocusRef: Ref<boolean>
   triggerElementRef: Ref<HTMLElement | null>
   hideOnClickOutsideRef: Ref<boolean>
   hideOnEscRef: Ref<boolean>

--- a/src/composables/use-focus-on-show.ts
+++ b/src/composables/use-focus-on-show.ts
@@ -15,6 +15,7 @@ type Props = {
   dialogRef: Ref<HTMLElement | null>
   visibleRef: Ref<boolean>
   autoFocusOnShowRef: Ref<boolean>
+  trapFocusRef: Ref<boolean>
   initialFocusElementRef?: Ref<HTMLElement | null>
 }
 
@@ -25,16 +26,19 @@ export const useFocusOnShow = ({
   dialogRef,
   visibleRef,
   autoFocusOnShowRef,
+  trapFocusRef,
   initialFocusElementRef = ref(null),
 }: Props) => {
   const { activate: activateFocusTrap, deactivate: deactivateFocusTrap } =
-    useFocusTrap(dialogRef, {
-      // Prevent FocusTrap from trying to focus the first element.
-      // We already do that in a more flexible, adaptive way in our Dialog composables.
-      initialFocus: false,
-      // if set to true, focus-trap prevents the default for the keyboard event, and we cannot handle it in our composables.
-      escapeDeactivates: false,
-    })
+    trapFocusRef.value
+      ? useFocusTrap(dialogRef, {
+          // Prevent FocusTrap from trying to focus the first element.
+          // We already do that in a more flexible, adaptive way in our Dialog composables.
+          initialFocus: false,
+          // if set to true, focus-trap prevents the default for the keyboard event, and we cannot handle it in our composables.
+          escapeDeactivates: false,
+        })
+      : { activate: undefined, deactivate: undefined }
 
   watch(
     [
@@ -45,7 +49,7 @@ export const useFocusOnShow = ({
     ] as const,
     ([dialog, visible, autoFocusOnShow, initialFocusElement]) => {
       if (!dialog || !visible) {
-        deactivateFocusTrap()
+        if (deactivateFocusTrap) deactivateFocusTrap()
         return
       }
       if (!dialog || !visible || !autoFocusOnShow) return
@@ -70,7 +74,7 @@ export const useFocusOnShow = ({
             }
           }
         }
-        activateFocusTrap()
+        if (activateFocusTrap) activateFocusTrap()
       })
     }
   )

--- a/src/composables/use-popover-content.ts
+++ b/src/composables/use-popover-content.ts
@@ -1,3 +1,5 @@
+import { ref } from '@nuxtjs/composition-api'
+
 import { PopoverContentProps, usePopper } from '~/composables/use-popper'
 
 import { useDialogContent } from '~/composables/use-dialog-content'
@@ -21,6 +23,7 @@ export function usePopoverContent({
     visibleRef: popoverPropsRefs.visible,
     autoFocusOnShowRef: popoverPropsRefs.autoFocusOnShow,
     autoFocusOnHideRef: popoverPropsRefs.autoFocusOnHide,
+    trapFocusRef: ref(false),
     triggerElementRef: popoverPropsRefs.triggerElement,
     hideOnClickOutsideRef: popoverPropsRefs.hideOnClickOutside,
     hideRef: popoverPropsRefs.hide,

--- a/test/playwright/e2e/homepage.spec.ts
+++ b/test/playwright/e2e/homepage.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 
 import { mockProviderApis } from '~~/test/playwright/utils/route'
 import {
@@ -24,3 +24,33 @@ for (const searchType of supportedSearchTypes) {
     await expect(page).toHaveURL(expectedUrl)
   })
 }
+
+const popoverIsVisible = async (page: Page) =>
+  await expect(page.locator('.popover-content')).toBeVisible()
+const popoverIsNotVisible = async (page: Page) =>
+  await expect(page.locator('.popover-content')).not.toBeVisible()
+const clickPopoverButton = async (page: Page) =>
+  await page.click('button[aria-label="All content"]')
+
+test('can close the search type popover by clicking outside', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await clickPopoverButton(page)
+  await popoverIsVisible(page)
+
+  await page.mouse.click(1, 1)
+  await popoverIsNotVisible(page)
+})
+
+test('can close the search type popover by pressing Escape', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await clickPopoverButton(page)
+  await popoverIsVisible(page)
+
+  await page.keyboard.press('Escape')
+
+  await popoverIsNotVisible(page)
+})


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #2033 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The change that moved the focus trap from the VModal component into the useDialog composable failed to account for the fact that Popovers also use it, and don't need a focus trap.

This PR only activates/deactivates the focus trap if the `trapFocus` prop is set to `true`, and sets `trapFocus` to `false` for VPopover component. 

It also adds an e2e test for closing the popover on click outside and pressing Escape to the `homepage` e2e test (that's the simplest place where we can open a popover).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try running the app on desktop. Open the popovers (content switcher on the homepage, pages menu or content switcher in the header) and check that pressing Escape or clicking outside closes them.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
