### PR TITLE
Extract Prometheus module

### DIFF
--- a/src/modules/prometheus.ts
+++ b/src/modules/prometheus.ts
@@ -6,6 +6,7 @@ import promBundle from "express-prom-bundle"
 import { searchTypes } from "../../src/constants/media"
 
 import type { ServerMiddleware, Module } from "@nuxt/types"
+import type { Server as ConnectServer } from "connect"
 
 let metricsServer: null | http.Server = null
 
@@ -53,17 +54,12 @@ const bundle = promBundle({
 }) as unknown as ServerMiddleware
 
 const PrometheusModule: Module = function () {
-  // Nuxt types don't fully type `this` parameter, this.nuxt is any.
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   this.nuxt.hook("close", () => {
     metricsServer?.close()
     // Clear registry so that metrics can re-register when the server restarts in development
     Prometheus.register.clear()
   })
-  // Nuxt types don't fully type `this` parameter, this.nuxt is any.
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+
   this.nuxt.hook("listen", () => {
     // Serve Prometheus metrics on a separate port to allow production
     // metrics to be hidden behind security group settings
@@ -76,10 +72,8 @@ const PrometheusModule: Module = function () {
       })
       .listen(parseFloat(process.env.METRICS_PORT || "54641"), "0.0.0.0")
   })
-  // Nuxt types don't fully type `this` parameter, this.nuxt is any.
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  this.nuxt.hook("render:setupMiddleware", (app) => {
+
+  this.nuxt.hook("render:setupMiddleware", (app: ConnectServer) => {
     /**
      * Register this here so that it's registered at the absolute top
      * of the middleware stack. Using server-middleware puts it

--- a/src/modules/prometheus.ts
+++ b/src/modules/prometheus.ts
@@ -1,0 +1,104 @@
+import http from "http"
+
+import Prometheus from "prom-client"
+import promBundle from "express-prom-bundle"
+
+import { searchTypes } from "../../src/constants/media"
+
+import type { ServerMiddleware, Module } from "@nuxt/types"
+
+let metricsServer: null | http.Server = null
+
+const bypassMetricsPathParts = [
+  /**
+   * Exclude static paths. Remove once we've moved static file
+   * hosting out of the SSR server's responsibilities.
+   */
+  "_nuxt",
+  /**
+   * Only include these paths in development. They do not exist in production
+   * so we can happily skip the extra iterations these path parts introduce.
+   */
+  ...(process.env.NODE_ENV === "development" ? ["__webpack", "sse"] : []),
+]
+
+const bundle = promBundle({
+  // We serve the Prometheus metrics on a separate port for production
+  // and if we let express-prom-bundle register the `/metrics` route then
+  // it exposes all the metrics on the publicly accessible port
+  autoregister: false,
+  promClient: {
+    // Set this to an empty object to pass falsy check in express-prom-bundle
+    // and default metrics get enabled with the default prom-client configuration
+    collectDefaultMetrics: {},
+  },
+  buckets: [0.03, 0.3, 0.5, 1, 1.5, 2, 5, 10, Infinity],
+  bypass: (req) =>
+    bypassMetricsPathParts.some((p) => req.originalUrl.includes(p)),
+  includeMethod: true,
+  includePath: true,
+  normalizePath: [
+    ...searchTypes.map(
+      // Normalize single result pages with IDs in the path
+      (t) => [`/${t}/.*`, `/${t}/#id`] as [string, string]
+    ),
+  ],
+  /**
+   * promBundle creates an Express middleware function, which is type-incompatible
+   * with Nuxt's "connect" middleware functions. I guess they _are_ compatible,
+   * in actual code, or maybe just in the particular implementation of the prometheus
+   * bundle middleware. In any case, this cast is necessary to appeas TypeScript
+   * without an ugly ts-ignore.
+   */
+}) as unknown as ServerMiddleware
+
+const PrometheusModule: Module = function () {
+  // Nuxt types don't fully type `this` parameter, this.nuxt is any.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  this.nuxt.hook("close", () => {
+    metricsServer?.close()
+    // Clear registry so that metrics can re-register when the server restarts in development
+    Prometheus.register.clear()
+  })
+  // Nuxt types don't fully type `this` parameter, this.nuxt is any.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  this.nuxt.hook("listen", () => {
+    // Serve Prometheus metrics on a separate port to allow production
+    // metrics to be hidden behind security group settings
+    metricsServer = http
+      .createServer(async (_, res) => {
+        res.writeHead(200, {
+          "Content-Type": Prometheus.register.contentType,
+        })
+        res.end(await Prometheus.register.metrics())
+      })
+      .listen(parseFloat(process.env.METRICS_PORT || "54641"), "0.0.0.0")
+  })
+  // Nuxt types don't fully type `this` parameter, this.nuxt is any.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  this.nuxt.hook("render:setupMiddleware", (app) => {
+    /**
+     * Register this here so that it's registered at the absolute top
+     * of the middleware stack. Using server-middleware puts it
+     * after a whole host of stuff.
+     *
+     * Note: The middleware only has access to server side navigations,
+     * as it is indeed an express middleware, not a Nuxt page middleware.
+     * There's no safe way to pipe client side metrics to Prometheus with
+     * this set up and if we wanted that anyway we'll want to invest into
+     * an actual RUM solution, not a systems monitoring solution like
+     * Prometheus. The implication of this is that the metrics will only
+     * include SSR'd requests. SPA navigations or anything else that
+     * happens exclusively on the client will not be measured. This is the
+     * expected behavior!
+     *
+     * @see {@link https://github.com/nuxt/nuxt.js/blob/dev/packages/server/src/server.js#L70-L138}
+     */
+    app.use(bundle)
+  })
+}
+
+export default PrometheusModule


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR is a suggested implementation of extracting the Prometheus setup from `nuxt.config` into a separate Nuxt module. I think it will be easier to have Prometheus set up as a separate module when moving from Nuxt 2 to Nuxt 3 because it will not affect the `nuxt.config` changes anymore, and typing the modules should become easier with Nuxt3.