### PR TITLE
Serve Prometheus metrics on a separate port; fix metrics development workflow

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -278,15 +278,6 @@ const config: NuxtConfig = {
         .listen(parseFloat(process.env.METRICS_PORT || "54641"), "0.0.0.0")
     },
     render: {
-      /**
-       * When modifying this function in development with automatic rebuilds enabled
-       * it _will_ crash your server with an error about duplicate metric name registration.
-       * To debug this function's behavior locally you will have to tolerate stopping and
-       * starting `pnpm dev` between each change to nuxt.config.ts. To prevent this from
-       * being a _general_ problem the metrics middleware is disabled in development
-       * mode, otherwise any change to `nuxt.config.ts` would cause this crash. If you
-       * need to debug metrics locally, comment out the early return in development.
-       */
       setupMiddleware: (app) => {
         const bypassMetricsPathParts = [
           /**

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,9 @@
 import path from "path"
 import fs from "fs"
 
+import http from "http"
+
+import Prometheus from "prom-client"
 import promBundle from "express-prom-bundle"
 
 import pkg from "./package.json"
@@ -16,7 +19,6 @@ import { env } from "./src/utils/env"
 import type { NuxtConfig, ServerMiddleware } from "@nuxt/types"
 import type { LocaleObject } from "@nuxtjs/i18n"
 import type { IncomingMessage, NextFunction } from "connect"
-import type http from "http"
 
 /**
  * The default metadata for the site. Can be extended and/or overwritten per page. And even in components!
@@ -137,6 +139,8 @@ const filenames: NonNullable<NuxtConfig["build"]>["filenames"] = {
     isDev ? "[path][name].[ext]" : `videos/${baseProdName}.[ext]`,
 }
 
+let metricsServer: null | http.Server = null
+
 const config: NuxtConfig = {
   // eslint-disable-next-line no-undef
   version: pkg.version, // used to purge cache :)
@@ -256,6 +260,23 @@ const config: NuxtConfig = {
   },
   sentry: sentryConfig,
   hooks: {
+    close() {
+      metricsServer?.close()
+      // Clear registry so that metrics can re-register when the server restarts in development
+      Prometheus.register.clear()
+    },
+    listen() {
+      // Serve Prometheus metrics on a separate port to allow production
+      // metrics to be hidden behind security group settings
+      metricsServer = http
+        .createServer(async (_, res) => {
+          res.writeHead(200, {
+            "Content-Type": Prometheus.register.contentType,
+          })
+          res.end(await Prometheus.register.metrics())
+        })
+        .listen(parseFloat(process.env.METRICS_PORT || "54641"), "0.0.0.0")
+    },
     render: {
       /**
        * When modifying this function in development with automatic rebuilds enabled
@@ -267,8 +288,6 @@ const config: NuxtConfig = {
        * need to debug metrics locally, comment out the early return in development.
        */
       setupMiddleware: (app) => {
-        if (process.env.NODE_ENV === "development") return
-
         const bypassMetricsPathParts = [
           /**
            * Exclude static paths. Remove once we've moved static file
@@ -302,6 +321,16 @@ const config: NuxtConfig = {
          */
         app.use(
           promBundle({
+            // We serve the Prometheus metrics on a separate port for production
+            // and if we let express-prom-bundle register the `/metrics` route then
+            // it exposes all the metrics on the publicly accessible port
+            autoregister: false,
+            promClient: {
+              // Set this to an empty object to pass falsy check in express-prom-bundle
+              // and default metrics get enabled with the default prom-client configuration
+              collectDefaultMetrics: {},
+            },
+            buckets: [0.03, 0.3, 0.5, 1, 1.5, 2, 5, 10, Infinity],
             bypass: (req) =>
               bypassMetricsPathParts.some((p) => req.originalUrl.includes(p)),
             includeMethod: true,


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Prometheus metrics generally should not be served on a public endpoint. The easiest way to make the metrics publicly inaccessible is to serve them on an entirely separate port. This allows us to easily make security group changes that only allow services internal to our VPC (specifically, Grafana Agent) to access the metrics endpoints.

In the process, I also went ahead and fixed some issues with the Prometheus development workflow, namely that its metrics were disabled by default in development due to a persistent crash when the server automatically restarts after changes. To fix this, we just need to de-register all the existing metrics when the server closes. This allows the `express-prom-bundle` middleware to re-register the same metrics without causing name clashes with the metrics registered during the initial start up.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the branch and run the app locally using `just run dev`. Run the prod version as well with `just run prod`. Confirm that in both cases, metrics are only accessible at `localhost:54641` and no longer at `localhost:8443/metrics`.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
