### PR TITLE
Tighten the condition for audio playback to continue across pages

### DIFF
--- a/src/components/VAudioTrack/VAudioTrack.vue
+++ b/src/components/VAudioTrack/VAudioTrack.vue
@@ -73,6 +73,10 @@ import {
   layoutMappings,
 } from "~/constants/audio"
 import { useSeekable } from "~/composables/use-seekable"
+import {
+  useMatchSearchRoutes,
+  useMatchSingleResultRoutes,
+} from "~/composables/use-match-routes"
 
 import { defineEvent } from "~/types/emits"
 
@@ -296,9 +300,13 @@ export default defineComponent({
         localAudio?.removeEventListener(name, fn)
       )
 
+      const { matches: isSearchRoute } = useMatchSearchRoutes()
+      const { matches: isSingleResultRoute } = useMatchSingleResultRoutes()
+
       if (
-        route.value?.params?.id === props.audio.id ||
-        mediaStore.getItemById(AUDIO, props.audio.id)
+        (isSingleResultRoute.value &&
+          route.value?.params?.id === props.audio.id) ||
+        (isSearchRoute.value && mediaStore.getItemById(AUDIO, props.audio.id))
       ) {
         /**
          * If switching to any route other than the single result

--- a/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
+++ b/test/unit/specs/components/AudioTrack/v-audio-track.spec.js
@@ -25,6 +25,12 @@ const mockI18n = new Vuei18n({
   messages: { en: enMessages },
 })
 
+jest.mock("~/composables/use-match-routes", () => ({
+  // mocking `Ref<boolean>` as `{ value: boolean }`
+  useMatchSearchRoutes: jest.fn(() => ({ matches: { value: false } })),
+  useMatchSingleResultRoutes: jest.fn(() => ({ matches: { value: false } })),
+}))
+
 jest.mock("~/composables/use-browser-detection", () => ({
   useBrowserIsBlink: jest.fn(() => false),
 }))


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #2118 by @obulat

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR tightens the condition that allows playback to continue by using the router matching composable. This fixes the condition where audio playback would continue on any page.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the PR and run the dev server.
1. Search for a term.
2. Play an audio track.
3. Click on any other result (be it image or audio) to open the single result page. Audio playback should be stopped. (Technically you could navigate to any other page, even the home or content pages and the playback should stop).
4. Go back and resume the audio track again.
6. Click on the same result to open the single result page. Audio playback should continue from the same spot.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
