### PR TITLE
Set and use `GH_SLACK_USERNAME_MAP` as an environment variable

### DIFF
--- a/.github/actions/staging-frontend-deploy/action.yml
+++ b/.github/actions/staging-frontend-deploy/action.yml
@@ -25,10 +25,12 @@ runs:
   steps:
     - name: Set the Slack user
       shell: python
+      env:
+        GH_SLACK_USERNAME_MAP: ${{ secrets.GH_SLACK_USERNAME_MAP }}
       run: |
         import json
         import os
-        mapping = json.loads("${{ toJSON(secrets.GH_SLACK_USERNAME_MAP) }}")
+        mapping = json.loads("${{ toJSON(env.GH_SLACK_USERNAME_MAP) }}")
         github_user = "${{ github.triggering_actor }}"
         slack_id = mapping[github_user]
         with open(os.getenv('GITHUB_ENV'), "a") as env_file:


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Follow up of #2053.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Previous changes to the **staging-frontend-nuxt-deploy** action [are not working](https://github.com/WordPress/openverse-frontend/actions/runs/3734996887/jobs/6337773734) because the encrypted secrets cannot be used directly, they need to be provided to actions as an input or environment variable, according to [GitHub docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow). I use an envvar here so trying again to see if it works.


[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
