### PR TITLE
Baseline SEO improvements

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -31,12 +31,9 @@ const meta = [
     name: "viewport",
     content: "width=device-width,initial-scale=1",
   },
-  // By default, tell all robots not to index pages. Will be overridden in the
+  // By default, tell all robots not to index pages. Will be overwritten in the
   // search, content and home pages.
   { hid: "robots", name: "robots", content: "noindex" },
-  // Tell Googlebot to crawl Openverse when iframed
-  // TODO: remove after the iframe is removed
-  { hid: "googlebot", name: "googlebot", content: "indexifembedded" },
   {
     vmid: "monetization",
     name: "monetization",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -204,6 +204,7 @@ const config: NuxtConfig = {
   ],
   serverMiddleware: [
     { path: "/healthcheck", handler: "~/server-middleware/healthcheck.js" },
+    { path: "/robots.txt", handler: "~/server-middleware/robots.js" },
   ],
   i18n: {
     locales: [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -204,6 +204,7 @@ const config: NuxtConfig = {
     { path: "/robots.txt", handler: "~/server-middleware/robots.js" },
   ],
   i18n: {
+    baseUrl: "https://openverse.org",
     locales: [
       {
         // unique identifier for the locale in Vue i18n

--- a/src/layouts/content-layout.vue
+++ b/src/layouts/content-layout.vue
@@ -199,15 +199,10 @@ export default defineComponent({
     }
   },
   head() {
-    return {
-      ...this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true }),
-      link: [
-        {
-          rel: "canonical",
-          href: "https://openverse.org" + this.$route.path,
-        },
-      ],
-    }
+    return this.$nuxtI18nHead({
+      addSeoAttributes: true,
+      addDirAttribute: true,
+    })
   },
 })
 </script>

--- a/src/layouts/content-layout.vue
+++ b/src/layouts/content-layout.vue
@@ -199,7 +199,15 @@ export default defineComponent({
     }
   },
   head() {
-    return this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true })
+    return {
+      ...this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true }),
+      link: [
+        {
+          rel: "canonical",
+          href: "https://openverse.org" + this.$route.path,
+        },
+      ],
+    }
   },
 })
 </script>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -71,7 +71,15 @@ export default defineComponent({
     }
   },
   head() {
-    return this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true })
+    return {
+      ...this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true }),
+      link: [
+        {
+          rel: "canonical",
+          href: "https://openverse.org" + this.$route.path,
+        },
+      ],
+    }
   },
 })
 </script>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -71,15 +71,10 @@ export default defineComponent({
     }
   },
   head() {
-    return {
-      ...this.$nuxtI18nHead({ addSeoAttributes: true, addDirAttribute: true }),
-      link: [
-        {
-          rel: "canonical",
-          href: "https://openverse.org" + this.$route.path,
-        },
-      ],
-    }
+    return this.$nuxtI18nHead({
+      addSeoAttributes: true,
+      addDirAttribute: true,
+    })
   },
 })
 </script>

--- a/src/pages/search/audio.vue
+++ b/src/pages/search/audio.vue
@@ -49,8 +49,6 @@ import { useUiStore } from "~/stores/ui"
 
 import { IsSidebarVisibleKey } from "~/types/provides"
 
-import { useFeatureFlagStore } from "~/stores/feature-flag"
-
 import VSnackbar from "~/components/VSnackbar.vue"
 import VAudioTrack from "~/components/VAudioTrack/VAudioTrack.vue"
 import VLoadMore from "~/components/VLoadMore.vue"
@@ -68,13 +66,8 @@ export default defineComponent({
   },
   props: propTypes,
   setup(props) {
-    const featureFlagStore = useFeatureFlagStore()
-
     useMeta({
       title: `${props.searchTerm} | Openverse`,
-      meta: featureFlagStore.isOn("new_header")
-        ? [{ hid: "robots", name: "robots", content: "all" }]
-        : undefined,
     })
 
     const uiStore = useUiStore()

--- a/src/pages/search/image.vue
+++ b/src/pages/search/image.vue
@@ -12,7 +12,6 @@ import { computed, defineComponent, useMeta } from "@nuxtjs/composition-api"
 
 import { propTypes } from "~/pages/search/search-page.types"
 import { useFocusFilters } from "~/composables/use-focus-filters"
-import { useFeatureFlagStore } from "~/stores/feature-flag"
 
 import VImageGrid from "~/components/VImageGrid/VImageGrid.vue"
 
@@ -21,13 +20,8 @@ export default defineComponent({
   components: { VImageGrid },
   props: propTypes,
   setup(props) {
-    const featureFlagStore = useFeatureFlagStore()
-
     useMeta({
       title: `${props.searchTerm} | Openverse`,
-      meta: featureFlagStore.isOn("new_header")
-        ? [{ hid: "robots", name: "robots", content: "all" }]
-        : undefined,
     })
 
     const results = computed(() => props.resultItems.image)

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -6,7 +6,6 @@
 import { defineComponent, useMeta } from "@nuxtjs/composition-api"
 
 import { propTypes } from "~/pages/search/search-page.types"
-import { useFeatureFlagStore } from "~/stores/feature-flag"
 
 import VAllResultsGrid from "~/components/VAllResultsGrid/VAllResultsGrid.vue"
 
@@ -15,13 +14,8 @@ export default defineComponent({
   components: { VAllResultsGrid },
   props: propTypes,
   setup(props) {
-    const featureFlagStore = useFeatureFlagStore()
-
     useMeta({
       title: `${props.searchTerm} | Openverse`,
-      meta: featureFlagStore.isOn("new_header")
-        ? [{ hid: "robots", name: "robots", content: "all" }]
-        : undefined,
     })
   },
   head: {},

--- a/src/server-middleware/robots.js
+++ b/src/server-middleware/robots.js
@@ -1,13 +1,9 @@
 const { LOCAL, PRODUCTION } = require("../constants/deploy-env")
 
 /**
- * A simple healthcheck that is always true.
- *
- * @todo Update to a resource-sensitive version that fails when
- * memory and/or cpu usage reach a configurable threshhold.
- * @type {import('@nuxt/types').ServerMiddleware}
+ * Send the correct robots.txt information per-environment.
  */
-export default function healthcheck(_, res) {
+export default function robots(_, res) {
   const deployEnv = process.env.DEPLOYMENT_ENV ?? LOCAL
 
   const contents =

--- a/src/server-middleware/robots.js
+++ b/src/server-middleware/robots.js
@@ -1,0 +1,23 @@
+const { LOCAL, PRODUCTION } = require("../constants/deploy-env")
+
+/**
+ * A simple healthcheck that is always true.
+ *
+ * @todo Update to a resource-sensitive version that fails when
+ * memory and/or cpu usage reach a configurable threshhold.
+ * @type {import('@nuxt/types').ServerMiddleware}
+ */
+export default function healthcheck(_, res) {
+  const deployEnv = process.env.DEPLOYMENT_ENV ?? LOCAL
+
+  const contents =
+    deployEnv === PRODUCTION
+      ? `# This file is intentionally left blank`
+      : `# Block crawlers from the staging site
+User-agent: *
+Disallow: /
+`
+
+  res.setHeader("Content-Type", "text/plain")
+  res.end(contents)
+}


### PR DESCRIPTION
- Add robots.txt file, which deindexes the staging site
- Make `canonical` and `hreflang` links absolute
- Deindex search routes, for now

## To test

- Run the app locally
- Go to the robots.txt route and observe the correct contents for staging
- Inspect any page, find the 'canonical' tag and observe that it starts with "https://openverse.org"
- Observe search routes are no longer indexed