### PR TITLE
Add Debounce to filter selection

### DIFF
--- a/src/components/VFilters/VSearchGridFilter.vue
+++ b/src/components/VFilters/VSearchGridFilter.vue
@@ -123,7 +123,7 @@ export default defineComponent({
           router.push(searchStore.getSearchPath())
         }
       },
-      { debounce: 500, maxWait: 5000 }
+      { debounce: 800, maxWait: 5000 }
     )
 
     const focusableElements = computed(() =>

--- a/src/components/VFilters/VSearchGridFilter.vue
+++ b/src/components/VFilters/VSearchGridFilter.vue
@@ -51,9 +51,10 @@ import {
   ref,
   useContext,
   useRouter,
-  watch,
 } from "@nuxtjs/composition-api"
 import { kebab } from "case"
+
+import { watchDebounced } from "@vueuse/core"
 
 import { useSearchStore } from "~/stores/search"
 import { areQueriesEqual, ApiQueryParams } from "~/utils/search-query-transform"
@@ -115,13 +116,14 @@ export default defineComponent({
      * This watcher fires even when the queries are equal. We update the path only
      * when the queries change.
      */
-    watch(
+    watchDebounced(
       () => searchStore.searchQueryParams,
       (newQuery: ApiQueryParams, oldQuery: ApiQueryParams) => {
         if (!areQueriesEqual(newQuery, oldQuery)) {
           router.push(searchStore.getSearchPath())
         }
-      }
+      },
+      { debounce: 500, maxWait: 5000 }
     )
 
     const focusableElements = computed(() =>

--- a/test/playwright/e2e/search-navigation-old.spec.ts
+++ b/test/playwright/e2e/search-navigation-old.spec.ts
@@ -24,7 +24,7 @@ test.describe("search history navigation", () => {
 
     // Apply a filter
     await page.click("#modification")
-    // There is a debounce of 500 ms when choosing a filter.
+    // There is a debounce when choosing a filter.
     // we need to wait for the page to reload before running the test
     await page.waitForNavigation()
 

--- a/test/playwright/e2e/search-navigation-old.spec.ts
+++ b/test/playwright/e2e/search-navigation-old.spec.ts
@@ -25,7 +25,7 @@ test.describe("search history navigation", () => {
     // Apply a filter
     await page.click("#modification")
     // There is a debounce of 500 ms when choosing a filter.
-    //we need to wait for the page to get reloaded before procceding the test
+    // we need to wait for the page to reload before running the test
     await page.waitForNavigation()
 
     // Verify the filter is applied to the URL and the checkbox is checked

--- a/test/playwright/e2e/search-navigation-old.spec.ts
+++ b/test/playwright/e2e/search-navigation-old.spec.ts
@@ -24,6 +24,9 @@ test.describe("search history navigation", () => {
 
     // Apply a filter
     await page.click("#modification")
+    // There is a debounce of 500 ms when choosing a filter.
+    //we need to wait for the page to get reloaded before procceding the test
+    await page.waitForNavigation()
 
     // Verify the filter is applied to the URL and the checkbox is checked
     // Note: Need to add that a search was actually executed with the new

--- a/test/playwright/e2e/search-navigation.spec.ts
+++ b/test/playwright/e2e/search-navigation.spec.ts
@@ -28,7 +28,7 @@ test.describe("search history navigation", () => {
 
       // Apply a filter
       await page.click("#modification")
-      // There is a debounce of 500 ms when choosing a filter.
+      // There is a debounce when choosing a filter.
       // we need to wait for the page to reload before running the test
       await page.waitForNavigation()
 

--- a/test/playwright/e2e/search-navigation.spec.ts
+++ b/test/playwright/e2e/search-navigation.spec.ts
@@ -29,7 +29,7 @@ test.describe("search history navigation", () => {
       // Apply a filter
       await page.click("#modification")
       // There is a debounce of 500 ms when choosing a filter.
-      //we need to wait for the page to get reloaded before procceding the test
+      // we need to wait for the page to reload before running the test
       await page.waitForNavigation()
 
       // Verify the filter is applied to the URL and the checkbox is checked

--- a/test/playwright/e2e/search-navigation.spec.ts
+++ b/test/playwright/e2e/search-navigation.spec.ts
@@ -28,6 +28,9 @@ test.describe("search history navigation", () => {
 
       // Apply a filter
       await page.click("#modification")
+      // There is a debounce of 500 ms when choosing a filter.
+      //we need to wait for the page to get reloaded before procceding the test
+      await page.waitForNavigation()
 
       // Verify the filter is applied to the URL and the checkbox is checked
       // Note: Need to add that a search was actually executed with the new


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #505 by @sarayourfriend 

## Description
as described in the issue by @sarayourfriend, currently when selecting several filters one after the other
a query will be excuted for each filter selection.
so, as suggested in the issue i added a debounce of 500ms to filter selection (basically switched the watch function to watchDebounced )

<b>Staging</b>

https://user-images.githubusercontent.com/29175506/213170688-53d17a10-0bb6-4039-88e6-88bd50cfa0bf.mp4


<b>This PR</b>


https://user-images.githubusercontent.com/29175506/213171268-41363f93-a314-4d4f-8644-e3d18fb12bb7.mp4




## Testing Instructions

follow the steps in the video :)

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
