### PR TITLE
Try without `toJSON` function and continue in any case

### DIFF
--- a/.github/actions/staging-frontend-deploy/action.yml
+++ b/.github/actions/staging-frontend-deploy/action.yml
@@ -40,6 +40,7 @@ runs:
 
     - name: Notify deployment start
       uses: slackapi/slack-github-action@v1.23.0
+      if: success() || failure()
       with:
         payload: |
           {
@@ -67,6 +68,7 @@ runs:
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
+      if: success() || failure()
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/.github/actions/staging-frontend-deploy/action.yml
+++ b/.github/actions/staging-frontend-deploy/action.yml
@@ -32,7 +32,7 @@ runs:
       run: |
         import json
         import os
-        mapping = json.loads("${{ toJSON(env.GH_SLACK_USERNAME_MAP) }}")
+        mapping = json.loads('${{ env.GH_SLACK_USERNAME_MAP }}')
         github_user = "${{ github.triggering_actor }}"
         slack_id = mapping[github_user]
         with open(os.getenv('GITHUB_ENV'), "a") as env_file:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Follow up of #2056, #2055 and therefore #2053.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Fix for the staging deployment. Here I omit the use of the `toJSON` function of GitHub actions, which might not be necessary if we follow how the input is set in other lines:

https://github.com/WordPress/openverse-frontend/blob/8881cd57f0a2963406e49c48de1bb6a62dff4015/.github/workflows/ghcr.yml#L62-L66

Also, use single quotes instead of double quotes and make the following steps continue even if the slack user and the notifications steps fail.

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
