### PR TITLE
Remove `net` and related words from translation in help page

### DIFF
--- a/src/locales/scripts/en.json5
+++ b/src/locales/scripts/en.json5
@@ -227,9 +227,8 @@
         "operator-name": "operator (wildcard)",
         "operator-aria-label": "star operator (wildcard)",
         "aria-label": "net star symbol",
-        example: "net*",
         // Do not translate 'network', 'Netflix' and 'Netherlands' are they are examples of words starting with 'net'.
-        content: "Example: {link}{br} This will search for images matching anything with 'net'. This might include 'network', 'Netflix', 'Netherlands', etc.",
+        content: "Example: {link}{br} This will search for images matching anything with '{net}'. This might include '{network}', '{netflix}', '{netherlands}', etc.",
       },
       precedence: {
         description: "You can use parentheses {highlight} to specify precedence of terms or combine more complex queries.",

--- a/src/pages/search-help.vue
+++ b/src/pages/search-help.vue
@@ -104,12 +104,16 @@
           :aria-label="$t('search-guide.example.prefix.aria-label')"
           :href="pathFromQuery('net*')"
         >
-          <em>{{ $t("search-guide.example.prefix.example") }}</em>
+          <em>net*</em>
         </VLink>
       </template>
       <template #br>
         <br />
       </template>
+      <template #net>net</template>
+      <template #network>network</template>
+      <template #netflix>Netflix</template>
+      <template #netherlands>Netherlands</template>
     </i18n>
 
     <i18n path="search-guide.example.precedence.description" tag="p">


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Follow up to #2189 and #2191.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Exclude "net" and the related example words on the Search Help page from translations. The comment previously added is not enough, as "net" was also translated in [Spanish](https://staging.openverse.org/es/search-help) (almost all variants) to "red", a valid translation, then it made the other words lose sense in the context.

An alternative could be a more elaborated comment on the relation that these words should keep but I'm afraid it might get ignored or overlooked.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
