### PR TITLE
Simplify step for setting the Slack user in GH action

### DIFF
--- a/.github/actions/staging-frontend-deploy/action.yml
+++ b/.github/actions/staging-frontend-deploy/action.yml
@@ -26,17 +26,8 @@ runs:
 
   steps:
     - name: Set the Slack user
-      shell: python
-      env:
-        GH_SLACK_USERNAME_MAP: ${{ inputs.gh-slack-username-map }}
-      run: |
-        import json
-        import os
-        mapping = json.loads('${{ env.GH_SLACK_USERNAME_MAP }}')
-        github_user = "${{ github.triggering_actor }}"
-        slack_id = mapping[github_user]
-        with open(os.getenv('GITHUB_ENV'), "a") as env_file:
-            env_file.write(f"SLACK_USER_ID={slack_id}")
+      shell: bash
+      run: echo "SLACK_USER_ID=${{ inputs.gh-slack-username-map[github.actor] }}" >> "$GITHUB_ENV"
 
     - name: Notify deployment start
       uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   deploy:
+    name: Deploy GitHub pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Now that we know the python code works[^1], I want to try the bash version that @sarayourfriend suggested. It's much more straightforward.

[^1]: Successful run: https://github.com/WordPress/openverse-frontend/actions/runs/3743973967/jobs/6356853268


## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
